### PR TITLE
Update Test-Assessment.21812.ps1

### DIFF
--- a/src/powershell/tests/Test-Assessment.21812.ps1
+++ b/src/powershell/tests/Test-Assessment.21812.ps1
@@ -36,7 +36,7 @@ function Test-Assessment-21812 {
     $passed = $false
     $testResultMarkdown = ""
 
-if ($globalAdmins.Count -gt 8) {
+if ($globalAdmins.Count -gt 5) {
         $passed = $false
     }
     else {


### PR DESCRIPTION
According to the documentation, it should be 5 and not 8.
[https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/best-practices?wt.mc_id=zerotrustrecommendations_automation_content_cnl_csasci#5-limit-the-number-of-global-administrators-to-less-than-5](url)