### PR TITLE
Refactor Test-Assessment-21787 function for clarity and consistency

### DIFF
--- a/src/powershell/private/tests/Test-Assessment.21787.ps1
+++ b/src/powershell/private/tests/Test-Assessment.21787.ps1
@@ -3,13 +3,13 @@
 
 #>
 
-function Test-Assessment-21787{
+function Test-Assessment-21787 {
     [CmdletBinding()]
     param()
 
     Write-PSFMessage '🟦 Start' -Tag Test -Level VeryVerbose
 
-    $activity = "Checking Permissions to create new tenants is limited to the Tenant Creator role"
+    $activity = "Checking permissions to create new tenants is limited to the Tenant Creator role"
     Write-ZtProgress -Activity $activity -Status "Getting policy"
 
     $result = Invoke-ZtGraphRequest -RelativeUri "policies/authorizationPolicy" -ApiVersion v1.0
@@ -20,13 +20,20 @@ function Test-Assessment-21787{
         $testResultMarkdown = "Non-privileged users are restricted from creating tenants.`n`n"
     }
     else {
-        $testResultMarkdown = "Non-privileged users are allowed to create tenants.`n`n%TestResult%"
+        $testResultMarkdown = "Non-privileged users are allowed to create tenants.`n`n"
     }
 
-    $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", "The defaultUserPermissions.allowedToCreateTenants property is set to true."
+    $params = @{
+        TestId              = '21787'
+        Title               = 'Permissions to create new tenants is limited to the Tenant Creator role'
+        UserImpact          = 'Medium'
+        Risk                = 'High'
+        ImplementationCost  = 'Medium'
+        AppliesTo           = 'Identity'
+        Tag                 = 'Identity'
+        Status              = $passed
+        Result              = $testResultMarkdown
+    }
 
-    Add-ZtTestResultDetail -TestId '21787' -Title "Permissions to create new tenants is limited to the Tenant Creator role" `
-        -UserImpact Low -Risk High -ImplementationCost Low `
-        -AppliesTo Identity -Tag Identity `
-        -Status $passed -Result $testResultMarkdown
+    Add-ZtTestResultDetail @params
 }


### PR DESCRIPTION
Rewrite Add-ZtTestResultDetail command using splatting.
Remove `%TestResult%` details.