### PR TITLE
System - Adding certificate authentication to Connect-ZtAssessment

### DIFF
--- a/src/powershell/private/core/Test-ZtContext.ps1
+++ b/src/powershell/private/core/Test-ZtContext.ps1
@@ -1,64 +1,73 @@
-<#
-.SYNOPSIS
-    Validates the MgContext to ensure a valid connection to Microsoft Graph including the required permissions.
-#>
-
 function Test-ZtContext {
-    [CmdletBinding()]
-    [OutputType([bool])]
-    param ()
+	<#
+	.SYNOPSIS
+		Validates the MgContext to ensure a valid connection to Microsoft Graph including the required permissions.
 
-    $validContext = $true
-    if (!(Get-MgContext)) {
-        $message = "Not connected to Microsoft Graph. Please use 'Connect-ZTAssessment'. For more information, use 'Get-Help Connect-ZTAssessment'."
-        $validContext = $false
-    } else {
-        $requiredScopes = Get-ZtGraphScope
-        $currentScopes = Get-MgContext | Select-Object -ExpandProperty Scopes
-        $missingScopes = $requiredScopes | Where-Object { $currentScopes -notcontains $_ }
+	.DESCRIPTION
+		Validates the MgContext to ensure a valid connection to Microsoft Graph including the required permissions.
 
-        if ($missingScopes) {
-            $message = "These Graph permissions are missing in the current connection => ($($missingScopes))."
-            $authType = (Get-MgContext).AuthType
-            if ($authType -eq  'Delegated') {
-                $message += " Please use 'Connect-ZTAssessment'. For more information, use 'Get-Help Connect-ZTAssessment'."
-            } else {
-                $clientId = (Get-MgContext).ClientId
-                $urlTemplate = "https://entra.microsoft.com/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/CallAnAPI/appId/$clientId/isMSAApp~/false"
-                $message += " Add the missing 'Application' permissions in the Microsoft Entra portal and grant consent. You will also need to Disconnect-Graph to refresh the permissions."
-                $message += " Click here to open the 'API Permissions' blade for this app: $urlTemplate"
-            }
-            $validContext = $false
-        }
+		What is needed?
+		- Connected: The MS Graph API requires authenticated access
+		- Scopes: Some scopes must be associated with the connection. Get-ZtGraphScope gives the list of what is needed.
+		- Roles: When in user mode, must be connected as "Global Reader" or "Global Administrator"
 
-        # Check if user has Global Reader or Global Administrator role activated (for delegated auth)
-        $authType = (Get-MgContext).AuthType
-        if ($authType -eq 'Delegated' -and $validContext) {
-            try {
-                $userId = (Get-MgContext).Account
+	.EXAMPLE
+		PS C:\> Test-ZtContext
 
-                # Get user's app role assignments to check for activated directory roles
-                $roleAssignments = Invoke-ZtGraphRequest -RelativeUri "me/transitiveMemberOf/microsoft.graph.directoryRole" -DisableCache
+		Validates the MgContext to ensure a valid connection to Microsoft Graph including the required permissions.
+	#>
+	[CmdletBinding()]
+	[OutputType([bool])]
+	param ()
 
-                # Check if user has either Global Reader or Global Administrator role assigned
-                $hasRequiredRole = $roleAssignments | Where-Object {
-                    $_.displayName -in @('Global Reader', 'Global Administrator')
-                }
+	$validContext = $true
+	$context = Get-MgContext
+	if (-not $context) {
+		throw "Not connected to Microsoft Graph. Please use 'Connect-ZTAssessment'. For more information, use 'Get-Help Connect-ZTAssessment'."
+		return $false
+	}
 
-                if (-not $hasRequiredRole) {
-                    $message = "The currently logged in user does not have the Global Reader or Global Administrator role activated. Please ensure you have one of these roles assigned and activated."
-                    # Also disconnect the context to avoid using cache
-                    Disconnect-MgGraph -ErrorAction SilentlyContinue | Out-Null
-                    $validContext = $false
-                }
-            } catch {
-                Write-Warning "Unable to verify user roles: $($_.Exception.Message)"
-            }
-        }
-    }
+	$requiredScopes = Get-ZtGraphScope
+	$currentScopes = $context.Scopes
+	$missingScopes = $requiredScopes | Where-Object { $currentScopes -notcontains $_ }
 
-    if (!$validContext) {
-        throw $message
-    }
-    return $validContext
+	if ($missingScopes) {
+		$message = "These Graph permissions are missing in the current connection => ($($missingScopes))."
+		if ($context.AuthType -eq 'Delegated') {
+			$message += " Please use 'Connect-ZTAssessment'. For more information, use 'Get-Help Connect-ZTAssessment'."
+		}
+		else {
+			$clientId = $context.ClientId
+			$urlTemplate = "https://entra.microsoft.com/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/CallAnAPI/appId/$clientId/isMSAApp~/false"
+			$message += " Add the missing 'Application' permissions in the Microsoft Entra portal and grant consent. You will also need to Disconnect-Graph to refresh the permissions."
+			$message += " Click here to open the 'API Permissions' blade for this app: $urlTemplate"
+		}
+		$validContext = $false
+	}
+
+	# Check if user has Global Reader or Global Administrator role activated (for delegated auth)
+	if ($context.AuthType -eq 'Delegated' -and $validContext) {
+		try {
+			# Get user's app role assignments to check for activated directory roles
+			$roleAssignments = Invoke-ZtGraphRequest -RelativeUri "me/transitiveMemberOf/microsoft.graph.directoryRole" -DisableCache
+
+			# Check if user has either Global Reader or Global Administrator role assigned
+			$hasRequiredRole = $roleAssignments | Where-Object displayName -in 'Global Reader', 'Global Administrator'
+
+			if (-not $hasRequiredRole) {
+				$message = "The currently logged in user does not have the Global Reader or Global Administrator role activated. Please ensure you have one of these roles assigned and activated."
+				# Also disconnect the context to avoid using cache
+				Disconnect-MgGraph -ErrorAction SilentlyContinue | Out-Null
+				$validContext = $false
+			}
+		}
+		catch {
+			Write-PSFMessage -Level Warning -Message "Unable to verify user roles" -ErrorRecord $_
+		}
+	}
+
+	if (-not $validContext) {
+		throw $message
+	}
+	return $validContext
 }

