### PR TITLE
Fixing throttling & dev experience update

### DIFF
--- a/src/powershell/ZeroTrustAssessment.format.ps1xml
+++ b/src/powershell/ZeroTrustAssessment.format.ps1xml
@@ -1,6 +1,41 @@
 ﻿<?xml version="1.0" encoding="utf-16"?>
 <Configuration>
     <ViewDefinitions>
+        <!-- ZeroTrustAssessment.ExportStatistics -->
+        <View>
+            <Name>ZeroTrustAssessment.ExportStatistics</Name>
+            <ViewSelectedBy>
+                <TypeName>ZeroTrustAssessment.ExportStatistics</TypeName>
+            </ViewSelectedBy>
+            <TableControl>
+                <AutoSize/>
+                <TableHeaders>
+                    <TableColumnHeader/>
+                    <TableColumnHeader/>
+                    <TableColumnHeader/>
+                    <TableColumnHeader/>
+                </TableHeaders>
+                <TableRowEntries>
+                    <TableRowEntry>
+                        <TableColumnItems>
+                            <TableColumnItem>
+                                <PropertyName>Name</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>Duration</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>Success</PropertyName>
+                            </TableColumnItem>
+                            <TableColumnItem>
+                                <PropertyName>Error</PropertyName>
+                            </TableColumnItem>
+                        </TableColumnItems>
+                    </TableRowEntry>
+                </TableRowEntries>
+            </TableControl>
+        </View>
+
         <!-- ZeroTrustAssessment.TestStatistics -->
         <View>
             <Name>ZeroTrustAssessment.TestStatistics</Name>
@@ -59,49 +94,6 @@
                     <TableColumnHeader>
                         <Label>Cost</Label>
                     </TableColumnHeader>
-                    <TableColumnHeader/>
-                    <TableColumnHeader/>
-                </TableHeaders>
-                <TableRowEntries>
-                    <TableRowEntry>
-                        <TableColumnItems>
-                            <TableColumnItem>
-                                <PropertyName>TestId</PropertyName>
-                            </TableColumnItem>
-                            <TableColumnItem>
-                                <PropertyName>Pillar</PropertyName>
-                            </TableColumnItem>
-                            <TableColumnItem>
-                                <PropertyName>RiskLevel</PropertyName>
-                            </TableColumnItem>
-                            <TableColumnItem>
-                                <PropertyName>ImplementationCost</PropertyName>
-                            </TableColumnItem>
-                            <TableColumnItem>
-                                <PropertyName>UserImpact</PropertyName>
-                            </TableColumnItem>
-                            <TableColumnItem>
-                                <PropertyName>Title</PropertyName>
-                            </TableColumnItem>
-                        </TableColumnItems>
-                    </TableRowEntry>
-                </TableRowEntries>
-            </TableControl>
-        </View>
-
-        <!-- ZeroTrustAssessment.Test -->
-        <View>
-            <Name>ZeroTrustAssessment.Test</Name>
-            <ViewSelectedBy>
-                <TypeName>ZeroTrustAssessment.Test</TypeName>
-            </ViewSelectedBy>
-            <TableControl>
-                <AutoSize/>
-                <TableHeaders>
-                    <TableColumnHeader/>
-                    <TableColumnHeader/>
-                    <TableColumnHeader/>
-                    <TableColumnHeader/>
                     <TableColumnHeader/>
                     <TableColumnHeader/>
                 </TableHeaders>

--- a/src/powershell/ZeroTrustAssessment.psd1
+++ b/src/powershell/ZeroTrustAssessment.psd1
@@ -72,8 +72,16 @@ FormatsToProcess = 'ZeroTrustAssessment.format.ps1xml'
 # NestedModules = @()
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-FunctionsToExport = 'Connect-ZtAssessment', 'Disconnect-ZtAssessment', 'Get-ZtExportStatistics', 'Get-ZtGraphScope',
-               'Get-ZtTest', 'Invoke-ZtAssessment', 'Invoke-ZtGraphRequest', 'Get-ZtTestStatistics'
+FunctionsToExport = @(
+	'Connect-ZtAssessment'
+	'Disconnect-ZtAssessment'
+	'Get-ZtExportStatistics'
+	'Get-ZtGraphScope'
+	'Get-ZtTest'
+	'Get-ZtTestStatistics'
+	'Invoke-ZtAssessment'
+	'Invoke-ZtGraphRequest'
+)
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @()

--- a/src/powershell/public/Invoke-ZtAssessment.ps1
+++ b/src/powershell/public/Invoke-ZtAssessment.ps1
@@ -387,7 +387,7 @@ function Invoke-ZtAssessment {
 
 	# Collect data
 	Write-PSFMessage -Message "Stage 1: Exporting Tenant Data" -Tag stage
-	Export-ZtTenantData -ExportPath $exportPath -Days $Days -MaximumSignInLogQueryTime $MaximumSignInLogQueryTime -Pillar $Pillar
+	Export-ZtTenantData -ExportPath $exportPath -Days $Days -MaximumSignInLogQueryTime $MaximumSignInLogQueryTime -Pillar $Pillar -ThrottleLimit $ExportThrottleLimit
 	$database = Export-Database -ExportPath $exportPath -Pillar $Pillar
 
 	# Run the tests

--- a/src/powershell/scripts/extend-supportpackage.ps1
+++ b/src/powershell/scripts/extend-supportpackage.ps1
@@ -1,2 +1,3 @@
-﻿# Ensure that any support packages also include the statistics of the last test run
+﻿# Ensure that any support packages also include the statistics of the last export and test run
+Register-PSFSupportDataProvider -Name 'ZTA_ExportStatistics' -ScriptBlock { Get-ZtExportStatistics }
 Register-PSFSupportDataProvider -Name 'ZTA_TestStatistics' -ScriptBlock { Get-ZtTestStatistics }


### PR DESCRIPTION
This PR wraps up some loose ends from the two main PRs that parallelized tests & exports.
Changes:

> Updated FunctionsToExport for improved Git handling

Essentially, with the old style - comma-separated in the same line - two PRs that add a new public function would always conflict.
Changing it to one line per function exported prevents that and works just as well.

> Fixed Throttling parameter in Invoke-ZtAssessment

Previously, the `-ExportThrottleLimit` parameter was unused. This was mostly due to me pushing the parameters in one go during PR one, originally planning to do both parallelization refactors in one go.
This proved impractical, but I did not want to deal with more conflicts than needed, so I left that for later, when both PRs were merged. Now.

> Added Format XML for Export Statistics

The output of `Get-ZtExportStatistics` now looks better, without losing any of the information contained.
Also removed a redundant XML setting that had no effect anyways.

> Added Export Statistics to the Support Package

When generating a Support Package for sending in debug data for the ZeroTrustAssessment, both test & export statistics are now included:

```powershell
Expand-Archive -Path .\powershell_support_pack_2025_12_11-14_30_35.zip -DestinationPath .
$data = Import-PSFClixml -Path .\powershell_support_pack_2025_12_11-14_30_35.cliDat
$data._ZTA_TestStatistics
$data._ZTA_ExportStatistics
```