### PR TITLE
Feature 21770 -  Moved functions to shared cmdlets for reuse

### DIFF
--- a/src/powershell/private/tests-shared/Add-AppPermissions.ps1
+++ b/src/powershell/private/tests-shared/Add-AppPermissions.ps1
@@ -1,0 +1,21 @@
+function Add-AppPermissions {
+    [CmdletBinding()]
+    param (
+        $item,
+        $Database
+    )
+    $sql = @"
+    select distinct spAppRole.*
+    from (select sp.id, sp.displayName, unnest(sp.appRoleAssignments).AppRoleId as appRoleId
+        from main.ServicePrincipal sp) sp
+        left join
+            (select unnest(main.ServicePrincipal.appRoles).id as id, unnest(main.ServicePrincipal.appRoles)."value" permissionName
+            from main.ServicePrincipal) spAppRole
+            on sp.appRoleId = spAppRole.id
+    where permissionName is not null and sp.id == '{0}'
+"@
+    $sql = $sql -f $item.id
+    $results = Invoke-DatabaseQuery -Database $Database -Sql $sql
+    $item.AppPermissions = $results.permissionName
+    return $item
+}

--- a/src/powershell/private/tests-shared/Add-DelegatePermissions.ps1
+++ b/src/powershell/private/tests-shared/Add-DelegatePermissions.ps1
@@ -1,0 +1,21 @@
+function Add-DelegatePermissions {
+    [CmdletBinding()]
+    param (
+        $item,
+        $Database
+    )
+    $sql = @"
+    select sp.id, sp.oauth2PermissionGrants.scope as permissionName,
+    from main.ServicePrincipal sp
+    where sp.oauth2PermissionGrants.scope is not null
+    and sp.id == '{0}'
+"@
+    $sql = $sql -f $item.id
+    $results = Invoke-DatabaseQuery -Database $Database -Sql $sql
+    $item.DelegatePermissions = @()
+    if ($results.permissionName) {
+        $perms = $results.permissionName.trim() -replace '"', ''
+        $item.DelegatePermissions = $perms -split ' ' | Where-Object { ![string]::IsNullOrEmpty($_) }
+    }
+    return $item
+}

--- a/src/powershell/private/tests-shared/Get-AppList.ps1
+++ b/src/powershell/private/tests-shared/Get-AppList.ps1
@@ -1,0 +1,17 @@
+function Get-AppList {
+    [CmdletBinding()]
+    param (
+        $Apps,
+        $Icon
+    )
+    $mdInfo = ""
+    foreach ($item in $apps) {
+        $tenant = $item.publisherName
+        $portalLink = "https://entra.microsoft.com/#view/Microsoft_AAD_IAM/ManagedAppMenuBlade/~/Overview/objectId/$($item.id)/appId/$($item.appId)"
+        $risk = $item.Risk
+        $delPerm = $item.DelegatePermissions -join ", "
+        $appPerm = $item.AppPermissions -join ", "
+        $mdInfo += "| $($Icon) | [$(Get-SafeMarkdown($item.displayName))]($portalLink) | $risk | $delPerm | $appPerm | $(Get-SafeMarkdown($tenant)) | $(Get-FormattedDate($item.lastSignInDateTime)) | `n"
+    }
+    return $mdInfo
+}

--- a/src/powershell/private/tests-shared/GraphRisk.ps1
+++ b/src/powershell/private/tests-shared/GraphRisk.ps1
@@ -1,0 +1,33 @@
+function Add-GraphRisk {
+    [CmdletBinding()]
+    param (
+        $item
+    )
+    $item.Risk = Get-GraphRisk -delegatePermissions $item.DelegatePermissions -applicationPermissions $item.AppPermissions
+    $item.IsRisky = $item.Risk -eq "High"
+    return $item
+}
+
+function Get-GraphRisk {
+    [CmdletBinding()]
+    param (
+        $delegatePermissions,
+        $applicationPermissions
+    )
+    $finalRisk = "Unranked"
+    foreach($permission in $applicationPermissions){
+        $risk = Get-GraphPermissionRisk -Permission $permission -PermissionType "Application"
+        switch($risk){
+            "High" { return $risk }
+            "Medium" { $finalRisk = $risk }
+        }
+    }
+    foreach($permission in $delegatePermissions){
+        $risk = Get-GraphPermissionRisk -Permission $permission -PermissionType "Delegated"
+        switch($risk){
+            "High" { return $risk }
+            "Medium" { $finalRisk = $risk }
+        }
+    }
+    return $finalRisk
+}


### PR DESCRIPTION
Moved permission extraction and risk calculation functions into shared cmdlet files for reuse across multiple tests. Updated test 21770 to use these shared cmdlets (Add-GraphRisk, Get-GraphRisk, Add-DelegatePermissions, Add-AppPermissions) instead of local function definitions. This PR only covers the refactor and updates for 21770.