### PR TITLE
Fix parsing of query parameters to handle nested OData queries correctly

### DIFF
--- a/src/powershell/private/core/ConvertFrom-QueryString.ps1
+++ b/src/powershell/private/core/ConvertFrom-QueryString.ps1
@@ -56,7 +56,8 @@ function ConvertFrom-QueryString {
 			$queryParameters = $inputString.Split('&')
 
 			foreach ($queryParameter in $queryParameters) {
-				$key, $value = $queryParameter.Split('=')
+				# Split only on the first '=' to handle nested OData queries that contain '=' in the value
+				$key, $value = $queryParameter.Split('=', 2)
 				if ($DecodeParameterNames) {
 					$key = [System.Net.WebUtility]::UrlDecode($key)
 				}


### PR DESCRIPTION
API calls in tests 25409 and 25411 (endpoints with nested OData query: `'networkAccess/filteringProfiles?$select=id,name,description,state,priority&$expand=policies($select=id,state;$expand=policy($select=id,name,version)),conditionalAccessPolicies($select=id,displayName)'` are failing with error:
```
PS> Invoke-ZtGraphRequest -RelativeUri $reluri -ApiVersion beta
Invoke-MgGraphRequest: C:\zerotrustassessment\src\powershell\private\core\Invoke-ZtGraphRequestCache.ps1:114:13
Line |
 114 |  …  $results = Invoke-MgGraphRequest -Method $Method -Uri $Uri -Headers  …
     |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | {"error":{"code":"BadRequest","message":"Parsing OData Select and Expand failed: Term '($select id,state;$expand policy($select id,name,version))' is not valid in a $select or $expand expression."}}
```

The issue was caused by the `ConvertFrom-QueryString` helper function, which `Invoke-ZtGraphRequest` uses to parse the query parameters from the URI.

The function `ConvertFrom-QueryString` was splitting each query parameter string by the `=` character without a limit.
```
$key, $value = $queryParameter.Split('=')
```
For a simple parameter like `$select=id`, this works fine.
However, for a nested OData query like `$expand=policies($select=id,state)`, the string contains multiple `=` signs.
The `Split('=')` method was breaking this into an array: `['$expand', 'policies($select', 'id,state)']`.
PowerShell assigned `$key = '$expand'` and `$value = 'policies($select'`. The rest of the string (containing the nested = and subsequent parts) was discarded or treated incorrectly.

When `ConvertTo-QueryString` later reconstructed the query string, it used this truncated value, resulting in the malformed URL you saw in the error message (missing `=` signs and parts of the query).