### PR TITLE
Fix command syntax in readme.md

### DIFF
--- a/src/powershell/doc/readme.md
+++ b/src/powershell/doc/readme.md
@@ -150,7 +150,7 @@ store the assessment report. For example, the following command produces the rep
 `C:/MyAssessment01/ZeroTrustAssessmentReport.html`
 
 ```powershell
-Invoke-ZtAssessment --Path C:/MyAssessment01
+Invoke-ZtAssessment -Path C:/MyAssessment01
 ```
 
 ## Review assessment results


### PR DESCRIPTION
removed double -- on line 153 command fails when -- used instead of -path