### PR TITLE
Bugfix/issue-651: Report "App registrations must not have dangling or abandoned domain redirect URIs" doesn't show the icon

### DIFF
--- a/src/powershell/private/tests-shared/Get-ZtAppWithUnsafeRedirectUris.ps1
+++ b/src/powershell/private/tests-shared/Get-ZtAppWithUnsafeRedirectUris.ps1
@@ -26,7 +26,7 @@ function Get-ZtAppWithUnsafeRedirectUris {
 			$Type
 		)
 		$mdInfo = ""
-		$mdInfo += "| | Name | Unsafe Redirect URIs |"
+		$mdInfo += "| | Name | Unsafe redirect URIs |"
 		# Only add the app owner tenant column for ServicePrincipal
 		if ($Type -eq 'ServicePrincipal') {
 			$mdInfo += "App owner tenant |`n"


### PR DESCRIPTION
fixes #651 where test 21888 was not displaying relevant icon in front of the unsafe redirect URIs


<img width="856" height="872" alt="image" src="https://github.com/user-attachments/assets/10d9afdf-557b-402d-bfc3-43bd68cfe83f" />
