### PR TITLE
test 24574 - Windows ASR block or warn obfusc win32apicalls

### DIFF
--- a/src/powershell/tests/Test-Assessment.24574.md
+++ b/src/powershell/tests/Test-Assessment.24574.md
@@ -1,0 +1,10 @@
+If Attack Surface Reduction (ASR) policies are not properly configured and assigned to Windows devices in Intune, threat actors can exploit unprotected endpoints to execute obfuscated scripts and invoke Win32 API calls from Office macros. These techniques are commonly used in phishing campaigns and malware delivery, allowing attackers to bypass traditional antivirus defenses and gain initial access. Once inside, they can escalate privileges, establish persistence, and move laterally across the network. Without ASR enforcement, devices remain vulnerable to script-based attacks and macro abuse, undermining the effectiveness of Microsoft Defender and exposing sensitive data to exfiltration. This gap in endpoint protection increases the likelihood of successful compromise and reduces the organization’s ability to contain and respond to threats.
+
+**Remediation action**
+
+- [Configure ASR rules in Intune:](https://learn.microsoft.com/en-us/intune/intune-service/protect/endpoint-security-asr-policy)
+
+- [Learn more about ASR rules:](https://learn.microsoft.com/en-us/microsoft-365/security/defender-endpoint/attack-surface-reduction-rules)
+
+<!--- Results --->
+%TestResult%

--- a/src/powershell/tests/Test-Assessment.24574.ps1
+++ b/src/powershell/tests/Test-Assessment.24574.ps1
@@ -1,0 +1,180 @@
+<#
+.SYNOPSIS
+    Deploy Attack Surface Reduction Policies (ASR) policies for Windows devices
+#>
+
+function Test-Assessment-24574 {
+    [ZtTest(
+    	Category = 'Device management',
+    	ImplementationCost = 'High',
+    	Pillar = 'Devices',
+    	RiskLevel = 'High',
+    	SfiPillar = 'Protect engineering systems',
+    	TenantType = ('Workforce'),
+    	TestId = 24574,
+    	Title = 'Deploy Attack Surface Reduction Policies (ASR) policies for Windows devices',
+    	UserImpact = 'Low'
+    )]
+    [CmdletBinding()]
+    param()
+
+    Write-PSFMessage '🟦 Start' -Tag Test -Level VeryVerbose
+
+    #region Data Collection
+    $activity = "Checking that an Attack Surface Reduction (ASR) policy for Windows devices is created and assigned"
+    Write-ZtProgress -Activity $activity
+
+    # Query 1: Retrieve all configuration policies for Windows 10 that use MDM and Microsoft Defender (Sense), and filter for ASR rules
+    $win10MdmSensePolicies = Invoke-ZtGraphRequest -RelativeUri "deviceManagement/configurationPolicies?`$filter=(platforms has 'windows10') and (technologies has 'mdm' and technologies has 'microsoftSense')&`$expand=settings,assignments" -ApiVersion beta
+    $win10MdmSenseASRPolicies = $win10MdmSensePolicies.Where{
+        $_.settings.settingInstance.settingDefinitionId -contains 'device_vendor_msft_policy_config_defender_attacksurfacereductionrules'
+    }
+
+    $requiredSettings = @{
+        'device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockexecutionofpotentiallyobfuscatedscripts' = @{
+            ExpectedValues = @('device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockexecutionofpotentiallyobfuscatedscripts_warn')
+            ContainerPath  = 'settings.settingInstance.groupSettingCollectionValue.children'
+            SettingIdPath  = 'settingDefinitionId'
+            ValuePath      = 'ChoiceSettingValue.Value'
+            Description    = 'block execution of potentially obfuscated scripts = Warn'
+        }
+    }
+
+    $warnObfuscated = Get-FilteredPoliciesBySetting -Policies $win10MdmSenseASRPolicies -RequiredSettings $requiredSettings
+
+    $requiredSettings = @{
+        'device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockexecutionofpotentiallyobfuscatedscripts' = @{
+            ExpectedValues = @('device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockexecutionofpotentiallyobfuscatedscripts_block')
+            ContainerPath  = 'settings.settingInstance.groupSettingCollectionValue.children'
+            SettingIdPath  = 'settingDefinitionId'
+            ValuePath      = 'ChoiceSettingValue.Value'
+            Description    = 'block execution of potentially obfuscated scripts = Block'
+        }
+    }
+
+    $blockObfuscated = Get-FilteredPoliciesBySetting -Policies $win10MdmSenseASRPolicies -RequiredSettings $requiredSettings
+
+    $requiredSettings = @{
+        'device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockwin32apicallsfromofficemacros' = @{
+            ExpectedValues = @('device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockwin32apicallsfromofficemacros_block')
+            ContainerPath  = 'settings.settingInstance.groupSettingCollectionValue.children'
+            SettingIdPath  = 'settingDefinitionId'
+            ValuePath      = 'ChoiceSettingValue.Value'
+            Description    = 'block execution of potentially obfuscated scripts = Block'
+        }
+    }
+
+    $blockWin32CallsFromMacros = Get-FilteredPoliciesBySetting -Policies $win10MdmSenseASRPolicies -RequiredSettings $requiredSettings
+
+    $requiredSettings = @{
+        'device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockwin32apicallsfromofficemacros' = @{
+            ExpectedValues = @('device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockwin32apicallsfromofficemacros_warn')
+            ContainerPath  = 'settings.settingInstance.groupSettingCollectionValue.children'
+            SettingIdPath  = 'settingDefinitionId'
+            ValuePath      = 'ChoiceSettingValue.Value'
+            Description    = 'block execution of potentially obfuscated scripts = Warn'
+        }
+    }
+
+    $warnWin32CallsFromMacros = Get-FilteredPoliciesBySetting -Policies $win10MdmSenseASRPolicies -RequiredSettings $requiredSettings
+    #endregion Data Collection
+
+    #region Assessment Logic
+    # The two required ASR settings must be configured to at least 'Warn' and assigned to a group, but can be done in separate policies
+    Write-ZtProgress -Activity $activity -Status "Checking ASR Policies"
+    $passed = ($warnObfuscated.Where{$_.assignments.count -gt 0}.count -gt 0 -or $blockObfuscated.Where{$_.assignments.count -gt 0}.count -gt 0) -and
+            ($blockWin32CallsFromMacros.Where{$_.assignments.count -gt 0}.count -gt 0 -or $warnWin32CallsFromMacros.Where{$_.assignments.count -gt 0}.count -gt 0)
+
+    if ($passed) {
+        $testResultMarkdown = "ASR policies are configured and assigned to Windows devices in Intune.`n`n%TestResult%"
+    }
+    else {
+        $testResultMarkdown = "No ASR policies are configured or assigned, leaving endpoints vulnerable.`n`n%TestResult%"
+    }
+    #endregion Assessment Logic
+
+    #region Report Generation
+    # Build the detailed sections of the markdown
+
+    # Define variables to insert into the format string
+    $reportTitle = 'Attack Surface Reduction Policies for Windows devices'
+    $formatTemplate = ''
+    # Generate markdown table rows for each policy
+    if ($win10MdmSenseASRPolicies.Count -gt 0) {
+        # Create a here-string with format placeholders {0}, {1}, etc.
+        $tableRows = ""
+        $formatTemplate = @'
+## {0}
+
+| Policy Name | Status | Assignment | Execution of Potentially obfuscated scripts | Win32 API calls from Office macros |
+| :---------- | :----- | :--------- | :------------------------------------------ | :--------------------------------- |
+{1}
+
+'@
+
+        foreach ($policy in $win10MdmSenseASRPolicies) {
+            $portalLink = 'https://intune.microsoft.com/#view/Microsoft_Intune_Workflows/SecurityManagementMenu/~/accountprotection'
+            $status = if ($policy.assignments.count -gt 0) {
+                '🟢 Assigned'
+            }
+            else {
+                '❌ Not Assigned'
+            }
+
+            $executionOfPotentiallyObfuscatedScripts = if ($policy.settings.settingInstance.groupSettingCollectionValue.children.settingDefinitionId -contains 'device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockexecutionofpotentiallyobfuscatedscripts') {
+                if ($policy.settings.settingInstance.groupSettingCollectionValue.children.choiceSettingValue.value -contains 'device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockexecutionofpotentiallyobfuscatedscripts_block') {
+                    '🟢 Block'
+                }
+                elseif ($policy.settings.settingInstance.groupSettingCollectionValue.children.choiceSettingValue.value -contains 'device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockexecutionofpotentiallyobfuscatedscripts_warn') {
+                    '⚠️ Warn'
+                }
+                else {
+                    '❌ Allowed'
+                }
+            }
+            else {
+                '❌ Not Configured'
+            }
+
+            $win32ApiCallsFromMacros = if ($policy.settings.settingInstance.groupSettingCollectionValue.children.settingDefinitionId -contains 'device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockwin32apicallsfromofficemacros') {
+                if ($policy.settings.settingInstance.groupSettingCollectionValue.children.choiceSettingValue.value -contains 'device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockwin32apicallsfromofficemacros_block') {
+                    '🟢 Block'
+                }
+                elseif ($policy.settings.settingInstance.groupSettingCollectionValue.children.choiceSettingValue.value -contains 'device_vendor_msft_policy_config_defender_attacksurfacereductionrules_blockwin32apicallsfromofficemacros_warn') {
+                    '⚠️ Warn'
+                }
+                else {
+                    '❌ Allowed'
+                }
+            }
+            else {
+                '❌ Not Configured'
+            }
+
+            $policyName = Get-SafeMarkdown -Text $policy.name
+            $assignmentTarget = "None"
+
+            if ($policy.assignments -and $policy.assignments.Count -gt 0) {
+                $assignmentTarget = Get-PolicyAssignmentTarget -Assignments $policy.assignments
+            }
+
+            $tableRows += "| [$policyName]($portalLink) | $status | $assignmentTarget | $executionOfPotentiallyObfuscatedScripts | $win32ApiCallsFromMacros |`n"
+        }
+    }
+
+    # Format the template by replacing placeholders with values
+    $mdInfo = $formatTemplate -f $reportTitle, $tableRows
+
+    # Replace the placeholder in the test result markdown with the generated details
+    $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $mdInfo
+    #endregion Report Generation
+
+    $params = @{
+        TestId             = '24574'
+        Title              = "Deploy Attack Surface Reduction Policies (ASR) policies for Windows devices"
+        Status             = $passed
+        Result             = $testResultMarkdown
+    }
+
+    Add-ZtTestResultDetail @params
+}


### PR DESCRIPTION
As we had discussed with Ravi:
- The policies can be blocking or Warning (for now)
- The two settings can be set in different policies (can be reviewed in v2)
- The policies must be assigned
- Feedback will tell us how it should improved for a v2

result:
<img width="863" height="942" alt="image" src="https://github.com/user-attachments/assets/67f89a95-75fe-4f8d-b79b-7115f39db6a5" />
