### PR TITLE
Update tasks.json

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -11,7 +11,11 @@
                 "/property:GenerateFullPaths=true",
                 "/consoleloggerparameters:NoSummary"
             ],
-            "problemMatcher": "$msCompile"
+            "problemMatcher": "$msCompile",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
         },
         {
             "label": "publish",
@@ -34,6 +38,18 @@
                 "run",
                 "--project",
                 "${workspaceFolder}/src/webapi/webapi.csproj"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "test",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "test",
+                "${workspaceFolder}/src/webapi/webapi.csproj",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
             ],
             "problemMatcher": "$msCompile"
         }


### PR DESCRIPTION
Added a new task called "test" that allows you to run tests for the web API project. This task runs the dotnet test command and uses the same project file as the other tasks.

Grouped the "build" task as the default build task. This means that when you run the build task, it will be the default task to execute if no other task is specified.