### PR TITLE
Updated Connect-ztAssessment module to include service principal login

### DIFF
--- a/src/powershell/public/Connect-ZtAssessment.ps1
+++ b/src/powershell/public/Connect-ZtAssessment.ps1
@@ -80,9 +80,12 @@ function Connect-ZtAssessment
             $Password = Read-Host -Prompt "Enter Password for Service Principal" -MaskInput
             $SecuredPassword = ConvertTo-SecureString -String $Password -AsPlainText -Force
             $ClientSecretCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $AppId, $SecuredPassword
-            $params['ClientSecretCredential'] = $ClientSecretCredential
-            $params['ClientId'] = $AppId
-            $params.Remove('Scopes')
+            $params = @{
+                TenantId               = $TenantId
+                ClientSecretCredential = $ClientSecretCredential
+                NoWelcome              = $true
+            }
+
         }
         Write-PSFMessage "Connecting to Microsoft Graph with params: $($params | Out-String)" -Level Verbose
         Connect-MgGraph @params


### PR DESCRIPTION
Allow both the MgGraph and azure connection to use clientid / service principal. This is so assessments can be done in an automated fashion without interactive logins. 