### PR TITLE
add tenant type detection

### DIFF
--- a/src/powershell/private/tests/Invoke-ZtTests.ps1
+++ b/src/powershell/private/tests/Invoke-ZtTests.ps1
@@ -6,151 +6,22 @@
 function Invoke-ZtTests {
     [CmdletBinding()]
     param (
-        $Database
+        $Database,
+        [string]$ConfigPath = ".\private\tests\tests-config.json",
+        [ValidateSet("AAD", "CIAM")]
+        [string]$TenantType = "AAD"
     )
 
-    # Maybe optimize in future to run tests in parallel, show better progress etc.
-    # We could also run all the cmdlets in this folder that start with Test-
-    # For now, just run all tests sequentially
+    # Load the test configuration from JSON file
+    $configContent = Get-Content -Path $ConfigPath -Raw
+    $config = $configContent | ConvertFrom-Json
 
-    Test-InactiveAppDontHaveHighPrivGraphPerm -Database $Database
-    Test-InactiveAppDontHaveHighPrivEntraRole -Database $Database
-    Test-AppDontHaveSecrets -Database $Database
-    Test-AppDontHaveCertsWithLongExpiry -Database $Database
-    ## Test-PrivilegedUsersSignInPhishResistant (Blocked by lack of sign in log filter)
-    Test-PrivilegedUsersCaAuthStrengthPhishResistant
-    Test-PrivilegedUsersPhishResistantMethodRegistered -Database $Database
-    Test-UsersPhishResistantMethodRegistered -Database $Database
-    Test-GuestCantInviteGuests
-    Test-GuestHaveRestrictedAccess
-    Test-BlockLegacyAuthCaPolicy
-    Test-CreatingNewAppsRestrictedToPrivilegedUsers
-    ## Test-GuestStrongAuthMethod # Not implemented - Blocked by lack of sign in log filter
-    Test-DiagnosticSettingsConfiguredEntraLogs
-    Test-HighPriorityEntraRecommendationsAddressed
-
-    Test-Assessment-21795
-    Test-Assessment-21797
-    Test-Assessment-21800
-    Test-Assessment-21808
-    Test-Assessment-21815
-    Test-Assessment-21829
-    Test-Assessment-21861
-    Test-Assessment-21863
-    Test-Assessment-21864
-    Test-Assessment-21866
-    Test-Assessment-21872
-    Test-Assessment-21774
-    Test-Assessment-21775
-    Test-Assessment-21776
-    Test-Assessment-21777
-    Test-Assessment-21778
-    Test-Assessment-21779
-    Test-Assessment-21780
-    Test-Assessment-21784
-    Test-Assessment-21786
-    Test-Assessment-21787
-    Test-Assessment-21788
-    Test-Assessment-21789
-    Test-Assessment-21790
-    Test-Assessment-21793
-    Test-Assessment-21798
-    Test-Assessment-21799
-    Test-Assessment-21802
-    Test-Assessment-21803
-    Test-Assessment-21804
-    Test-Assessment-21806
-    Test-Assessment-21809
-    Test-Assessment-21810
-    Test-Assessment-21811
-    Test-Assessment-21812
-    Test-Assessment-21813
-    Test-Assessment-21816
-    Test-Assessment-21817
-    Test-Assessment-21818
-    Test-Assessment-21819
-    Test-Assessment-21820
-    Test-Assessment-21821
-    Test-Assessment-21822
-    Test-Assessment-21823
-    Test-Assessment-21824
-    Test-Assessment-21825
-    Test-Assessment-21828
-    Test-Assessment-21830
-    Test-Assessment-21831
-    Test-Assessment-21832
-    Test-Assessment-21833
-    Test-Assessment-21834
-    Test-Assessment-21835
-    Test-Assessment-21836
-    Test-Assessment-21837
-    Test-Assessment-21838
-    Test-Assessment-21839
-    Test-Assessment-21840
-    Test-Assessment-21841
-    Test-Assessment-21842
-    Test-Assessment-21843
-    Test-Assessment-21844
-    Test-Assessment-21845
-    Test-Assessment-21846
-    Test-Assessment-21847
-    Test-Assessment-21848
-    Test-Assessment-21849
-    Test-Assessment-21850
-    Test-Assessment-21854
-    Test-Assessment-21855
-    Test-Assessment-21857
-    Test-Assessment-21858
-    Test-Assessment-21859
-    Test-Assessment-21862
-    Test-Assessment-21865
-    Test-Assessment-21867
-    Test-Assessment-21868
-    Test-Assessment-21869
-    Test-Assessment-21870
-    Test-Assessment-21874
-    Test-Assessment-21875
-    Test-Assessment-21876
-    Test-Assessment-21877
-    Test-Assessment-21878
-    Test-Assessment-21879
-    Test-Assessment-21881
-    Test-Assessment-21882
-    Test-Assessment-21883
-    Test-Assessment-21884
-    Test-Assessment-21885 -Database $Database
-    Test-Assessment-21886
-    Test-Assessment-21887
-    Test-Assessment-21888
-    Test-Assessment-21889
-    Test-Assessment-21890
-    Test-Assessment-21891
-    Test-Assessment-21892
-    Test-Assessment-21893
-    Test-Assessment-21894
-    Test-Assessment-21895
-    Test-Assessment-21896
-    Test-Assessment-21897
-    Test-Assessment-21898
-    Test-Assessment-21899
-    Test-Assessment-21912
-    Test-Assessment-21929
-    Test-Assessment-21941
-    Test-Assessment-21953
-    Test-Assessment-21954
-    Test-Assessment-21955
-    Test-Assessment-21964
-    Test-Assessment-21983
-    Test-Assessment-21984
-    Test-Assessment-21985
-    Test-Assessment-21992 -Database $Database
-    Test-Assessment-22072
-    Test-Assessment-22098
-    Test-Assessment-22099
-    Test-Assessment-22100
-    Test-Assessment-22101
-    Test-Assessment-22102
-    Test-Assessment-22128
-    Test-Assessment-22659
-    Test-Assessment-23183 -Database $Database
+    # Filter tests by tenant type and execute them
+    $config.tests | Where-Object { $_.tenantTypes -contains $TenantType } | ForEach-Object {
+        if ($_.requiresDatabase) {
+            & $_.name -Database $Database
+        } else {
+            & $_.name
+        }
+    }
 }

