### PR TITLE
fix(21788): contradictionary conditions

### DIFF
--- a/src/powershell/tests/Test-Assessment.21788.ps1
+++ b/src/powershell/tests/Test-Assessment.21788.ps1
@@ -64,7 +64,7 @@ function Test-Assessment-21788 {
 
         $testResultMarkdown = ""
 
-        if (( -not $results ) -or ( $results.Count -eq 0 )) {
+        if ( -not $results -or $results.Count -eq 0 ) {
             $passed = $true
             $testResultMarkdown += "No standing access to Azure Root Management Group."
         }


### PR DESCRIPTION
The condition `$results` -and `$results.Count -eq 0` is logically contradictory. If $results is truthy (non-null/non-empty), it cannot have a count of 0. This condition will never evaluate to true