### PR TITLE
Test 22128 - Only include guests in output table

### DIFF
--- a/src/powershell/tests/Test-Assessment.22128.ps1
+++ b/src/powershell/tests/Test-Assessment.22128.ps1
@@ -78,6 +78,10 @@ function Test-Assessment-22128 {
 '@
 
     foreach ($role in $resultsPrivilegedRoles) {
+        if ($role.userType -ne 'Guest') {
+            continue
+        }
+        
         $portalLink = 'https://entra.microsoft.com/#view/Microsoft_AAD_UsersAndTenants/UserProfileMenuBlade/~/overview/userId/{0}/hidePreviewBanner~/true' -f $role.principalId
         $tableRows += @"
 | $($role.roleDisplayName) | [$(Get-SafeMarkdown($role.principalDisplayName))]($portalLink) | $($role.userPrincipalName) | $($role.userType) | $($role.assignmentType) |`n


### PR DESCRIPTION
When the output table for this test is generated, it includes **all** privileged-role assignments. Making this change to only show the role assignments for guests, which are the assignments that are causing the test to fail.