--- a/src/powershell/private/tests/tests-config.json
+++ b/src/powershell/private/tests/tests-config.json
@@ -1,0 +1,689 @@
+{
+  "tests": [
+    {
+      "name": "Test-InactiveAppDontHaveHighPrivGraphPerm",
+      "tenantType": ["AAD"],
+      "requiresDatabase": true
+    },
+    {
+      "name": "Test-InactiveAppDontHaveHighPrivEntraRole",
+      "tenantType": ["AAD"],
+      "requiresDatabase": true
+    },
+    {
+      "name": "Test-AppDontHaveSecrets",
+      "tenantType": ["AAD"],
+      "requiresDatabase": true
+    },
+    {
+      "name": "Test-AppDontHaveCertsWithLongExpiry",
+      "tenantType": ["AAD", "CIAM"],
+      "requiresDatabase": true
+    },
+    {
+      "name": "Test-PrivilegedUsersCaAuthStrengthPhishResistant",
+      "tenantType": ["AAD", "CIAM"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-PrivilegedUsersPhishResistantMethodRegistered",
+      "tenantType": ["AAD", "CIAM"],
+      "requiresDatabase": true
+    },
+    {
+      "name": "Test-UsersPhishResistantMethodRegistered",
+      "tenantType": ["AAD", "CIAM"],
+      "requiresDatabase": true
+    },
+    {
+      "name": "Test-GuestCantInviteGuests",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-GuestHaveRestrictedAccess",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-BlockLegacyAuthCaPolicy",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-CreatingNewAppsRestrictedToPrivilegedUsers",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-DiagnosticSettingsConfiguredEntraLogs",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-HighPriorityEntraRecommendationsAddressed",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21795",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21797",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21800",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21808",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21815",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21829",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21861",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21863",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21864",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21866",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21872",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21774",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21775",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21776",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21777",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21778",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21779",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21780",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21784",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21786",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21787",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21788",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21789",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21790",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21793",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21798",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21799",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21802",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21803",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21804",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21806",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21809",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21810",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21811",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21812",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21813",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21816",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21817",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21818",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21819",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21820",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21821",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21822",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21823",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21824",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21825",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21828",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21830",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21831",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21832",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21833",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21834",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21835",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21836",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21837",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21838",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21839",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21840",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21841",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21842",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21843",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21844",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21845",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21846",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21847",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21848",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21849",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21850",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21854",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21855",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21857",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21858",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21859",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21862",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21865",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21867",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21868",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21869",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21870",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21874",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21875",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21876",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21877",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21878",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21879",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21881",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21882",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21883",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21884",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21885",
+      "tenantType": ["AAD"],
+      "requiresDatabase": true
+    },
+    {
+      "name": "Test-Assessment-21886",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21887",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21888",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21889",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21890",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21891",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21892",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21893",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21894",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21895",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21896",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21897",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21898",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21899",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21912",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21929",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21941",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21953",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21954",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21955",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21964",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21983",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21984",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21985",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-21992",
+      "tenantType": ["AAD"],
+      "requiresDatabase": true
+    },
+    {
+      "name": "Test-Assessment-22072",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-22098",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-22099",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-22100",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-22101",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-22102",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-22128",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-22659",
+      "tenantType": ["AAD"],
+      "requiresDatabase": false
+    },
+    {
+      "name": "Test-Assessment-23183",
+      "tenantType": ["AAD"],
+      "requiresDatabase": true
+    }
+  ]
+}

--- a/src/powershell/public/Invoke-ZtAssessment.ps1
+++ b/src/powershell/public/Invoke-ZtAssessment.ps1
@@ -110,8 +110,12 @@ Write-Host $banner -ForegroundColor Cyan
     Export-TenantData -ExportPath $exportPath -Days $Days -MaximumSignInLogQueryTime $MaximumSignInLogQueryTime
     $db = Export-Database -ExportPath $exportPath
 
+    # Get Tenant Type (AAD = Workforce, CIAM = EEID)
+    $tenantType = Get-MgOrganization | Select-Object -ExpandProperty TenantType
+    Write-Host $tenantType "tenant detected. This will determine the tests that are run." -ForegroundColor Yellow
+
     # Run the tests
-    Invoke-ZtTests -Database $db
+    Invoke-ZtTests -Database $db -TenantType $tenantType
     Invoke-ZtTenantInfo -Database $db
 
     $assessmentResults = Get-ZtAssessmentResults


### PR DESCRIPTION
Add the capability for differentiated tests based on tenant type.
The tenant type is obtained from /organization endpoint and can be either AAD (Workforce tenant) or CIAM (External tenant).

The tests are moved into a JSON file from which we can mark whether the test is applicable to AAD, CIAM or both.
This can be expanded with other attributes, such as "template": "CISA", to enhance the runtime of any particular tenant specific test set.