### PR TITLE
Refactor Test-Assessment-21787 function and add test code to Test-Assessment-21828 function

### DIFF
--- a/src/powershell/private/tests/Test-Assessment.21787.ps1
+++ b/src/powershell/private/tests/Test-Assessment.21787.ps1
@@ -3,13 +3,13 @@
 
 #>
 
-function Test-Assessment-21787{
+function Test-Assessment-21787 {
     [CmdletBinding()]
     param()
 
     Write-PSFMessage '🟦 Start' -Tag Test -Level VeryVerbose
 
-    $activity = "Checking Permissions to create new tenants is limited to the Tenant Creator role"
+    $activity = "Checking permissions to create new tenants is limited to the Tenant Creator role"
     Write-ZtProgress -Activity $activity -Status "Getting policy"
 
     $result = Invoke-ZtGraphRequest -RelativeUri "policies/authorizationPolicy" -ApiVersion v1.0
@@ -20,13 +20,20 @@ function Test-Assessment-21787{
         $testResultMarkdown = "Non-privileged users are restricted from creating tenants.`n`n"
     }
     else {
-        $testResultMarkdown = "Non-privileged users are allowed to create tenants.`n`n%TestResult%"
+        $testResultMarkdown = "Non-privileged users are allowed to create tenants.`n`n"
     }
 
-    $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", "The defaultUserPermissions.allowedToCreateTenants property is set to true."
+    $params = @{
+        TestId              = '21787'
+        Title               = 'Permissions to create new tenants is limited to the Tenant Creator role'
+        UserImpact          = 'Medium'
+        Risk                = 'High'
+        ImplementationCost  = 'Medium'
+        AppliesTo           = 'Identity'
+        Tag                 = 'Identity'
+        Status              = $passed
+        Result              = $testResultMarkdown
+    }
 
-    Add-ZtTestResultDetail -TestId '21787' -Title "Permissions to create new tenants is limited to the Tenant Creator role" `
-        -UserImpact Low -Risk High -ImplementationCost Low `
-        -AppliesTo Identity -Tag Identity `
-        -Status $passed -Result $testResultMarkdown
+    Add-ZtTestResultDetail @params
 }

--- a/src/powershell/private/tests/Test-Assessment.21828.ps1
+++ b/src/powershell/private/tests/Test-Assessment.21828.ps1
@@ -12,13 +12,16 @@ function Test-Assessment-21828 {
     $activity = "Checking Authentication transfer is blocked"
     Write-ZtProgress -Activity $activity -Status "Getting conditional access policies"
 
-    $enabledCAPolicies = Invoke-ZtGraphRequest -RelativeUri "policies/conditionalAccessPolicies?`$filter=state eq 'enabled'" -ApiVersion beta
+    # Query for all CA policies
+    $allCAPolicies = Invoke-ZtGraphRequest -RelativeUri 'policies/conditionalAccessPolicies' -ApiVersion beta
 
-    $matchedPolicies = $enabledCAPolicies | Where-Object {
+    # Local filtering for blocked authentication transfer policies - only consider enabled policies
+    $matchedPolicies = $allCAPolicies | Where-Object {
         $_.conditions.authenticationFlows.transferMethods -match "authenticationTransfer" -and
         $_.grantControls.builtInControls -contains "block" -and
         $_.conditions.users.includeUsers -eq "all" -and
-        $_.conditions.applications.includeApplications -eq "all"
+        $_.conditions.applications.includeApplications -eq "all" -and
+        $_.state -eq "enabled"
     }
 
     $testResultMarkdown = ""

--- a/src/powershell/private/tests/Test-Assessment.21828.ps1
+++ b/src/powershell/private/tests/Test-Assessment.21828.ps1
@@ -3,22 +3,82 @@
 
 #>
 
-function Test-Assessment-21828{
+function Test-Assessment-21828 {
     [CmdletBinding()]
     param()
 
     Write-PSFMessage '🟦 Start' -Tag Test -Level VeryVerbose
 
     $activity = "Checking Authentication transfer is blocked"
-    Write-ZtProgress -Activity $activity -Status "Getting policy"
+    Write-ZtProgress -Activity $activity -Status "Getting conditional access policies"
 
-    $result = $false
-    $testResultMarkdown = "Planned for future release."
-    $passed = $result
+    $enabledCAPolicies = Invoke-ZtGraphRequest -RelativeUri "policies/conditionalAccessPolicies?`$filter=state eq 'enabled'" -ApiVersion beta
+
+    $matchedPolicies = $enabledCAPolicies | Where-Object {
+        $_.conditions.authenticationFlows.transferMethods -match "authenticationTransfer" -and
+        $_.grantControls.builtInControls -contains "block" -and
+        $_.conditions.users.includeUsers -eq "all" -and
+        $_.conditions.applications.includeApplications -eq "all"
+    }
+
+    $testResultMarkdown = ""
+
+    if ($matchedPolicies.Count -gt 0) {
+        $passed = $true
+        $testResultMarkdown += "Authentication transfer is blocked by Conditional Access Policy(s).%TestResult%"
+    }
+    else {
+        $passed = $false
+        $testResultMarkdown += "Authentication transfer is not blocked."
+    }
+
+    # Build the detailed sections of the markdown
+
+    # Define variables to insert into the format string
+    $reportTitle = "Conditional Access Policies targeting Authentication Transfer"
+    $tableRows = ""
+
+    if ($matchedPolicies.Count -gt 0) {
+        # Create a here-string with format placeholders {0}, {1}, etc.
+        $formatTemplate = @'
+
+## {0}
 
 
-    Add-ZtTestResultDetail -TestId '21828' -Title "Authentication transfer is blocked" `
-        -UserImpact Low -Risk High -ImplementationCost Low `
-        -AppliesTo Identity -Tag Identity `
-        -Status $passed -Result $testResultMarkdown -SkippedBecause UnderConstruction
+| Policy Name | Policy ID | State | Created | Modified |
+| :---------- | :-------- | :---- | :------ | :------- |
+{1}
+
+'@
+
+        foreach ($policy in $matchedPolicies) {
+            $portalLink = "https://entra.microsoft.com/#view/Microsoft_AAD_ConditionalAccess/PolicyBlade/policyId/{0}" -f $policy.id
+            $tableRows += @"
+| [$(Get-SafeMarkdown($policy.displayName))]($portalLink) | $($policy.id) | $($policy.state) | $($policy.createdDateTime) | $($policy.modifiedDateTime) |`n
+"@
+        }
+
+        # Format the template by replacing placeholders with values
+        $mdInfo = $formatTemplate -f $reportTitle, $tableRows
+    }
+    else {
+        $mdInfo = "No enabled Conditional Access policies targeting authentication transfer.`n"
+    }
+
+    # Replace the placeholder with the detailed information
+    $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $mdInfo
+
+    $params = @{
+        TestId             = '21828'
+        Title              = "Authentication transfer is blocked"
+        UserImpact         = 'Low'
+        Risk               = 'High'
+        ImplementationCost = 'Low'
+        AppliesTo          = 'Identity'
+        Tag                = 'Identity'
+        Status             = $passed
+        Result             = $testResultMarkdown
+    }
+
+    Add-ZtTestResultDetail @params
 }


### PR DESCRIPTION
Test 21787:
Rewrite Add-ZtTestResultDetail command using splatting.
Remove %TestResult% details.

Test 21828:
Add test code to find matching policies for blocked authentication transfer.
Write markdown details using a here-string template. (That's a new approach. @merill, let's discuss it at the next meeting.)