### PR TITLE
Refactor Test-Assessment-21788 to handle skipped auth to Azure

### DIFF
--- a/src/powershell/tests/Test-Assessment.21788.ps1
+++ b/src/powershell/tests/Test-Assessment.21788.ps1
@@ -58,30 +58,30 @@ function Test-Assessment-21788 {
             }
         }
 
-    $results = ($roleAssignments.Content | ConvertFrom-Json).value.properties | Where-Object {
-        $_.roleDefinitionId -eq '/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9'
-    }
+        $results = ($roleAssignments.Content | ConvertFrom-Json).value.properties | Where-Object {
+            $_.roleDefinitionId -eq '/providers/Microsoft.Authorization/roleDefinitions/18d7d88d-d35e-4fb5-a5c3-7773c20a72d9'
+        }
 
-    $testResultMarkdown = ""
+        $testResultMarkdown = ""
 
-    if ($results -and $results.Count -eq 0) {
-        $passed = $true
-        $testResultMarkdown += "No standing access to Azure Root Management Group."
-    }
-    else {
-        $passed = $false
-        $testResultMarkdown += "Standing access to Root Management group was found.`n`n%TestResult%"
-    }
+        if ($results -and $results.Count -eq 0) {
+            $passed = $true
+            $testResultMarkdown += "No standing access to Azure Root Management Group."
+        }
+        else {
+            $passed = $false
+            $testResultMarkdown += "Standing access to Root Management group was found.`n`n%TestResult%"
+        }
 
-    # Build the detailed sections of the markdown
+        # Build the detailed sections of the markdown
 
-    # Define variables to insert into the format string
-    $reportTitle = "Entra ID objects with standing access to Root Management group"
-    $tableRows = ""
+        # Define variables to insert into the format string
+        $reportTitle = "Entra ID objects with standing access to Root Management group"
+        $tableRows = ""
 
-    if ($results -and $results.Count -gt 0) {
-        # Create a here-string with format placeholders {0}, {1}, etc.
-        $formatTemplate = @'
+        if ($results -and $results.Count -gt 0) {
+            # Create a here-string with format placeholders {0}, {1}, etc.
+            $formatTemplate = @'
 
 ## {0}
 
@@ -92,39 +92,40 @@ function Test-Assessment-21788 {
 
 '@
 
-        foreach ($result in $results) {
-            try {
-                $object = Invoke-ZtGraphRequest -RelativeUri "directoryObjects/$($result.principalId)" -ApiVersion 'v1.0'
-                if ($result.principalType -eq 'User') {
-                    $displayName = $object.userPrincipalName
+            foreach ($result in $results) {
+                try {
+                    $object = Invoke-ZtGraphRequest -RelativeUri "directoryObjects/$($result.principalId)" -ApiVersion 'v1.0'
+                    if ($result.principalType -eq 'User') {
+                        $displayName = $object.userPrincipalName
+                    }
+                    else {
+                        $displayName = $object.displayName
+                    }
+
                 }
-                else {
-                    $displayName = $object.displayName
+                catch {
+                    Write-PSFMessage "Failed to get object for principalId $($result.principalId): $_"
+                    $displayName = $result.principalId
                 }
 
-            }
-            catch {
-                Write-PSFMessage "Failed to get object for principalId $($result.principalId): $_"
-                $displayName = $result.principalId
-            }
-
-            $tableRows += @"
+                $tableRows += @"
 | $displayName | $($object.id) | $($result.principalType) |`n
 "@
+            }
+
+            # Format the template by replacing placeholders with values
+            $mdInfo = $formatTemplate -f $reportTitle, $tableRows
         }
 
-        # Format the template by replacing placeholders with values
-        $mdInfo = $formatTemplate -f $reportTitle, $tableRows
-    }
+        # Replace the placeholder with the detailed information
+        $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $mdInfo
 
-    # Replace the placeholder with the detailed information
-    $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $mdInfo
-
-    $params = @{
-        TestId             = '21788'
-        Title              = "Global Administrators don't have standing elevated access to all Azure subscriptions in the tenant"
-        Status             = $passed
-        Result             = $testResultMarkdown
+        $params = @{
+            TestId = '21788'
+            Title  = "Global Administrators don't have standing elevated access to all Azure subscriptions in the tenant"
+            Status = $passed
+            Result = $testResultMarkdown
+        }
+        Add-ZtTestResultDetail @params
     }
-    Add-ZtTestResultDetail @params
 }


### PR DESCRIPTION
Refactor `Test-Assessment-21788` function to handle skipped authentication to Azure.
Clean up parameters for `Add-ZtTestResultDetail`.
Fix the logic for `$passed` status to correctly handle situation when `$result` is $null.