### PR TITLE
Bugfix/issue-593: Inactive guest identities are disabled or removed from the tenant not checking correctly

### DIFF
--- a/src/powershell/tests/Test-Assessment.21858.ps1
+++ b/src/powershell/tests/Test-Assessment.21858.ps1
@@ -49,15 +49,14 @@ function Test-Assessment-21858 {
         foreach ($guest in $enabledGuestUsers) {
             $daysSinceLastActivity = $null
             $activitySource = ''
-
             # Check if daysSinceLastSignIn has a value (not null)
             # Fixed issue #593: Check the actual column returned by SQL query, not signInActivity object
-            if ($null -ne $guest.daysSinceLastSignIn -and $guest.daysSinceLastSignIn -is [System.IComparable]) {
+            if ($guest.daysSinceLastSignIn -ne [System.DBNull]::Value) {
                 # Use lastSuccessfulSignInDateTime
                 $daysSinceLastActivity = $guest.daysSinceLastSignIn
                 $activitySource = 'last successful sign-in'
             }
-            elseif ($null -ne $guest.daysSinceCreated -and $guest.daysSinceCreated -is [System.IComparable]) {
+            elseif ($guest.daysSinceCreated -ne [System.DBNull]::Value) {
                 # signInActivity is null, calculate days since creation using createdDateTime
                 $daysSinceLastActivity = $guest.daysSinceCreated
                 $activitySource = 'creation date (no sign-in activity)'

--- a/src/powershell/tests/Test-Assessment.21858.ps1
+++ b/src/powershell/tests/Test-Assessment.21858.ps1
@@ -93,6 +93,7 @@ function Test-Assessment-21858 {
 
     # Define variables to insert into the format string
     $reportTitle = 'Inactive guest accounts in the tenant'
+    $tableRows = ''
 
     if ($inactiveGuests.Count -gt 0) {
         # Create a here-string with format placeholders {0}, {1}, etc.
@@ -107,15 +108,15 @@ function Test-Assessment-21858 {
 
 '@
 
-        $tableRowsArray = foreach ($inactiveGuest in $inactiveGuests) {
+        foreach ($inactiveGuest in $inactiveGuests) {
             $portalLink = 'https://entra.microsoft.com/#view/Microsoft_AAD_UsersAndTenants/UserProfileMenuBlade/~/overview/userId/{0}/hidePreviewBanner~/true' -f $inactiveGuest.guest.id
             $displayName = Get-SafeMarkdown $inactiveGuest.guest.displayName
             $userPrincipalName = $inactiveGuest.guest.userPrincipalName
             $lastSignInDateTime = $inactiveGuest.LastSignInDate
             $createdDateTime = $inactiveGuest.CreatedDate
-            "| [$displayName]($portalLink) | $userPrincipalName | $lastSignInDateTime | $createdDateTime |"
+            $tableRows += "| [$displayName]($portalLink) | $userPrincipalName | $lastSignInDateTime | $createdDateTime |`n"
         }
-        $tableRows = $tableRowsArray -join "`n"
+
         # Format the template by replacing placeholders with values
         $mdInfo = $formatTemplate -f $reportTitle, $tableRows
     }

--- a/src/powershell/tests/Test-Assessment.21858.ps1
+++ b/src/powershell/tests/Test-Assessment.21858.ps1
@@ -52,14 +52,14 @@ function Test-Assessment-21858 {
 
             # Check if daysSinceLastSignIn has a value (not null)
             # Fixed issue #593: Check the actual column returned by SQL query, not signInActivity object
-            if ($null -ne $guest.daysSinceLastSignIn -and $guest.daysSinceLastSignIn -ne '' -and $guest.daysSinceLastSignIn -is [System.IComparable]) {
+            if ($null -ne $guest.daysSinceLastSignIn -and $guest.daysSinceLastSignIn -is [System.IComparable]) {
                 # Use lastSuccessfulSignInDateTime
-                $daysSinceLastActivity = [int]$guest.daysSinceLastSignIn
+                $daysSinceLastActivity = $guest.daysSinceLastSignIn
                 $activitySource = 'last successful sign-in'
             }
-            elseif ($null -ne $guest.daysSinceCreated -and $guest.daysSinceCreated -ne '' -and $guest.daysSinceCreated -is [System.IComparable]) {
+            elseif ($null -ne $guest.daysSinceCreated -and $guest.daysSinceCreated -is [System.IComparable]) {
                 # signInActivity is null, calculate days since creation using createdDateTime
-                $daysSinceLastActivity = [int]$guest.daysSinceCreated
+                $daysSinceLastActivity = $guest.daysSinceCreated
                 $activitySource = 'creation date (no sign-in activity)'
             }
 
@@ -77,11 +77,11 @@ function Test-Assessment-21858 {
         # Mark as FAIL if inactive guests exist
         if ($inactiveGuests.Count -gt 0) {
             $passed = $false
-            $testResultMarkdown = "Found $($inactiveGuests.Count) inactive guest user(s) with no sign-in activity in the last $inactivityThresholdDays days:`n`n%TestResult%"
+            $testResultMarkdown = "❌ Found $($inactiveGuests.Count) inactive guest user(s) with no sign-in activity in the last $inactivityThresholdDays days:`n`n%TestResult%"
         }
         else {
             $passed = $true
-            $testResultMarkdown = "All enabled guest user(s) have been active within the last $inactivityThresholdDays days."
+            $testResultMarkdown = "✅ All enabled guest user(s) have been active within the last $inactivityThresholdDays days."
         }
     }
     else {
@@ -124,6 +124,7 @@ function Test-Assessment-21858 {
     $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $mdInfo
 
     $params = @{
+        TestId             = '21858'
         Status             = $passed
         Result             = $testResultMarkdown
     }

--- a/src/powershell/tests/Test-Assessment.21858.ps1
+++ b/src/powershell/tests/Test-Assessment.21858.ps1
@@ -50,9 +50,10 @@ function Test-Assessment-21858 {
             $daysSinceLastActivity = $null
             $activitySource = ""
 
-            # Check if signInActivity property exists
-            if ([string]::IsNullOrEmpty($guest.signInActivity) -eq $false) {
-                # Evaluate lastSuccessfulSignInDateTime if lastSignInDateTime is not available
+            # Check if daysSinceLastSignIn has a value (not null)
+            # Fixed issue #593: Check the actual column returned by SQL query, not signInActivity object
+            if ($null -ne $guest.daysSinceLastSignIn) {
+                # Use lastSuccessfulSignInDateTime
                 $daysSinceLastActivity = $guest.daysSinceLastSignIn
                 $activitySource = "last successful sign-in"
             }

--- a/src/powershell/tests/Test-Assessment.21858.ps1
+++ b/src/powershell/tests/Test-Assessment.21858.ps1
@@ -49,15 +49,16 @@ function Test-Assessment-21858 {
         foreach ($guest in $enabledGuestUsers) {
             $daysSinceLastActivity = $null
             $activitySource = ''
-            # Check if daysSinceLastSignIn has a value (not null)
-            # Fixed issue #593: Check the actual column returned by SQL query, not signInActivity object
-            if ($guest.daysSinceLastSignIn -ne [System.DBNull]::Value) {
+            # Fixed issue #593: Check the actual column returned by SQL query, not signInActivity object.
+            # Ensure the value is a valid number (handles NULL, DBNull, and empty strings).
+            # DuckDB date_diff returns BIGINT, so we check for [long] (and [int] for safety).
+            if ($guest.daysSinceLastSignIn -is [int] -or $guest.daysSinceLastSignIn -is [long]) {
                 # Use lastSuccessfulSignInDateTime
                 $daysSinceLastActivity = $guest.daysSinceLastSignIn
                 $activitySource = 'last successful sign-in'
             }
-            elseif ($guest.daysSinceCreated -ne [System.DBNull]::Value) {
-                # signInActivity is null, calculate days since creation using createdDateTime
+            elseif ($guest.daysSinceCreated -is [int] -or $guest.daysSinceCreated -is [long]) {
+                # signInActivity is null, use days since creation
                 $daysSinceLastActivity = $guest.daysSinceCreated
                 $activitySource = 'creation date (no sign-in activity)'
             }

--- a/src/powershell/tests/Test-Assessment.21858.ps1
+++ b/src/powershell/tests/Test-Assessment.21858.ps1
@@ -32,18 +32,10 @@ function Test-Assessment-21858 {
 
     $sql = @"
     SELECT id, displayName, userPrincipalName, accountEnabled, externalUserState,
-    CASE
-        WHEN signInActivity.lastSuccessfulSignInDateTime IS NOT NULL
-        THEN date_diff('day', signInActivity.lastSuccessfulSignInDateTime, today())
-        ELSE NULL
-    END as daysSinceLastSignIn,
+    date_diff('day', signInActivity.lastSuccessfulSignInDateTime, today()) as daysSinceLastSignIn,
     date_diff('day', createdDateTime, today()) daysSinceCreated,
     strftime(createdDateTime, '%Y-%m-%d') fmtCreatedDateTime,
-    CASE
-        WHEN signInActivity.lastSuccessfulSignInDateTime IS NOT NULL
-        THEN strftime(signInActivity.lastSuccessfulSignInDateTime, '%Y-%m-%d')
-        ELSE NULL
-    END as fmtLastSignInDateTime
+    strftime(signInActivity.lastSuccessfulSignInDateTime, '%Y-%m-%d') as fmtLastSignInDateTime
     FROM User
     WHERE UserType = 'Guest' AND AccountEnabled = true
 "@

--- a/src/powershell/tests/Test-Assessment.21858.ps1
+++ b/src/powershell/tests/Test-Assessment.21858.ps1
@@ -27,8 +27,8 @@ function Test-Assessment-21858 {
         return
     }
 
-    $activity = "Checking Inactive guest identities are removed from the tenant"
-    Write-ZtProgress -Activity $activity -Status "Querying enabled guest users"
+    $activity = 'Checking Inactive guest identities are removed from the tenant'
+    Write-ZtProgress -Activity $activity -Status 'Querying enabled guest users'
 
     $sql = @"
     SELECT id, displayName, userPrincipalName, accountEnabled, externalUserState,
@@ -48,19 +48,19 @@ function Test-Assessment-21858 {
         foreach ($guest in $enabledGuestUsers) {
             $inactivityThresholdDays = 90
             $daysSinceLastActivity = $null
-            $activitySource = ""
+            $activitySource = ''
 
             # Check if daysSinceLastSignIn has a value (not null)
             # Fixed issue #593: Check the actual column returned by SQL query, not signInActivity object
             if ($null -ne $guest.daysSinceLastSignIn) {
                 # Use lastSuccessfulSignInDateTime
                 $daysSinceLastActivity = $guest.daysSinceLastSignIn
-                $activitySource = "last successful sign-in"
+                $activitySource = 'last successful sign-in'
             }
             else {
                 # signInActivity is null, calculate days since creation using createdDateTime
                 $daysSinceLastActivity = $guest.daysSinceCreated
-                $activitySource = "creation date (no sign-in activity)"
+                $activitySource = 'creation date (no sign-in activity)'
             }
 
             # if guests exist with no sign-in activity in the last $inactivityThresholdDays days add them to the list
@@ -77,23 +77,23 @@ function Test-Assessment-21858 {
         # Mark as FAIL if inactive guests exist
         if ($inactiveGuests.Count -gt 0) {
             $passed = $false
-            $testResultMarkdown = "❌ **FAIL**: Found $($inactiveGuests.Count) inactive guest user(s) with no sign-in activity in the last $inactivityThresholdDays days:`n`n%TestResult%"
+            $testResultMarkdown = "Found $($inactiveGuests.Count) inactive guest user(s) with no sign-in activity in the last $inactivityThresholdDays days:`n`n%TestResult%"
         }
         else {
             $passed = $true
-            $testResultMarkdown = "✅ **PASS**: All enabled guest user(s) have been active within the last $inactivityThresholdDays days."
+            $testResultMarkdown = "All enabled guest user(s) have been active within the last $inactivityThresholdDays days."
         }
     }
     else {
         $passed = $true   # Test passes if no enabled guests
-        $testResultMarkdown = "✅ No guest users found in the tenant."
+        $testResultMarkdown = "No guest users found in the tenant."
     }
 
     # Build the detailed sections of the markdown
 
     # Define variables to insert into the format string
-    $reportTitle = "Inactive guest accounts in the tenant"
-    $tableRows = ""
+    $reportTitle = 'Inactive guest accounts in the tenant'
+    $tableRows = ''
 
     if ($inactiveGuests.Count -gt 0) {
         # Create a here-string with format placeholders {0}, {1}, etc.
@@ -102,7 +102,7 @@ function Test-Assessment-21858 {
 ## {0}
 
 
-| Display Name | User Principal Name | Last Sign-in Date | Created Date |
+| Display name | User principal name | Last sign-in date | Created date |
 | :----------- | :------------------ | :---------------- | :----------- |
 {1}
 
@@ -127,13 +127,6 @@ function Test-Assessment-21858 {
     $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $mdInfo
 
     $params = @{
-        TestId             = '21858'
-        Title              = 'Inactive guest identities are removed from the tenant'
-        UserImpact         = 'Low'
-        Risk               = 'Medium'
-        ImplementationCost = 'Medium'
-        AppliesTo          = 'Identity'
-        Tag                = 'Identity'
         Status             = $passed
         Result             = $testResultMarkdown
     }


### PR DESCRIPTION
Issue: Test 21858 was using **signInActivity** object instead of **daysSinceLastSignIn** (successful) causing incorrect results in the report.

Solution:  Updated code to use daysSinceLastSignIn property which is calculated by difference of lastSuccessfulSignInDateTime and today().

Other changes:
- Moved inactivityThresholdDays outside loop and scope of inactiveGuest to function level
- Updated strings to use single quotes where variable expansion is not
- Standardized casing in the report columns

Fixes #593