### PR TITLE
Add interactive configuration wizard for Zero Trust Assessment

### DIFF
--- a/src/powershell/private/core/New-ZtInteractiveConfig.ps1
+++ b/src/powershell/private/core/New-ZtInteractiveConfig.ps1
@@ -1,0 +1,276 @@
+<#
+.SYNOPSIS
+Creates a Zero Trust Assessment configuration file using an interactive text-based user interface.
+
+.DESCRIPTION
+This function provides a text-based user interface (TUI) for creating Zero Trust Assessment configuration files.
+The generated .json file can be used internally by the Invoke-ZtAssessment function.
+
+.EXAMPLE
+New-ZtInteractiveConfig
+
+Creates a configuration file using the TUI interface and saves it to the temporary directory.
+
+.INPUTS
+None. You cannot pipe objects to this function.
+
+.OUTPUTS
+System.IO.FileInfo. Returns the created configuration file object.
+
+.NOTES
+Requires PowerShell 7+ and the PwshSpectreConsole module.
+Use 'Install-Module PwshSpectreConsole' to install the required module.
+#>
+
+#requires -version 7
+#requires -modules PwshSpectreConsole
+
+function New-ZtInteractiveConfig {
+    [CmdletBinding()]
+    [OutputType([System.IO.FileInfo])]
+    param (
+        # No parameters needed
+    )
+
+    if (!(Get-Module -Name PwshSpectreConsole -ListAvailable)) {
+        Import-Module PwshSpectreConsole -Force
+    }
+
+    # Create the output file path in temporary folder
+    $tempPath = [System.IO.Path]::GetTempPath()
+    $OutputPath = Join-Path $tempPath "zt-interactive-config.json"
+
+    # Enhanced header with better visual appeal
+    Clear-Host
+    $headerText = "Zero Trust Assessment Configuration Wizard"
+    $headerEmoji = "🛡️"
+    $headerDisplay = if ($Host.UI.SupportsVirtualTerminal) { "$headerEmoji $headerText" } else { $headerText }
+    Write-SpectreRule $headerDisplay -Color ([Spectre.Console.Color]::Blue)
+    Write-Host
+    Write-SpectreHost "[dim]Welcome to the interactive configuration wizard.[/]"
+    Write-SpectreHost "[dim]This tool will help you create a custom configuration for your Zero Trust Assessment.[/]"
+    Write-Host
+    Write-SpectreRule "Step 1: Assessment Settings" -Color ([Spectre.Console.Color]::Cyan1)
+
+    # Create configuration hashtable
+    $configData = @{}
+
+    try {
+        # Collect Days setting with better description
+        Write-SpectreHost "[bold cyan1]📊 Sign-in Log Query Duration[/]"
+        Write-SpectreHost "[dim]How many days of sign-in logs would you like to analyze?[/]"
+        Write-SpectreHost "[dim]• More days = more comprehensive analysis[/]"
+        Write-SpectreHost "[dim]• Fewer days = faster processing[/]"
+        Write-Host
+
+        # Loop until a valid number of days is provided
+        do {
+            $days = Read-SpectreText -Prompt "[cyan1]Number of days[/] [dim](1-30)[/]" -DefaultAnswer "30"
+            $daysValid = $days -as [int] -and $days -ge 1 -and $days -le 30
+            if (!$daysValid) {
+                Write-SpectreHost "[red]❌ Please enter a number between 1 and 30.[/]"
+            }
+        } while (!$daysValid)
+        $configData.Days = [int]$days
+        Write-SpectreHost "[green]✅ Will analyze $days days of sign-in logs[/]"
+        Write-Host
+
+        # Collect Maximum query time with better explanation
+        Write-SpectreHost "[bold cyan1]⏱️ Query Time Limit[/]"
+        Write-SpectreHost "[dim]Set a maximum time limit for querying sign-in logs to prevent long waits.[/]"
+        Write-SpectreHost "[dim]• 0 = No time limit (may take longer)[/]"
+        Write-SpectreHost "[dim]• Recommended: 60 minutes for most environments[/]"
+        Write-Host
+
+        do {
+            $maxTime = Read-SpectreText -Prompt "[cyan1]Maximum query time in minutes[/] [dim](0 = no limit)[/]" -DefaultAnswer "60"
+            $maxTimeValid = $maxTime -match '^\d+$' -and [int]$maxTime -ge 0
+            if (!$maxTimeValid) {
+                Write-SpectreHost "[red]❌ Please enter a number 0 or greater.[/]"
+            }
+        } while (!$maxTimeValid)
+        $configData.MaximumSignInLogQueryTime = [int]$maxTime
+
+        if ([int]$maxTime -eq 0) {
+            Write-SpectreHost "[yellow]⚠️ No time limit set - assessment may take longer[/]"
+        } else {
+            Write-SpectreHost "[green]✅ Query time limit set to $maxTime minutes[/]"
+        }
+        Write-Host
+
+        # Collect output path with better guidance
+        Write-SpectreHost "[bold cyan1]📁 Report Output Location[/]"
+        Write-SpectreHost "[dim]Where would you like to save the assessment report?[/]"
+        Write-Host
+
+        $reportPath = Read-SpectreText -Prompt "[cyan1]Report output path[/]" -DefaultAnswer "./ZeroTrustReport"
+        $configData.Path = $reportPath
+        Write-SpectreHost "[green]✅ Report will be saved to: $reportPath[/]"
+        Write-Host
+
+        # Enhanced configuration options section
+        Write-SpectreRule "Step 2: Advanced Options" -Color ([Spectre.Console.Color]::Cyan1)
+        Write-Host
+        Write-SpectreHost "[bold cyan1]🔧 Additional Configuration Options[/]"
+        Write-SpectreHost "[dim]These options provide additional functionality for your assessment.[/]"
+        Write-Host
+
+        # Display available options with better descriptions
+        $options = @(
+            "Enable detailed logging",
+            "Export logs to support package",
+            "Disable telemetry collection",
+            "Resume from previous export"
+        )
+
+        $optionDescriptions = @{
+            "Enable detailed logging" = "Shows verbose output during assessment execution"
+            "Export logs to support package" = "Creates diagnostic files for troubleshooting"
+            "Disable telemetry collection" = "Prevents sending anonymous usage data to Microsoft"
+            "Resume from previous export" = "Continues from a previously interrupted assessment"
+        }
+
+        Write-SpectreHost "[bold yellow]Available Options:[/]"
+        for ($i = 0; $i -lt $options.Count; $i++) {
+            $option = $options[$i]
+            $description = $optionDescriptions[$option]
+            Write-SpectreHost "  [bold]$($i + 1). $option[/]"
+            Write-SpectreHost "     [dim]$description[/]"
+        }
+        $selectionMethod = Read-SpectreSelection -Prompt "[cyan1]How would you like to configure these options?[/]" -Choices @(
+            "🎯 Select options individually (recommended)",
+            "✅ Select all options",
+            "⏭️ Skip all options (use defaults)"
+        )
+
+        $selectedOptions = @()
+
+        switch ($selectionMethod) {
+            "🎯 Select options individually (recommended)" {
+                Write-Host
+                Write-SpectreHost "[bold cyan1]Interactive Selection Mode[/]"
+                Write-SpectreHost "[dim]• Use [bold]SPACE[/] to toggle options on/off[/]"
+                Write-SpectreHost "[dim]• Use [bold]ENTER[/] to confirm your selection[/]"
+                Write-SpectreHost "[dim]• Use [bold]arrow keys[/] to navigate[/]"
+                Write-Host
+                $selectedOptions = Read-SpectreMultiSelection -Prompt "[cyan1]Select your desired options[/]" -Choices $options -AllowEmpty
+            }
+            "✅ Select all options" {
+                $selectedOptions = $options
+                Write-Host
+                Write-SpectreHost "[bold green]✅ All options selected[/]"
+                Write-SpectreHost "[dim]The assessment will run with all advanced features enabled.[/]"
+            }
+            "⏭️ Skip all options (use defaults)" {
+                $selectedOptions = @()
+                Write-Host
+                Write-SpectreHost "[bold yellow]⏭️ Using default settings[/]"
+                Write-SpectreHost "[dim]The assessment will run with standard configuration.[/]"
+            }
+        }
+
+        # Show selected options summary
+        if ($selectedOptions.Count -gt 0) {
+            Write-Host
+            Write-SpectreHost "[bold green]Selected Options Summary:[/]"
+            foreach ($option in $selectedOptions) {
+                Write-SpectreHost "  [green]✅[/] $option"
+            }
+        }
+
+        $configData.ShowLog = $selectedOptions -contains "Enable detailed logging"
+        $configData.ExportLog = $selectedOptions -contains "Export logs to support package"
+        $configData.DisableTelemetry = $selectedOptions -contains "Disable telemetry collection"
+        $configData.Resume = $selectedOptions -contains "Resume from previous export"
+
+        # Enhanced test IDs collection
+        Write-Host
+        Write-SpectreRule "Step 3: Test Selection (Optional)" -Color ([Spectre.Console.Color]::Cyan1)
+        Write-Host
+        Write-SpectreHost "[bold cyan1]🧪 Specific Test Selection[/]"
+        Write-SpectreHost "[dim]By default, all available tests will be executed.[/]"
+        Write-SpectreHost "[dim]You can optionally specify specific test IDs to run only those tests.[/]"
+        Write-Host
+
+        $testIds = Read-SpectreText -Prompt "[cyan1]Specific test IDs[/] [dim](comma-separated, leave empty for all tests)[/]" -AllowEmpty
+        if (![string]::IsNullOrWhiteSpace($testIds)) {
+            $testArray = $testIds -split ',' | ForEach-Object { $_.Trim() } | Where-Object { $_ }
+            $invalidIds = $testArray | Where-Object { $_ -notmatch '^\d+$' }
+            if ($invalidIds.Count -gt 0) {
+                Write-SpectreHost "[red]❌ Invalid test IDs detected: $($invalidIds -join ', ')[/]"
+                Write-SpectreHost "[dim]Test IDs must only contain numbers.[/]"
+                throw "Invalid test IDs provided."
+            }
+            if ($testArray.Count -gt 0) {
+                $configData.Tests = $testArray
+                Write-SpectreHost "[green]✅ Will run $($testArray.Count) specific test(s): $($testArray -join ', ')[/]"
+            }
+        } else {
+            Write-SpectreHost "[green]✅ Will run all available tests[/]"
+        }
+
+        # Enhanced preview section
+        Write-Host
+        Write-SpectreRule "Step 4: Review & Save" -Color ([Spectre.Console.Color]::Cyan1)
+        Write-Host
+
+        $showPreview = Read-SpectreConfirm -Prompt "[cyan1]Would you like to preview your configuration?[/]" -DefaultAnswer "y"
+
+        if ($showPreview) {
+            Write-Host
+            Write-SpectreRule "📋 Configuration Preview" -Color ([Spectre.Console.Color]::Green)
+
+            # Create a more readable preview format
+            Write-SpectreHost "[bold yellow]Assessment Configuration Summary:[/]"
+            Write-SpectreHost "  [cyan1]Days to analyze:[/] $($configData.Days)"
+            Write-SpectreHost "  [cyan1]Query time limit:[/] $($configData.MaximumSignInLogQueryTime) minutes"
+            Write-SpectreHost "  [cyan1]Report output path:[/] $($configData.Path)"
+            Write-SpectreHost "  [cyan1]Detailed logging:[/] $($configData.ShowLog)"
+            Write-SpectreHost "  [cyan1]Export logs:[/] $($configData.ExportLog)"
+            Write-SpectreHost "  [cyan1]Telemetry disabled:[/] $($configData.DisableTelemetry)"
+            Write-SpectreHost "  [cyan1]Resume mode:[/] $($configData.Resume)"
+
+            if ($configData.Tests) {
+                Write-SpectreHost "  [cyan1]Specific tests:[/] $($configData.Tests -join ', ')"
+            } else {
+                Write-SpectreHost "  [cyan1]Test selection:[/] All tests"
+            }
+
+            Write-Host
+        }
+
+        $saveConfig = Read-SpectreConfirm -Prompt "[bold cyan1]💾 Save this configuration?[/]" -DefaultAnswer "y"
+
+        if (!$saveConfig) {
+            Write-Host
+            Write-SpectreRule "❌ Configuration Cancelled" -Color ([Spectre.Console.Color]::Red)
+            Write-SpectreHost "[yellow]Configuration creation cancelled by user.[/]"
+            Write-SpectreHost "[dim]No configuration file was created. You can run this wizard again anytime.[/]"
+            Write-Host
+            return $null
+        }
+
+        # Generate and save configuration file as JSON in temporary folder
+        $configJson = $configData | ConvertTo-Json -Depth 3
+        $configJson | Out-File -FilePath $OutputPath -Encoding UTF8
+
+        # Enhanced success message
+        Write-Host
+        Write-SpectreRule "🎉 Configuration Created Successfully!" -Color ([Spectre.Console.Color]::Green)
+        Write-SpectreHost "[bold green]✅ Configuration file created successfully![/]"
+        Write-SpectreHost "[green]📁 Location:[/] [white]$OutputPath[/]"
+        Write-SpectreHost "[dim]This temporary file will be moved to your report directory when the assessment starts.[/]"
+        Write-Host
+        Write-SpectreHost "[bold cyan1]🚀 Ready to start your Zero Trust Assessment![/]"
+        Write-Host
+
+        return Get-Item $OutputPath
+    }
+    catch {
+        Write-Host
+        Write-SpectreRule "❌ Error Occurred" -Color ([Spectre.Console.Color]::Red)
+        Write-SpectreHost "[red]An error occurred: $($_.Exception.Message)[/]"
+        Write-Host
+        throw
+    }
+}

