### PR TITLE
Added check to exclude Terms of Use CA policies - Test 21824

### DIFF
--- a/src/powershell/tests/Test-Assessment.21824.ps1
+++ b/src/powershell/tests/Test-Assessment.21824.ps1
@@ -30,7 +30,8 @@ function Test-Assessment-21824 {
 
     $filteredCAPolicies = $allCAPolicies | Where-Object {
         ($null -ne $_.conditions.users.includeGuestsOrExternalUsers) -and
-        ($_.state -in @('enabled', 'enabledForReportingButNotEnforced'))
+        ($_.state -in @('enabled', 'enabledForReportingButNotEnforced')) -and
+        ($null -eq $_.grantControls.termsOfUse -or $_.grantControls.termsOfUse.Count -eq 0) # Exclude Terms of Use policies
     }
 
     # Local filtering - validate sign-in frequency for guest sessions


### PR DESCRIPTION
Issue: Current test 21824 doesn't filter Terms of Use CA policies, which have their own sign in frequency.

Resolution: Exclude Terms of Use CA policies from the test.

fixes #592 