### PR TITLE
Fixing database closure

### DIFF
--- a/src/powershell/private/db/engine/Connect-Database.ps1
+++ b/src/powershell/private/db/engine/Connect-Database.ps1
@@ -64,8 +64,7 @@
     if ($PassThru -or $Transient) {$database}
 	if (-not $Transient) {
 		if ($script:_DatabaseConnection) {
-			$script:_DatabaseConnection.Close()
-			$script:_DatabaseConnection.Dispose()
+			Disconnect-Database
 		}
 		$script:_DatabaseConnection = $database
 	}

--- a/src/powershell/private/db/engine/Disconnect-Database.ps1
+++ b/src/powershell/private/db/engine/Disconnect-Database.ps1
@@ -29,11 +29,15 @@
 	)
 
 	if ($Database) {
-		$Database.Close()
+		if ($Database.State -eq 'Open') {
+			$Database.Close()
+		}
 		$Database.Dispose()
 	}
 	elseif ($script:_DatabaseConnection) {
-		$script:_DatabaseConnection.Close()
+		if ($script:_DatabaseConnection.State -eq 'Open') {
+			$script:_DatabaseConnection.Close()
+		}
 		$script:_DatabaseConnection.Dispose()
 		$script:_DatabaseConnection = $null
 	}


### PR DESCRIPTION
Checks whether the database has already been closed, before calling the `.Close()` method, preventing issues when the database object has already been closed outside of the commands