### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/webapp-ghpages.yml
+++ b/.github/workflows/webapp-ghpages.yml
@@ -27,7 +27,7 @@ jobs:
         working-directory: ./src/react/src
         run: npm run build
       - name: Upload Build Artifact        
-        uses: actions/upload-pages-artifact@v3        
+        uses: actions/upload-pages-artifact@v4        
         with:
           path: ./src/react/build
 


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/upload-pages-artifact` | [`v3`](https://github.com/actions/upload-pages-artifact/releases/tag/v3) | [`v4`](https://github.com/actions/upload-pages-artifact/releases/tag/v4) | [Release](https://github.com/actions/upload-pages-artifact/releases/tag/v4) | webapp-ghpages.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
