### PR TITLE
Add RoleManagementPolicyAssignment export

### DIFF
--- a/src/powershell/private/export/Export-Database.ps1
+++ b/src/powershell/private/export/Export-Database.ps1
@@ -41,6 +41,7 @@ function Export-Database {
     Import-Table -db $db -absExportPath $absExportPath -tableName 'RoleAssignmentGroup'
     Import-Table -db $db -absExportPath $absExportPath -tableName 'RoleEligibilityScheduleRequest'
     Import-Table -db $db -absExportPath $absExportPath -tableName 'RoleEligibilityScheduleRequestGroup'
+    Import-Table -db $db -absExportPath $absExportPath -tableName 'RoleManagementPolicyAssignment'
     Import-Table -db $db -absExportPath $absExportPath -tableName 'UserRegistrationDetails'
 
     New-ViewRole -db $db

--- a/src/powershell/private/export/Export-TenantData.ps1
+++ b/src/powershell/private/export/Export-TenantData.ps1
@@ -59,6 +59,11 @@ function Export-TenantData {
         Export-GraphEntity -ExportPath $ExportPath -EntityName 'RoleEligibilityScheduleRequest' `
             -EntityUri 'beta/roleManagement/directory/roleEligibilityScheduleRequests' -ProgressActivity 'Role Eligibility' `
             -QueryString "`$expand=principal&`$filter = NOT(status eq 'Canceled' or status eq 'Denied' or status eq 'Failed' or status eq 'Revoked')"
+
+        # Export role management policy assignments for PIM activation alert configuration
+        Export-GraphEntity -ExportPath $ExportPath -EntityName 'RoleManagementPolicyAssignment' `
+            -EntityUri 'beta/policies/roleManagementPolicyAssignments' -ProgressActivity 'Role Management Policy Assignments' `
+            -QueryString "`$filter=scopeId eq '/' and scopeType eq 'DirectoryRole'"
     }
 
     Export-GraphEntity -ExportPath $ExportPath -EntityName 'UserRegistrationDetails' `


### PR DESCRIPTION
Add `RoleManagementPolicyAssignment` export to tenant data and database export functions.
 Changed endpoint version from "v1.0" (in spec) to "beta", because all endpoints in `Export-TenantData` are "beta" endpoints.