--- a/src/powershell/public/Invoke-ZtAssessment.ps1
+++ b/src/powershell/public/Invoke-ZtAssessment.ps1
@@ -3,23 +3,76 @@
 Runs the Zero Trust Assessment against the signed in tenant and generates a report of the findings.
 
 .DESCRIPTION
-This function is only a sample Advanced function that returns the Data given via parameter Data.
+This function runs the Zero Trust Assessment against the signed in tenant and generates a report of the findings.
+The assessment can be configured using command-line parameters, a configuration file, or through interactive prompts.
+
+.PARAMETER Path
+The path to the folder to output the report to. If not specified, the report will be output to the current directory.
+
+.PARAMETER Days
+Optional. Number of days (between 1 and 30) to query sign-in logs. Defaults to 30 days.
+
+.PARAMETER MaximumSignInLogQueryTime
+Optional. The maximum time (in minutes) the assessment should spend on querying sign-in logs. Defaults to 60 minutes. Set to 0 for no limit.
+
+.PARAMETER Resume
+If specified, the previously exported data will be used to generate the report.
+
+.PARAMETER ShowLog
+If specified, the script will output a high level summary of log messages. Useful for debugging. Use -Verbose and -Debug for more detailed logs.
+
+.PARAMETER ExportLog
+If specified, writes the log to a file.
+
+.PARAMETER DisableTelemetry
+If specified, disables the collection of telemetry. The only telemetry collected is the tenant id. Defaults to false.
+
+.PARAMETER Tests
+The IDs of the specific test(s) to run. If not specified, all tests will be run.
+
+.PARAMETER ConfigurationFile
+Path to a configuration file. Parameters specified on the command line will override values from the configuration file.
+
+.PARAMETER Interactive
+If specified, prompts the user interactively for input values using a text-based user interface.
 
 .EXAMPLE
