### PR TITLE
Refactor test functions to use array syntax for database query results

### DIFF
--- a/src/powershell/private/tests/Test-Assessment.21773.ps1
+++ b/src/powershell/private/tests/Test-Assessment.21773.ps1
@@ -1,4 +1,3 @@
-
 <#
 .SYNOPSIS
 
@@ -32,8 +31,8 @@ function Test-Assessment-21773 {
     order by displayName, keyEndDateTime DESC
 "@
 
-    $resultsApp = Invoke-DatabaseQuery -Database $Database -Sql $sqlApp
-    $resultsSP = Invoke-DatabaseQuery -Database $Database -Sql $sqlSP
+    $resultsApp = @(Invoke-DatabaseQuery -Database $Database -Sql $sqlApp)
+    $resultsSP = @(Invoke-DatabaseQuery -Database $Database -Sql $sqlSP)
 
     $passed = ($resultsApp.Count -eq 0) -and ($resultsSP.Count -eq 0)
 
@@ -50,7 +49,7 @@ function Test-Assessment-21773 {
         $mdInfo += "| :--- | :--- |`n"
         foreach ($item in $resultsApp) {
             $portalLink = "https://entra.microsoft.com/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/Credentials/appId/{0}" -f $item.appId
-            $mdInfo += "| [$(Get-SafeMarkdown($item.displayName))]($portalLink) | $($item.keyEndDateTime) |`n"
+            $mdInfo += "| [$(Get-SafeMarkdown($item.displayName))]($portalLink) | $(Get-FormattedDate($item.keyEndDateTime)) |`n"
         }
     }
 
@@ -61,14 +60,23 @@ function Test-Assessment-21773 {
         foreach ($item in $resultsSP) {
             $tenant = Get-ZtTenant -tenantId $item.appOwnerOrganizationId
             $portalLink = "https://entra.microsoft.com/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/SignOn/objectId/$($item.id)/appId/$($item.appId)/preferredSingleSignOnMode/saml/servicePrincipalType/Application/fromNav/"
-            $mdInfo += "| [$(Get-SafeMarkdown($item.displayName))]($portalLink) | $(Get-SafeMarkdown($tenant.displayName)) | $($item.keyEndDateTime) |`n"
+            $mdInfo += "| [$(Get-SafeMarkdown($item.displayName))]($portalLink) | $(Get-SafeMarkdown($tenant.displayName)) | $(Get-FormattedDate($item.keyEndDateTime)) |`n"
         }
     }
 
     $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $mdInfo
 
-    Add-ZtTestResultDetail -TestId '21773' -Title 'Applications don''t have certificates with expiration longer than 180 days' `
-        -UserImpact Medium -Risk High -ImplementationCost Medium `
-        -AppliesTo Identity -Tag Application `
-        -Status $passed -Result $testResultMarkdown
+    $params = @{
+        TestId             = '21773'
+        Title              = 'Applications don''t have certificates with expiration longer than 180 days'
+        UserImpact         = 'Medium'
+        Risk               = 'High'
+        ImplementationCost = 'Medium'
+        AppliesTo          = 'Identity'
+        Tag                = 'Application'
+        Status             = $passed
+        Result             = $testResultMarkdown
+    }
+
+    Add-ZtTestResultDetail @params
 }

--- a/src/powershell/private/tests/Test-Assessment.21828.ps1
+++ b/src/powershell/private/tests/Test-Assessment.21828.ps1
@@ -57,7 +57,7 @@ function Test-Assessment-21828 {
         foreach ($policy in $matchedPolicies) {
             $portalLink = "https://entra.microsoft.com/#view/Microsoft_AAD_ConditionalAccess/PolicyBlade/policyId/{0}" -f $policy.id
             $tableRows += @"
-| [$(Get-SafeMarkdown($policy.displayName))]($portalLink) | $($policy.id) | $($policy.state) | $($policy.createdDateTime) | $($policy.modifiedDateTime) |`n
+| [$(Get-SafeMarkdown($policy.displayName))]($portalLink) | $($policy.id) | $($policy.state) | $(Get-FormattedDate($policy.createdDateTime)) | $(Get-FormattedDate($policy.modifiedDateTime)) |`n
 "@
         }
 

--- a/src/powershell/private/tests/Test-Assessment.21992.ps1
+++ b/src/powershell/private/tests/Test-Assessment.21992.ps1
@@ -27,8 +27,8 @@ function Test-Assessment-21992{
     where keyStartDateTime < minStartDate
     order by displayName, keyStartDateTime DESC
 "@
-    $resultsApp = Invoke-DatabaseQuery -Database $Database -Sql $sqlApp
-    $resultsSP = Invoke-DatabaseQuery -Database $Database -Sql $sqlSP
+    $resultsApp = @(Invoke-DatabaseQuery -Database $Database -Sql $sqlApp)
+    $resultsSP = @(Invoke-DatabaseQuery -Database $Database -Sql $sqlSP)
 
     $passed = ($resultsApp.Count -eq 0) -and ($resultsSP.Count -eq 0)
     if ($passed) {
@@ -43,7 +43,7 @@ function Test-Assessment-21992{
         $mdInfo += "| :--- | :--- |`n"
         foreach ($item in $resultsApp) {
             $portalLink = "https://entra.microsoft.com/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/Credentials/appId/{0}" -f $item.appId
-            $mdInfo += "| [$(Get-SafeMarkdown($item.displayName))]($portalLink) | $($item.keyStartDateTime) |`n"
+            $mdInfo += "| [$(Get-SafeMarkdown($item.displayName))]($portalLink) | $(Get-FormattedDate($item.keyStartDateTime)) |`n"
         }
     }
     if ($resultsSP.Count -gt 0) {
@@ -53,14 +53,23 @@ function Test-Assessment-21992{
         foreach ($item in $resultsSP) {
             $tenant = Get-ZtTenant -tenantId $item.appOwnerOrganizationId
             $portalLink = "https://entra.microsoft.com/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/SignOn/objectId/$($item.id)/appId/$($item.appId)/preferredSingleSignOnMode/saml/servicePrincipalType/Application/fromNav/"
-            $mdInfo += "| [$(Get-SafeMarkdown($item.displayName))]($portalLink) | $(Get-SafeMarkdown($tenant.displayName)) | $($item.keyStartDateTime) |`n"
+            $mdInfo += "| [$(Get-SafeMarkdown($item.displayName))]($portalLink) | $(Get-SafeMarkdown($tenant.displayName)) | $(Get-FormattedDate($item.keyStartDateTime)) |`n"
         }
     }
 
     $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $mdInfo
 
-    Add-ZtTestResultDetail -TestId '21992' -Title "Application Certificates need to be rotated on a regular basis" `
-        -UserImpact Low -Risk High -ImplementationCost High `
-        -AppliesTo Identity -Tag Identity `
-        -Status $passed -Result $testResultMarkdown
+    $params = @{
+        TestId             = '21992'
+        Title              = 'Application Certificates need to be rotated on a regular basis'
+        UserImpact         = 'Low'
+        Risk               = 'High'
+        ImplementationCost = 'High'
+        AppliesTo          = 'Identity'
+        Tag                = 'Identity'
+        Status             = $passed
+        Result             = $testResultMarkdown
+    }
+
+    Add-ZtTestResultDetail @params
 }


### PR DESCRIPTION
Refactor test functions to use array syntax for database query results and format date outputs consistently.

Just wanted to format date outputs consistently using the `Get-FormattedDate` function and use splatting for the `Add-ZtTestResultDetail` command.

But found a bug in tests: 21772, 21773, and 21992.

```powershell
    $resultsApp = Invoke-DatabaseQuery -Database $Database -Sql $sqlApp
    $resultsSP = Invoke-DatabaseQuery -Database $Database -Sql $sqlSP

    $passed = ($resultsApp.Count -eq 0) -and ($resultsSP.Count -eq 0)
```

Sometimes, `Invoke-DatabaseQuery` returns an array of hash tables. In that case, $resultsApp.Count and $resultsSP.Count correctly return a number of hash tables.
However, if the result contains only one hash table, `Count` property returns a number of hash table's key-value pairs. That leads to incorrect test results.

**Fix**: Wrapping the call in @(...) forces an array. Regardless of how many results come back, you always get an array:
- If zero records, you get an empty array (@()), not $null.
- If one record, you get a single-element array containing that object.
- If multiple records, you get an array of those objects (same as unwrapped in many cases, but consistently an array).

```powershell
    $resultsApp = @(Invoke-DatabaseQuery -Database $Database -Sql $sqlApp)
    $resultsSP = @(Invoke-DatabaseQuery -Database $Database -Sql $sqlSP)

    $passed = ($resultsApp.Count -eq 0) -and ($resultsSP.Count -eq 0)
```
