### PR TITLE
Bugfix/issue-584

### DIFF
--- a/src/powershell/private/tenantinfo/devices/Add-ZtDeviceWindowsEnrollment.ps1
+++ b/src/powershell/private/tenantinfo/devices/Add-ZtDeviceWindowsEnrollment.ps1
@@ -14,14 +14,18 @@ function Add-ZtDeviceWindowsEnrollment
     $activity = "Getting Windows enrollment summary"
     Write-ZtProgress -Activity $activity -Status "Processing"
 
-    $policies = Invoke-ZtGraphRequest -RelativeUri 'Policies/MobileDeviceManagementPolicies' -QueryParameters @{ '$expand' = 'includedGroups' } -ApiVersion 'beta'
-
-    # Sort policies by AppliesTo (descending) then by DisplayName (ascending)
-    $sortedPolicies = $policies | Sort-Object @{Expression='appliesTo';Descending=$true}, @{Expression='displayName';Ascending=$true}
-
-    # Create the table data structure
+    # Initialize table data structure
     $tableData = @()
-    foreach ($policy in $sortedPolicies) {
+
+    try {
+        # The Policies/MobileDeviceManagementPolicies endpoint requires delegated permissions
+        # and is not supported with application-only authentication (service principal)
+        $policies = Invoke-ZtGraphRequest -RelativeUri 'Policies/MobileDeviceManagementPolicies' -QueryParameters @{ '$expand' = 'includedGroups' } -ApiVersion 'beta'
+
+        # Sort policies by AppliesTo (descending) then by DisplayName (ascending)
+        $sortedPolicies = $policies | Sort-Object @{Expression='appliesTo';Descending=$true}, @{Expression='displayName';Ascending=$true}
+
+        foreach ($policy in $sortedPolicies) {
         # Determine group names display
         $groupNames = if ($policy.appliesTo -eq 'selected' -and $policy.includedGroups) {
             ($policy.includedGroups | ForEach-Object { $_.displayName }) -join ', '
@@ -37,12 +41,30 @@ function Add-ZtDeviceWindowsEnrollment
             default { $policy.appliesTo }
         }
 
-        $tableData += [PSCustomObject]@{
-            Type = 'MDM'
-            PolicyName = $policy.displayName
-            AppliesTo = $appliesToName
-            Groups = $groupNames
+            $tableData += [PSCustomObject]@{
+                Type = 'MDM'
+                PolicyName = $policy.displayName
+                AppliesTo = $appliesToName
+                Groups = $groupNames
+            }
         }
+    }
+    catch {
+        # Check if this is an authorization error
+        $authType = (Get-MgContext).AuthType
+        if ($_.Exception.Message -match "(Unauthorized|403|401)" -or $_.Exception.Message -match "Insufficient privileges") {
+            if ($authType -eq 'AppOnly') {
+                Write-PSFMessage -Level Warning -Message "Windows enrollment policies could not be retrieved. The 'Policies/MobileDeviceManagementPolicies' endpoint requires delegated permissions and is not supported with service principal authentication. This section will be skipped."
+            } else {
+                Write-PSFMessage -Level Warning -Message "Windows enrollment policies could not be retrieved due to insufficient permissions. Ensure the current user has the required permissions to access Mobile Device Management policies. This section will be skipped."
+            }
+        } else {
+            # For other types of errors, log the full error but continue execution
+            Write-PSFMessage -Level Warning -Message "Failed to retrieve Windows enrollment policies: $($_.Exception.Message). This section will be skipped."
+        }
+
+        # Continue with empty data to prevent the entire assessment from failing
+        Write-PSFMessage -Level Debug -Message "Continuing assessment without Windows enrollment policy data"
     }
 
     Add-ZtTenantInfo -Name "ConfigWindowsEnrollment" -Value $tableData

--- a/src/powershell/tests/Test-Assessment.24546.ps1
+++ b/src/powershell/tests/Test-Assessment.24546.ps1
@@ -30,7 +30,30 @@ function Test-Assessment-24546 {
 
     # Retrieve Mobile Device Management Policies
     $MDMPoliciesUri = "policies/mobileDeviceManagementPolicies"
-    $MDMPolicies = Invoke-ZtGraphRequest -RelativeUri $MDMPoliciesUri -ApiVersion beta
+
+    try {
+        # The policies/mobileDeviceManagementPolicies endpoint requires delegated permissions
+        # and is not supported with application-only authentication (service principal)
+        $MDMPolicies = Invoke-ZtGraphRequest -RelativeUri $MDMPoliciesUri -ApiVersion beta
+    }
+    catch {
+        # Check if this is an authorization error
+        $authType = (Get-MgContext).AuthType
+        if ($_.Exception.Message -match "(Unauthorized|403|401)" -or $_.Exception.Message -match "Insufficient privileges") {
+            if ($authType -eq 'AppOnly') {
+                Write-PSFMessage -Level Warning -Message "Mobile Device Management policies could not be retrieved. The 'policies/mobileDeviceManagementPolicies' endpoint requires delegated permissions and is not supported with service principal authentication. This test will be marked as failed due to insufficient permissions."
+            } else {
+                Write-PSFMessage -Level Warning -Message "Mobile Device Management policies could not be retrieved due to insufficient permissions. Ensure the current user has the required permissions to access Mobile Device Management policies. This test will be marked as failed."
+            }
+        } else {
+            # For other types of errors, log the full error
+            Write-PSFMessage -Level Warning -Message "Failed to retrieve Mobile Device Management policies: $($_.Exception.Message). This test will be marked as failed."
+        }
+
+        # Set empty policies array to continue with test logic
+        $MDMPolicies = @()
+        Write-PSFMessage -Level Debug -Message "Continuing test evaluation with empty policy data"
+    }
 
     # Convert to array if it's a single value to ensure consistent handling
     if ($null -eq $MDMPolicies) {


### PR DESCRIPTION
Added try-catch exception handling to handle authorization failures when querying the `policies/mobileDeviceManagementPolicies` endpoint. This endpoint requires delegated permissions and fails when running with service principal (AppOnly) authentication.

Before fixing : 
<img width="1775" height="753" alt="Screenshot 2025-11-27 104711" src="https://github.com/user-attachments/assets/d3495616-5fcf-4646-8660-e50c96e36838" />

After fixes: 
<img width="1903" height="630" alt="Screenshot 2025-11-27 104903" src="https://github.com/user-attachments/assets/8564d8fb-ca18-4d6f-bb02-2e468469f007" />

#584