-Invoke-ZeroTrustAssessment
+Invoke-ZtAssessment
 
-Run the Zero Trust Assessment against the signed in tenant and generates a report of the findings.
+Run the Zero Trust Assessment against the signed in tenant and generates a report of the findings using default settings.
+
+.EXAMPLE
+Invoke-ZtAssessment -Path "C:\Reports\ZT" -Days 7 -ShowLog
+
+Run the Zero Trust Assessment with a custom output path, querying 7 days of logs, and showing detailed logging.
+
+.EXAMPLE
+Invoke-ZtAssessment -ConfigurationFile "C:\Config\zt-config.json"
+
+Run the Zero Trust Assessment using settings from a configuration file.
+
+.EXAMPLE
+Invoke-ZtAssessment -ConfigurationFile "C:\Config\zt-config.json" -Days 14 -ShowLog
+
+Run the Zero Trust Assessment using settings from a configuration file, but override the Days parameter to 14 and enable ShowLog.
+
+.EXAMPLE
+Invoke-ZtAssessment -Interactive
+
+Run the Zero Trust Assessment with an interactive text-based user interface to configure all parameters.
 #>
 
 function Invoke-ZtAssessment {
     [Alias('Invoke-ZeroTrustAssessment')]
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'Default')]
     param (
         # The path to the folder folder to output the report to. If not specified, the report will be output to the current directory.
+        [Parameter(ParameterSetName = 'Default')]
         [string]
         $Path = "./ZeroTrustReport",
 
         # Optional. Number of days (between 1 and 30) to query sign-in logs. Defaults to last two days.
+        [Parameter(ParameterSetName = 'Default')]
         [ValidateScript({
                 $_ -ge 1 -and $_ -le 30
             },
@@ -28,37 +81,155 @@ function Invoke-ZtAssessment {
         $Days = 30,
 
         # Optional. The maximum time (in minutes) the assessment should spend on querying sign-in logs. Defaults to collecting sign logs for 60 minutes. Set to 0 for no limit.
+        [Parameter(ParameterSetName = 'Default')]
         [int]
         $MaximumSignInLogQueryTime = 60,
 
         # If specified, the previously exported data will be used to generate the report.
+        [Parameter(ParameterSetName = 'Default')]
         [switch]
         $Resume,
 
         # If specified, the script will output a high level summary of log messages. Useful for debugging. Use -Verbose and -Debug for more detailed logs.
+        [Parameter(ParameterSetName = 'Default')]
         [switch]
         $ShowLog,
 
         # If specified, writes the log to a file.
+        [Parameter(ParameterSetName = 'Default')]
         [switch]
         $ExportLog,
 
         # If specified, disables the collection of telemetry. The only telemetry collected is the tenant id. Defaults to true.
+        [Parameter(ParameterSetName = 'Default')]
         [switch]
         $DisableTelemetry = $false,
 
         # The IDs of the specific test(s) to run. If not specified, all tests will be run.
+        [Parameter(ParameterSetName = 'Default')]
         [string[]]
-        $Tests
+        $Tests,
+
+        # Path to a configuration file. Parameters specified on the command line will override values from the configuration file.
+        [Parameter(ParameterSetName = 'Default')]
+        [ValidateScript({
+                if (Test-Path $_ -PathType Leaf) {
+                    $true
+                } else {
+                    throw "Configuration file '$_' does not exist."
+                }
+            })]
+        [string]
+        $ConfigurationFile,
+
+        # If specified, prompts the user interactively for input values.
+        [Parameter(ParameterSetName = 'Interactive', Mandatory)]
+        [switch]
+        $Interactive
     )
 
     $banner = @"
-╔═══════════════════════════════════════════════════════════════╗
-║ Microsoft Zero Trust Assessment v2                            ║
-╚═══════════════════════════════════════════════════════════════╝
+╔═════════════════════════════════════════════════════════════════════════════╗
+║                    🛡️  Microsoft Zero Trust Assessment v2                   ║
+║                                                                             ║
+║    Comprehensive security posture evaluation for your Microsoft 365 tenant  ║
+╚═════════════════════════════════════════════════════════════════════════════╝
 "@
 
-Write-Host $banner -ForegroundColor Cyan
+    Write-Host $banner -ForegroundColor Cyan
+    Write-Host
+    Write-Host "🚀 " -NoNewline -ForegroundColor Green
+    Write-Host "Starting Zero Trust Assessment..." -ForegroundColor White
+    Write-Host
+
+    # Handle configuration file parameter
+    if ($ConfigurationFile) {
+        try {
+            Write-Host "📄 " -NoNewline -ForegroundColor Blue
+            Write-Host "Loading configuration from file: " -NoNewline -ForegroundColor White
+            Write-Host $ConfigurationFile -ForegroundColor Cyan
+            $configContent = Get-Content -Path $ConfigurationFile -Raw | ConvertFrom-Json
+
+            # Define parameters that can be configured
+            $configurableParameters = @('Path', 'Days', 'MaximumSignInLogQueryTime', 'ShowLog', 'ExportLog', 'DisableTelemetry', 'Resume', 'Tests')
+
+            # Apply configuration values only if parameters weren't explicitly provided
+            foreach ($paramName in $configurableParameters) {
+                # Skip if parameter was explicitly provided or config doesn't contain the property
+                if ($PSBoundParameters.ContainsKey($paramName) -or
+                    $configContent.PSObject.Properties.Name -notcontains $paramName) {
+                    continue
+                }
+
+                # Special handling for Tests array to ensure it has items
+                if ($paramName -eq 'Tests') {
+                    if ($configContent.$paramName -and $configContent.$paramName.Count -gt 0) {
+                        Set-Variable -Name $paramName -Value $configContent.$paramName
+                    }
+                } else {
+                    Set-Variable -Name $paramName -Value $configContent.$paramName
+                }
+            }
+
+            Write-Host "✅ " -NoNewline -ForegroundColor Green
+            Write-Host "Configuration loaded successfully. Command line parameters will override configuration file values." -ForegroundColor White
+            Write-Host
+        }
+        catch {
+            Write-Host "❌ " -NoNewline -ForegroundColor Red
+            Write-Host "Failed to load configuration from file '$ConfigurationFile': $($_.Exception.Message)" -ForegroundColor Red
+            return
+        }
+    }
+
+    # Handle interactive parameter collection
+    if ($Interactive) {
+        try {
+            Write-Host "🎮 " -NoNewline -ForegroundColor Magenta
+            Write-Host "Starting interactive parameter collection..." -ForegroundColor White
+            Write-Host
+            $tempConfigFile = New-ZtInteractiveConfig
+
+            # Check if user cancelled the configuration creation
+            if ($null -eq $tempConfigFile -or -not $tempConfigFile) {
+                Write-Host "⏹️ " -NoNewline -ForegroundColor Yellow
+                Write-Host "Interactive configuration cancelled by user. Exiting." -ForegroundColor Yellow
+                return
+            }
+
+            # Verify the file exists before trying to read it (only if tempConfigFile is not null)
+            if (-not (Test-Path $tempConfigFile.FullName -ErrorAction SilentlyContinue)) {
+                Write-Host "❌ " -NoNewline -ForegroundColor Red
+                Write-Host "Configuration file was not created. Exiting." -ForegroundColor Red
+                return
+            }
+
+            # Import the configuration data from JSON
+            $config = Get-Content -Path $tempConfigFile.FullName | ConvertFrom-Json
+
+            # Assign interactive parameter values to variables
+            $Path = $config.Path
+            $Days = $config.Days
+            $MaximumSignInLogQueryTime = $config.MaximumSignInLogQueryTime
+            $ShowLog = $config.ShowLog
+            $ExportLog = $config.ExportLog
+            $DisableTelemetry = $config.DisableTelemetry
+            $Resume = $config.Resume
+
+            if ($config.PSObject.Properties.Name -contains 'Tests' -and $config.Tests.Count -gt 0) {
+                $Tests = $config.Tests
+            }
+
+            Write-Host "✅ " -NoNewline -ForegroundColor Green
+            Write-Host "Interactive configuration complete. Starting assessment..." -ForegroundColor Green
+            Write-Host
+        }
+        catch {
+            Write-Host "❌ " -NoNewline -ForegroundColor Red
+            Write-Host "Failed to collect interactive parameters: $($_.Exception.Message)" -ForegroundColor Red
+            return
+        }
+    }
 
     #$ExportLog = $true # Always create support package during public preview TODO: Remove this line after public preview
 
@@ -74,14 +245,28 @@ Write-Host $banner -ForegroundColor Cyan
     # Stop if folder has items inside it
     if (!$Resume.IsPresent -and (Test-Path $Path)) {
         if ((Get-ChildItem $Path).Count -gt 0) {
-            # Prompt user if it's okay to delete the folder and get confirmation
-            Write-Host "`nFolder $Path is not empty. Do you want to delete the contents and continue (y/n)?" -ForegroundColor Yellow -NoNewline
-            $deleteFolder = Read-Host
+            Write-Host
+            Write-Host "⚠️ " -NoNewline -ForegroundColor Yellow
+            Write-Host "Output folder is not empty" -ForegroundColor Yellow
+            Write-Host "📁 Path: " -NoNewline -ForegroundColor White
+            Write-Host $Path -ForegroundColor Cyan
+            Write-Host
+            Write-Host "To generate a new report, the existing contents need to be removed." -ForegroundColor White
+            Write-Host "Do you want to delete the contents and continue? " -NoNewline -ForegroundColor White
+            Write-Host "[y/n]" -NoNewline -ForegroundColor Yellow
+            $deleteFolder = Read-Host " "
+
             if ($deleteFolder -eq "y") {
+                Write-Host "🗑️ " -NoNewline -ForegroundColor Red
+                Write-Host "Cleaning up existing files..." -ForegroundColor White
                 Remove-Item -Path $Path -Recurse -Force -ErrorAction Stop | Out-Null
+                Write-Host "✅ " -NoNewline -ForegroundColor Green
+                Write-Host "Folder cleaned successfully" -ForegroundColor Green
+                Write-Host
             }
             else {
-                Write-Error "Folder $Path is not empty. Please provide a path to an empty folder."
+                Write-Host "❌ " -NoNewline -ForegroundColor Red
+                Write-Host "Assessment cancelled. Please provide a path to an empty folder or use -Resume to continue from existing data." -ForegroundColor Red
                 return
             }
         }
@@ -109,6 +294,18 @@ Write-Host $banner -ForegroundColor Cyan
 
     Write-PSFMessage 'Creating report folder $Path'
     New-Item -ItemType Directory -Path $Path -Force -ErrorAction Stop | Out-Null
+
+    # Move the interactive configuration file to the report directory if it exists
+    if ($Interactive -and $tempConfigFile) {
+        try {
+            $finalConfigPath = Join-Path $Path "zt-interactive-config.json"
+            Move-Item -Path $tempConfigFile.FullName -Destination $finalConfigPath -Force
+            Write-Host "Configuration file moved to report directory: $finalConfigPath" -ForegroundColor Green
+        }
+        catch {
+            Write-PSFMessage -Level Warning -Message "Failed to move configuration file to report directory: $_"
+        }
+    }
 
     # Collect data
     Export-TenantData -ExportPath $exportPath -Days $Days -MaximumSignInLogQueryTime $MaximumSignInLogQueryTime


### PR DESCRIPTION
I've added `-Interactive` and `-ConfigurationFile` parameters to `Invoke-ZtAssessment`.
All interactivity is in new `New-ZtInteractiveConfig.ps1` file.
TUI is based on `PwshSpectreConsole` module. For now, that module is not added to .psd1 file, but you can install it manually. You can also test how `Invoke-ZtAssessment` works before you install the module.

@merill, you wanted to add support for excluding emergency accounts from tests. Could you provide a spec for that?