### PR TITLE
Update video link in Advanced Analytics documentation

### DIFF
--- a/src/react/docs/workshop-guidance/devices/RMD_Win_Suite_01_AdvancedAnalytics.mdx
+++ b/src/react/docs/workshop-guidance/devices/RMD_Win_Suite_01_AdvancedAnalytics.mdx
@@ -25,9 +25,9 @@ If not implemented, organizations risk delayed detection of performance issues, 
 
 ### **Video Walkthrough**
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/Vn6OKB94cP0?si=v6kGGBlNaxt3dDsm" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/qlQX-_MczbI?si=bAUO06srTgyXcsST" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
-https://www.youtube.com/watch?v=Vn6OKB94cP0
+
 
 
 * * *


### PR DESCRIPTION
Replaced the old YouTube video link with a new one in the documentation.