### PR TITLE
Add Test-Assessment-21886 to validate application provisioning

### DIFF
--- a/src/powershell/private/tests/Test-Assessment.21886.md
+++ b/src/powershell/private/tests/Test-Assessment.21886.md
@@ -1,6 +1,8 @@
-...
+When applications that support both authentication and provisioning through Microsoft Entra are not configured for automatic provisioning, organizations become vulnerable to identity lifecycle gaps that threat actors can exploit. Without automated provisioning, user accounts may persist in applications after employees leave the organization, creating dormant accounts that threat actors can discover through reconnaissance activities. These orphaned accounts often retain their original access permissions but lack active monitoring, making them attractive targets for initial access. Threat actors who gain access to these dormant accounts can use them to establish persistence in the target application, as the accounts appear legitimate and may not trigger security alerts. From these compromised application accounts, attackers can then attempt to escalate their privileges by exploring application-specific permissions, accessing sensitive data stored within the application, or using the application as a pivot point to access other connected systems. The lack of centralized identity lifecycle management also makes it difficult for security teams to detect when an attacker is using these orphaned accounts, as the accounts may not be properly correlated with the organization's active user directory.
 
 **Remediation action**
 
+Configure application provisioning for missing applications:
+- [Managing user account provisioning for enterprise apps in the Microsoft Entra admin center](https://learn.microsoft.com/entra/identity/app-provisioning/configure-automatic-user-provisioning-portal)
 <!--- Results --->
 %TestResult%

--- a/src/powershell/private/tests/Test-Assessment.21886.ps1
+++ b/src/powershell/private/tests/Test-Assessment.21886.ps1
@@ -3,22 +3,110 @@
 
 #>
 
-function Test-Assessment-21886{
+function Test-Assessment-21886 {
     [CmdletBinding()]
-    param()
+    param(
+        $Database
+    )
 
     Write-PSFMessage '🟦 Start' -Tag Test -Level VeryVerbose
 
     $activity = "Checking Applications that use Microsoft Entra for authentication and support provisioning are configured"
-    Write-ZtProgress -Activity $activity -Status "Getting policy"
+    Write-ZtProgress -Activity $activity -Status "Getting all service principals that have SSO configured"
 
-    $result = $false
-    $testResultMarkdown = "Planned for future release."
-    $passed = $result
+    $sql = @"
+SELECT
+    id,
+    appId,
+    displayName,
+    preferredSingleSignOnMode,
+    accountEnabled
+FROM ServicePrincipal
+WHERE preferredSingleSignOnMode IN ('password', 'saml', 'oidc')
+    AND accountEnabled = true
+ORDER BY LOWER(displayName) ASC
+"@
+
+    $matchedServicePrincipals = Invoke-DatabaseQuery -Database $Database -Sql $sql
+
+    $apps = @()
+    foreach ($servicePrincipal in $matchedServicePrincipals) {
+        $app = [PSCustomObject]@{
+            Id                    = $servicePrincipal.id
+            AppId                 = $servicePrincipal.appId
+            DisplayName           = Get-SafeMarkdown $servicePrincipal.displayName
+            PreferredSingleSignOn = $servicePrincipal.preferredSingleSignOnMode
+            AccountEnabled        = $servicePrincipal.accountEnabled
+            Templates             = Invoke-ZtGraphRequest -RelativeUri "servicePrincipals/$($servicePrincipal.id)/synchronization/templates" -ApiVersion 'v1.0'
+            Jobs                  = Invoke-ZtGraphRequest -RelativeUri "servicePrincipals/$($servicePrincipal.id)/synchronization/jobs" -ApiVersion 'v1.0'
+        }
+        $apps += $app
+    }
+
+    $unconfiguredApps = @()
+    $configuredApps = @()
+    foreach ($app in $apps) {
+        if (($app.Templates | Measure-Object).Count -gt 0 -and ($app.Jobs.value | Measure-Object).Count -eq 0) {
+            $unconfiguredApps += $app
+        }
+    else {
+        $configuredApps += $app
+    }
+}
+
+    if ($unconfiguredApps.Count -eq 0) {
+        $passed = $true
+        $testResultMarkdown = "Applications that are configured for SSO and support provisioning are also configured for provisioning."
+    }
+    else {
+        $passed = $false
+        $testResultMarkdown = "Applications that are configured for SSO and support provisioning are NOT configured for provisioning.`n`n%TestResult%"
+    }
+
+    # Build the detailed sections of the markdown
+
+    # Define variables to insert into the format string
+    $reportTitle = "Applications that are NOT configured for provisioning"
+    $tableRows = ""
+
+    if ($unconfiguredApps.Count -gt 0) {
+        # Create a here-string with format placeholders {0}, {1}, etc.
+        $formatTemplate = @'
+
+## {0}
 
 
-    Add-ZtTestResultDetail -TestId '21886' -Title "Applications that use Microsoft Entra for authentication and support provisioning are configured" `
-        -UserImpact Low -Risk Medium -ImplementationCost Medium `
-        -AppliesTo Identity -Tag Identity `
-        -Status $passed -Result $testResultMarkdown -SkippedBecause UnderConstruction
+| Application Name | Object ID | Application ID |
+| :--------------- | :-------- | :------------- |
+{1}
+
+'@
+
+        foreach ($app in $unconfiguredApps) {
+            $portalLink = "https://entra.microsoft.com/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/Overview/objectId/{0}/appId/{1}/preferredSingleSignOnMode/{2}/servicePrincipalType/Application/fromNav/" -f $app.Id, $app.AppId, $app.PreferredSingleSignOn
+            $tableRows += @"
+| [$($app.displayName)]($portalLink) | $($app.Id) | $($app.AppId) |`n
+"@
+        }
+
+        # Format the template by replacing placeholders with values
+        $mdInfo = $formatTemplate -f $reportTitle, $tableRows
+
+        # Replace the placeholder with the detailed information
+        $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $mdInfo
+    }
+
+    $params = @{
+        TestId             = '21886'
+        Title              = 'Applications that use Microsoft Entra for authentication and support provisioning are configured'
+        UserImpact         = 'Low'
+        Risk               = 'Medium'
+        ImplementationCost = 'Medium'
+        AppliesTo          = 'Identity'
+        Tag                = 'Identity'
+        Status             = $passed
+        Result             = $testResultMarkdown
+    }
+
+    Add-ZtTestResultDetail @params
 }


### PR DESCRIPTION
Add `Test-Assessment-21886` to validate application provisioning for Microsoft Entra, including detailed reporting on unconfigured applications.

This test has the same issue when `Invoke-ZtRequestGraph` returns a single object with `value` property equals to `{}`.
It also has performance issues with API calls.