### PR TITLE
Add Test-Assessment-21874 to test external collaboration domain checks

### DIFF
--- a/src/powershell/private/tests/Test-Assessment.21874.md
+++ b/src/powershell/private/tests/Test-Assessment.21874.md
@@ -1,6 +1,8 @@
-...
+Without configured domain allow/deny lists for external collaboration, organizations lack granular control over which external domains can be invited into their tenant for B2B collaboration. This configuration gap allows internal users to invite external users from any domain, including potentially compromised or malicious domains that threat actors' control. When unrestricted domain access is permitted, threat actors can register domains that appear legitimate to conduct social engineering attacks, tricking internal users into extending collaboration invitations to attacker-controlled accounts. Once threat actors receive invitations and gain guest access to the tenant, they can perform reconnaissance activities to map internal resources, user relationships, and collaboration patterns within the organization. These externally invited accounts provide threat actors with persistent access that appears legitimate within audit logs and security monitoring systems, enabling them to maintain long-term presence for data collection activities. The external guest accounts can be leveraged to access shared resources, documents, and applications that internal users have configured for external collaboration, potentially leading to data exfiltration through authorized collaboration channels that may not trigger security alerts.
 
 **Remediation action**
 
+Configure Domain-Based Allow or Deny Lists as per the article:
+- [Set the allow or blocklist policy in the portal](https://learn.microsoft.com/entra/external-id/allow-deny-list#set-the-allow-or-blocklist-policy-in-the-portal)
 <!--- Results --->
 %TestResult%

--- a/src/powershell/private/tests/Test-Assessment.21874.ps1
+++ b/src/powershell/private/tests/Test-Assessment.21874.ps1
@@ -3,22 +3,39 @@
 
 #>
 
-function Test-Assessment-21874{
+function Test-Assessment-21874 {
     [CmdletBinding()]
     param()
 
     Write-PSFMessage '🟦 Start' -Tag Test -Level VeryVerbose
 
-    $activity = "Checking Tenant does have controls to selectively onboard external organizations (cross-tenant access polices and domain-based allow/deny lists)"
+    $activity = "Checking Allow/Deny lists of domains to restrict external collaboration are configured"
     Write-ZtProgress -Activity $activity -Status "Getting policy"
 
-    $result = $false
-    $testResultMarkdown = "Planned for future release."
-    $passed = $result
+    $policies = Invoke-ZtGraphRequest -RelativeUri 'legacy/policies' -ApiVersion beta -DisableCache
 
+    foreach ($policy in $policies) {
+        if ( $policy.definition -and ($null -ne ($policy.definition | ConvertFrom-Json).B2BManagementPolicy.InvitationsAllowedAndBlockedDomainsPolicy.AllowedDomains) ) {
+            $passed = $true
+            $testResultMarkdown = "Allow/Deny lists of domains to restrict external collaboration are configured."
+            break
+        }
+        else {
+            $passed = $false
+            $testResultMarkdown = "Allow/Deny lists of domains to restrict external collaboration are not configured."
+        }
+    }
 
-    Add-ZtTestResultDetail -TestId '21874' -Title "Tenant does have controls to selectively onboard external organizations (cross-tenant access polices and domain-based allow/deny lists)" `
-        -UserImpact Medium -Risk Medium -ImplementationCost Medium `
-        -AppliesTo Identity -Tag Identity `
-        -Status $passed -Result $testResultMarkdown -SkippedBecause UnderConstruction
+    $params = @{
+        TestId             = '21874'
+        Title              = "Allow/Deny lists of domains to restrict external collaboration are configured"
+        UserImpact         = 'Medium'
+        Risk               = 'Medium'
+        ImplementationCost = 'Medium'
+        AppliesTo          = 'Identity'
+        Tag                = 'Identity'
+        Status             = $passed
+        Result             = $testResultMarkdown
+    }
+    Add-ZtTestResultDetail @params
 }


### PR DESCRIPTION
Add Test-Assessment-21874 to enhance external collaboration domain checks.

The test title in the spec and TestMeta.json are not the same. I've used one from the spec. It was overwritten.