### PR TITLE
24576 - Modify device configuration policies URI

### DIFF
--- a/src/powershell/tests/Test-Assessment.24576.ps1
+++ b/src/powershell/tests/Test-Assessment.24576.ps1
@@ -40,7 +40,7 @@ function Test-PolicyAssignment {
     Write-ZtProgress -Activity $activity -Status "Getting policy"
 
     # Retrieve all device configuration policies
-    $deviceConfigurationPolicies_Uri = "deviceManagement/deviceConfigurations?`$select=id,displayName,assignments,deviceStatusOverview&`$expand=deviceStatusOverview,assignments"
+    $deviceConfigurationPolicies_Uri = "deviceManagement/deviceConfigurations?`$select=id,displayName,assignments&`$expand=assignments"
     $deviceConfigurationPolicies = Invoke-ZtGraphRequest -RelativeUri $deviceConfigurationPolicies_Uri -ApiVersion beta
 
     # Filter device configuration policies for Windows Health Monitoring


### PR DESCRIPTION
After talking to Ravi, we've decided that `deviceStatusOverview` could be removed.