--- a/src/powershell/public/Connect-ZtAssessment.ps1
+++ b/src/powershell/public/Connect-ZtAssessment.ps1
@@ -1,121 +1,148 @@
-﻿<#
-.SYNOPSIS
-   Helper method to connect to Microsoft Graph using Connect-MgGraph with the required scopes.
+﻿function Connect-ZtAssessment {
+	<#
+	.SYNOPSIS
+		Helper method to connect to Microsoft Graph using Connect-MgGraph with the required scopes.
 
-.DESCRIPTION
-   Use this cmdlet to connect to Microsoft Graph using Connect-MgGraph.
+	.DESCRIPTION
+		Use this cmdlet to connect to Microsoft Graph using Connect-MgGraph.
 
-   This command is completely optional if you are already connected to Microsoft Graph and other services using Connect-MgGraph with the required scopes.
+		This command is completely optional if you are already connected to Microsoft Graph and other services using Connect-MgGraph with the required scopes.
 
-   ```
-   Connect-MgGraph -Scopes (Get-ZtGraphScope)
-   ```
+		```
+		Connect-MgGraph -Scopes (Get-ZtGraphScope)
+		```
 
-.EXAMPLE
-   Connect-ZtAssessment
+	.PARAMETER UseDeviceCode
+		If specified, the cmdlet will use the device code flow to authenticate to Graph and Azure.
+		This will open a browser window to prompt for authentication and is useful for non-interactive sessions and on Windows when SSO is not desired.
 
-   Connects to Microsoft Graph using Connect-MgGraph with the required scopes.
+	.PARAMETER Environment
+		The environment to connect to. Default is Global.
 
+	.PARAMETER UseTokenCache
+		Uses Graph Powershell's cached authentication tokens.
 
-.EXAMPLE
-   Connect-ZtAssessment -UseDeviceCode
+	.PARAMETER TenantId
+		The tenant ID to connect to. If not specified, the default tenant will be used.
 
-   Connects to Microsoft Graph and Azure using the device code flow. This will open a browser window to prompt for authentication.
+	.PARAMETER ClientId
+		If specified, connects using a custom application identity. See https://learn.microsoft.com/powershell/microsoftgraph/authentication-commands
 
-.EXAMPLE
-    Connect-ZtAssessment -SkipAzureConnection
+	.PARAMETER Certificate
+		The certificate to use for the connection(s).
+		Use this to authenticate in Application mode, rather than in Delegate (user) mode.
+		The application will need to be configured to have the matching Application scopes, compared to the Delegate scopes and may need to be added into roles.
+		If this certificate is also used for connecting to Azure, it must come from a certificate store on the local computer.
 
-    Connects to Microsoft Graph only, skipping the Azure connection. The tests that require Azure connectivity will be skipped.
-#>
+	.PARAMETER SkipAzureConnection
+		If specified, skips connecting to Azure and only connects to Microsoft Graph.
 
-function Connect-ZtAssessment
-{
-    [CmdletBinding()]
-    param(
-        # If specified, the cmdlet will use the device code flow to authenticate to Graph and Azure.
-        # This will open a browser window to prompt for authentication and is useful for non-interactive sessions and on Windows when SSO is not desired.
-        [switch] $UseDeviceCode,
+	.EXAMPLE
+		PS C:\> Connect-ZtAssessment
 
-        # The environment to connect to. Default is Global.
-        [ValidateSet('China', 'Germany', 'Global', 'USGov', 'USGovDoD')]
-        [string]$Environment = 'Global',
+		Connects to Microsoft Graph using Connect-MgGraph with the required scopes.
 
-        # Uses Graph Powershell's cached authentication tokens.
-        [switch]$UseTokenCache,
+	.EXAMPLE
+		PS C:\> Connect-ZtAssessment -UseDeviceCode
 
-        # The tenant ID to connect to. If not specified, the default tenant will be used.
-        [string]$TenantId,
+		Connects to Microsoft Graph and Azure using the device code flow. This will open a browser window to prompt for authentication.
 
-        # If specified, connects using a custom application identity. See https://learn.microsoft.com/powershell/microsoftgraph/authentication-commands
-        [string]$ClientId,
+	.EXAMPLE
+		PS C:\> Connect-ZtAssessment -SkipAzureConnection
 
-        # If specified, skips connecting to Azure and only connects to Microsoft Graph.
-        [switch]$SkipAzureConnection
-    )
+		Connects to Microsoft Graph only, skipping the Azure connection. The tests that require Azure connectivity will be skipped.
 
-    Write-Host "`nConnecting to Microsoft Graph" -ForegroundColor Yellow
-    Write-PSFMessage 'Connecting to Microsoft Graph'
-    try
-    {
-        $params = @{
-            Scopes       = (Get-ZtGraphScope)
-            NoWelcome    = $true
-            Environment  = $Environment
-        }
+	.EXAMPLE
+		PS C:\> Connect-ZtAssessment -ClientID $clientID -TenantID $tenantID -Certificate 'CN=ZeroTrustAssessment'
 
-        if ($UseDeviceCode) {
-            $params['UseDeviceCode'] = $true
-        }
+		Connects to Microsoft Graph and Azure using the specified client/application ID & tenant ID, using the latest, valid certificate available with the subject 'CN=ZeroTrustAssessment'.
+		This assumes the correct scopes and permissions are assigned to the application used.
+	#>
+	[CmdletBinding()]
+	param(
+		[switch]
+		$UseDeviceCode,
 
-        # If force use -ContextScope Process to force re-authentication
-        if (!$UseTokenCache) {
-            $params['ContextScope'] = 'Process'
-        }
+		[ValidateSet('China', 'Germany', 'Global', 'USGov', 'USGovDoD')]
+		[string]
+		$Environment = 'Global',
 
-        if ($TenantId) {
-            $params['TenantId'] = $TenantId
-        }
+		[switch]
+		$UseTokenCache,
 
-        if ($ClientId) {
-            $params['ClientId'] = $ClientId
-        }
+		[string]
+		$TenantId,
 
-        Write-PSFMessage "Connecting to Microsoft Graph with params: $($params | Out-String)" -Level Verbose
-        Connect-MgGraph @params
-        $contextTenantId = (Get-MgContext).TenantId
-    }
-    catch [Management.Automation.CommandNotFoundException]
-    {
-        Write-Host "`nThe Graph PowerShell module is not installed. Please install the module using the following command. For more information see https://learn.microsoft.com/powershell/microsoftgraph/installation" -ForegroundColor Red
-        Write-Host "`Install-Module Microsoft.Graph -Scope CurrentUser`n" -ForegroundColor Yellow
-    }
+		[string]
+		$ClientId,
 
-    if (!$SkipAzureConnection)
-    {
-        Write-Host "`nConnecting to Azure" -ForegroundColor Yellow
-        Write-PSFMessage 'Connecting to Azure'
-        try
-        {
-            $azEnvironment = 'AzureCloud'
-            if($Environment -eq 'China') {
-                $azEnvironment = Get-AzEnvironment -Name AzureChinaCloud
-            }
-            elseif($Environment -in 'USGov', 'USGovDoD') {
-                $azEnvironment = 'AzureUSGovernment'
-            }
+		[PSFramework.Parameter.CertificateParameter]
+		$Certificate,
 
-            $azParams = @{
-                UseDeviceAuthentication = $UseDeviceCode
-                Environment = $azEnvironment
-                Tenant = if ($TenantId) { $TenantId } else { $contextTenantId }
-            }
+		[switch]
+		$SkipAzureConnection
+	)
 
-            Connect-AzAccount @azParams
-        }
-        catch [Management.Automation.CommandNotFoundException]
-        {
-            Write-Host "`nThe Azure PowerShell module is not installed. Please install the module using the following command." -ForegroundColor Red
-            Write-Host "`Install-Module Az.Accounts -Scope CurrentUser`n" -ForegroundColor Yellow
-        }
-    }
+	Write-Host "`nConnecting to Microsoft Graph" -ForegroundColor Yellow
+	Write-PSFMessage 'Connecting to Microsoft Graph'
+
+	$params = $PSBoundParameters | ConvertTo-PSFHashtable -Include UseDeviceCode, Environment, TenantId, ClientId
+	$params.NoWelcome = $true
+	if ($Certificate) {
+		$params.Certificate = $Certificate
+	}
+	else {
+		$params.Scopes = Get-ZtGraphScope
+	}
+	if (-not $UseTokenCache) {
+		$params.ContextScope = 'Process'
+	}
+
+	try {
+		Write-PSFMessage "Connecting to Microsoft Graph with params: $($params | Out-String)" -Level Verbose
+		Connect-MgGraph @params -ErrorAction Stop
+		$contextTenantId = (Get-MgContext).TenantId
+	}
+	catch {
+		Stop-PSFFunction -Message "Failed to authenticate to Graph" -ErrorRecord $_ -EnableException $true -Cmdlet $PSCmdlet
+	}
+
+	try {
+		Test-ZtContext
+	}
+	catch {
+		Stop-PSFFunction -Message "Authenticated to Graph, but the requirements for the ZeroTrustAssessment are not met by the established session:`n$_" -ErrorRecord $_ -EnableException $true -Cmdlet $PSCmdlet
+	}
+
+	if ($SkipAzureConnection) {
+		return
+	}
+
+	Write-Host "`nConnecting to Azure" -ForegroundColor Yellow
+	Write-PSFMessage 'Connecting to Azure'
+
+	$azEnvironment = 'AzureCloud'
+	if ($Environment -eq 'China') {
+		$azEnvironment = Get-AzEnvironment -Name AzureChinaCloud
+	}
+	elseif ($Environment -in 'USGov', 'USGovDoD') {
+		$azEnvironment = 'AzureUSGovernment'
+	}
+
+	$azParams = @{
+		UseDeviceAuthentication = $UseDeviceCode
+		Environment             = $azEnvironment
+		Tenant                  = $TenantId ? $TenantId : $contextTenantId
+	}
+	if ($ClientId -and $Certificate) {
+		$azParams.ApplicationId = $ClientId
+		$azParams.CertificateThumbprint = $Certificate.Certificate.Thumbprint
+	}
+
+	try {
+		Connect-AzAccount @azParams -ErrorAction Stop
+	}
+	catch {
+		Stop-PSFFunction -Message "Failed to authenticate to Azure: $_" -ErrorRecord $_ -EnableException $true -Cmdlet $PSCmdlet
+	}
 }

--- a/src/powershell/public/Get-ZtGraphScope.ps1
+++ b/src/powershell/public/Get-ZtGraphScope.ps1
@@ -12,7 +12,18 @@
 #>
 
 Function Get-ZtGraphScope {
+	<#
+	.SYNOPSIS
+		List the Graph scopes needed for the ZeroTrustAssessment.
 
+	.DESCRIPTION
+		List the Graph scopes needed for the ZeroTrustAssessment.
+
+	.EXAMPLE
+		PS C:\> Get-ZtGraphScope
+
+		List the Graph scopes needed for the ZeroTrustAssessment.
+	#>
     [CmdletBinding()]
     param()
 
@@ -42,7 +53,5 @@ Function Get-ZtGraphScope {
         'UserAuthenticationMethod.Read.All'
     )
 
-    #$scopes += Get-EERequiredScopes -PermissionType Delegated
-
-    return $scopes | Sort-Object -Unique
+    $scopes | Sort-Object -Unique
 }


### PR DESCRIPTION
While previously established connections using certificate-based authentication (or other application-mode authentication options) were already supported, doing so directly from within `Connect-ZtAssessment` was not.

Specifically, this update makes a few changes:

+ Added `-Certificate` parameter to `Connect-ZtAssessment`. It accepts a certificate object, a thumbprint or a subject.
+ Added graph session verification to `Connect-ZtAssessment` - after connecting, it will now validate immediately, whether the session is good enough for our toolkit (scopes, role membership).
+ Refactored `Test-ZtContext`, for cleaner code and including validation errors in the logs