### PR TITLE
Improve progress reporting in Wait-ZtTest function

### DIFF
--- a/src/powershell/private/tests/Wait-ZtTest.ps1
+++ b/src/powershell/private/tests/Wait-ZtTest.ps1
@@ -27,6 +27,7 @@
 	}
 	process {
 		Write-Progress -Id $progressID -Activity "Processing $($totalCount) Tests" -PercentComplete 0
+		$lastTest = "Starting..."
 		while (-not $Workflow.Queues["Results"].Closed) {
 			Start-Sleep -Milliseconds 500
 
@@ -40,7 +41,8 @@
 			if ($percent -lt 0) { $percent = 0 }
 			if ($percent -gt 100) { $percent = 100 }
 
-			$lastTest = (Get-PSFMessage -Tag start | Select-Object -Last 1).StringValue[0]
+			$lastMessage = Get-PSFMessage -Tag start | Select-Object -Last 1
+			if ($lastMessage -and $lastMessage.StringValue) { $lastTest = $lastMessage.StringValue[0] }
 			$status = "Completed: $($Workflow.Queues["Results"].Count) / $totalCount | Last Test: $lastTest"
 
 			Write-Progress -Id $progressID -Activity "Processing $($totalCount) Tests" -Status $status -PercentComplete $percent


### PR DESCRIPTION
Add a fix for this error that I've experienced a number of times.
```
Wait-ZtTest: C:\gh\zerotrustassessment\src\powershell\private\tests\Invoke-ZtTests.ps1:59:3
Line |                                                                                                                  
  59 |          Wait-ZtTest -Workflow $workflow                                                                         
     |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                                                                         
     | Cannot index into a null array.
``` 