### PR TITLE
fixing #874 module dependency for Public Preview

### DIFF
--- a/build/powershell/Resolve-PSDependencies.ps1
+++ b/build/powershell/Resolve-PSDependencies.ps1
@@ -1,0 +1,145 @@
+param (
+    [Parameter()]
+    [string]
+    $ModuleManifestPath = '{0}\..\src\powershell\ZeroTrustAssessment.psd1' -f (Split-Path -Parent $PSScriptRoot).TrimEnd([io.path]::DirectorySeparatorChar),
+
+    [Parameter()]
+    [string]
+    $OutputPath = '{0}\..\output\RequiredModules' -f (Split-Path -Parent $PSScriptRoot).TrimEnd([io.path]::DirectorySeparatorChar),
+
+    [Parameter()]
+    [switch]
+    $DoNotUpdatePSModulePath,
+
+    [Parameter()]
+    [switch]
+    $SkipModuleInstallation,
+
+    [Parameter()]
+    [switch]
+    $AllowPrerelease
+)
+
+if (-not (Test-Path -Path $OutputPath -PathType Container))
+{
+    Write-Verbose -Message "Output path not found: $OutputPath"
+    $OutputPath =  (New-Item -Path $OutputPath -ItemType Directory -Force -ErrorAction Stop).FullName
+    Write-Verbose -Message "Created output directory: $OutputPath"
+}
+else
+{
+    $OutputPath = (Get-Item -Path $OutputPath -ErrorAction Stop).FullName
+    Write-Verbose -Message "Output path already exists: $OutputPath"
+}
+
+if (-not $DoNotUpdatePSModulePath.IsPresent)
+{
+    Write-Information -MessageData "Updating PSModulePath to include $OutputPath..."
+    $modulePath = $env:PSModulePath.Split([System.IO.Path]::PathSeparator).ForEach{$_.TrimEnd([io.path]::DirectorySeparatorChar)}
+    if ($OutputPath.TrimEnd([io.path]::DirectorySeparatorChar) -notin $modulePath)
+    {
+        Write-Verbose -Message "Adding $OutputPath to PSModulePath."
+        $env:PSModulePath = (@($OutputPath) + $modulePath) -join [System.IO.Path]::PathSeparator
+        Write-Verbose -Message "Updated PSModulePath to:`r`n$env:PSModulePath"
+    }
+    else
+    {
+        Write-Information -MessageData "PSModulePath already contains $OutputPath. No update needed."
+    }
+}
+
+if (-not $SkipModuleInstallation.IsPresent)
+{
+    Write-Verbose -Message "Installing required modules to $OutputPath..."
+    $moduleManifest = Import-PowerShellDataFile -Path $ModuleManifestPath -ErrorAction Stop
+    [Microsoft.PowerShell.Commands.ModuleSpecification[]]$requiredModules = $moduleManifest.RequiredModules
+    [Microsoft.PowerShell.Commands.ModuleSpecification[]]$externalModuleDependencies = $moduleManifest.PrivateData.PSData.ExternalModuleDependencies
+    # [Microsoft.PowerShell.Commands.ModuleSpecification[]]$windowsPowerShellRequiredModules = $moduleManifest.PrivateData.PSData.WindowsPowerShellRequiredModules
+
+    $requiredModuleToSave = $requiredModules.Where{$_.Name -notin $externalModuleDependencies.Name}
+    # $requiredModuleToSave += $windowsPowerShellRequiredModules.Where{ $_.Name -notin $requiredModules.Name -and $_.Name -notin $externalModuleDependencies.Name }
+
+    if (-not $SkipModuleInstallation.IsPresent)
+    {
+        Write-Host -Object "`r`n"
+        Write-Host -Object 'Resolving dependencies...' -ForegroundColor Green
+
+        $saveModuleCmdParams = @{
+            Path = $OutputPath
+        }
+
+        if ($saveModuleCmd = (Get-Command -Name Save-PSResource -ErrorAction Ignore))
+        {
+            $saveModuleCmdParams.Add('TrustRepository', $true)
+            $saveModuleCmdParams.Add('Prerelease', $AllowPrerelease.IsPresent)
+            Write-Verbose -Message "Saving required modules using Save-PSResource..."
+        }
+        elseif ($saveModuleCmd = (Get-Command -Name Save-Module -ErrorAction Ignore))
+        {
+            $saveModuleCmdParams.Add('Force', $true)
+            $saveModuleCmdParams.Add('AllowPrerelease', $AllowPrerelease.IsPresent)
+            Write-Verbose -Message "Saving required modules using Save-Module..."
+        }
+        else
+        {
+            Write-Error -Message 'Neither Save-PSResource nor Save-Module is available. Please install the PowerShellGet module to save required modules.'
+            return
+        }
+
+        foreach ($moduleSpec in $requiredModuleToSave)
+        {
+            Write-Verbose -Message ("Saving module {0} with version {1}..." -f $moduleSpec.Name, $moduleSpec.Version)
+            $saveModuleCmdParamsClone = $saveModuleCmdParams.Clone()
+            $isModulePresent = Get-Module -Name $moduleSpec.Name -ListAvailable -ErrorAction Ignore | Where-Object {
+                $isValid = $true
+                if ($moduleSpec.Guid)
+                {
+                    $isValid = $_.Guid -eq $moduleSpec.Guid
+                }
+
+                if ($moduleSpec.Version)
+                {
+                    $isValid = $isValid -and $_.Version -ge [Version]$moduleSpec.Version
+                }
+                elseif ($moduleSpec.RequiredVersion)
+                {
+                    $isValid = $isValid -and $_.Version -eq [Version]$moduleSpec.RequiredVersion
+                }
+
+                $isValid
+            }
+
+            if ($isModulePresent)
+            {
+                Write-Host -Object ('    ✅ Module {0} found (v{1}).' -f $moduleSpec.Name,$isModulePresent[0].Version) -ForegroundColor Green
+                continue
+            }
+
+            try
+            {
+                $saveModuleCmdParamsClone['Name'] = $moduleSpec.Name
+                if ($moduleSpec.Version -and $saveModuleCmd.Name -eq 'Save-Module')
+                {
+                    $saveModuleCmdParamsClone['MinimumVersion'] = $moduleSpec.Version
+                }
+                elseif ($moduleSpec.Version -and $saveModuleCmd.Name -eq 'Save-PSResource')
+                {
+                    $saveModuleCmdParamsClone['Version'] = '[{0}, ]' -f $moduleSpec.Version
+                }
+
+                & $saveModuleCmd @saveModuleCmdParamsClone
+                Write-Host -Object ('    ⬇️ Module {0} saved successfully.' -f $moduleSpec.Name) -ForegroundColor Green
+            }
+            catch
+            {
+                Write-Host -Object ('    ❌ Failed to save module {0}: {1}' -f $moduleSpec.Name, $_) -ForegroundColor Red
+            }
+        }
+    }
+
+}
+else
+{
+    Write-Verbose -Message "Skipping module installation as per parameter. Required modules will not be saved to $OutputPath."
+    return
+}

--- a/src/powershell/Initialize-Dependencies.ps1
+++ b/src/powershell/Initialize-Dependencies.ps1
@@ -1,63 +1,250 @@
+param (
+    [Parameter()]
+    [string]
+    $ModuleManifestPath,
+
+    [Parameter()]
+    [string]
+    $RequiredModulesPath,
+
+    [Parameter()]
+    [switch]
+    $SkipModuleInstallation,
+
+    [Parameter()]
+    [switch]
+    $SkipLoadMSAL,
+
+    [Parameter()]
+    [switch]
+    $DoNotUpdatePSModulePath
+)
+
 # Initialize-Dependencies.ps1
 # This script is run by the module manifest (ScriptsToProcess) before the module is imported.
 # It ensures that dependencies are loaded in the correct order to avoid DLL conflicts.
 # Specifically, ExchangeOnlineManagement and Az.Accounts/Graph both use Microsoft.Identity.Client.dll.
-# We must ensure the oldest compatible version is loaded first, BEFORE any modules import.
+# It also updates the PSModulePath to include the directory where dependencies are saved,
+# and saves required modules if they are not already present.
+function Initialize-Dependencies {
+    [CmdletBinding()]
+    param (
+        [Parameter()]
+        [string]
+        $ModuleManifestPath = (Join-Path -Path $PSScriptRoot -ChildPath "ZeroTrustAssessment.psd1" -Resolve -ErrorAction Stop),
 
-# Wrapped in a scriptblock to prevent variable leakage into the user's session
-& {
-    Write-Verbose "=== Initialize-Dependencies.ps1 Starting ==="
+        [Parameter()]
+        [string]
+        $RequiredModulesPath = $(
+            if ($IsLinux -or $IsMacOS) {
+                Join-Path -Path $env:HOME -ChildPath ".cache/ZeroTrustAssessment/Modules"
+            }
+            else {
+                Join-Path -Path $env:APPDATA -ChildPath "ZeroTrustAssessment\Modules"
+            }
+        ),
+
+        [Parameter()]
+        [switch]
+        $AllowPrerelease,
+
+        [Parameter()]
+        [switch]
+        $SkipModuleInstallation,
+
+        [Parameter()]
+        [switch]
+        $SkipLoadMSAL= ($Env:SkipLoadMSAL -eq 'true' -or $Env:SkipLoadMSAL -eq '1'),
+
+        [Parameter()]
+        [switch]
+        $DoNotUpdatePSModulePath
+    )
+
+    Write-Verbose -Message "=== Initialize-Dependencies.ps1 Starting ==="
+
+    #region Prepend $Env:PSModulePath with ~\AppData|.cache\ZeroTrustAssessment\Modules
+    Write-Verbose -Message ("Setting $Env:PSModulePath to include the {0} for module dependencies..." -f $RequiredModulesPath)
+    if (-not (Test-Path -Path $RequiredModulesPath -PathType Container))
+    {
+        Write-Verbose -Message "RequiredModulesPath path not found: $RequiredModulesPath"
+        $RequiredModulesPath =  (New-Item -Path $RequiredModulesPath -ItemType Directory -Force -ErrorAction Stop).FullName
+        Write-Verbose -Message "Created output directory: $RequiredModulesPath"
+    }
+    else
+    {
+        $RequiredModulesPath = (Get-Item -Path $RequiredModulesPath -ErrorAction Stop).FullName
+        Write-Verbose -Message "RequiredModulesPath path already exists: $RequiredModulesPath"
+    }
+
+    if (-not $DoNotUpdatePSModulePath.IsPresent)
+    {
+        Write-Verbose -Message "Updating PSModulePath to include $RequiredModulesPath..."
+        $modulePath = $env:PSModulePath.Split([System.IO.Path]::PathSeparator).ForEach{$_.TrimEnd([io.path]::DirectorySeparatorChar)}
+        if ($RequiredModulesPath.TrimEnd([io.path]::DirectorySeparatorChar) -notin $modulePath)
+        {
+            Write-Debug -Message "Adding $RequiredModulesPath to PSModulePath."
+            $env:PSModulePath = (@($RequiredModulesPath) + $modulePath) -join [System.IO.Path]::PathSeparator
+            Write-Debug -Message "Updated PSModulePath to:`r`n$env:PSModulePath"
+        }
+        else
+        {
+            Write-Debug -Message "PSModulePath already contains $RequiredModulesPath. No update needed."
+        }
+    }
+    #endregion
+
+    #region Load module Manifest
+    $moduleManifest = Import-PowerShellDataFile -Path $ModuleManifestPath -ErrorAction Stop
+    [Microsoft.PowerShell.Commands.ModuleSpecification[]]$requiredModules = $moduleManifest.RequiredModules
+    [Microsoft.PowerShell.Commands.ModuleSpecification[]]$externalModuleDependencies = $moduleManifest.PrivateData.PSData.ExternalModuleDependencies
+    [Microsoft.PowerShell.Commands.ModuleSpecification[]]$windowsPowerShellRequiredModules = $moduleManifest.PrivateData.PSData.WindowsPowerShellRequiredModules
+
+    $requiredModuleToSave = $requiredModules.Where{$_.Name -notin $externalModuleDependencies.Name}
+    $requiredModuleToSave += $windowsPowerShellRequiredModules.Where{ $_.Name -notin $requiredModules.Name -and $_.Name -notin $externalModuleDependencies.Name }
+    #endregion
+
+    if ($IsMacOS -or $IsLinux)
+    {
+        #region The ZeroTrustAssessment report should be run in Windows.
+        # on Non-windows platform, some pillars won't be available, because some required modules only work on Windows PowerShell.
+        Write-Host -Object "`r`n" -ForegroundColor Yellow
+        Write-Host -Object '⚠️ Warning: The ZeroTrustAssessment module is designed to run on Windows, in PowerShell 7.'
+        Write-Host -Object 'Some pillars require modules that can only run on Windows PowerShell (Windows PowerShell 5.1) with implicit remoting.' -ForegroundColor Yellow
+        # skipping module installation.
+        #endregion
+    }
+    elseif (-not $SkipModuleInstallation.IsPresent)
+    {
+        Write-Host -Object "`r`n"
+        Write-Host -Object 'Resolving dependencies...' -ForegroundColor Green
+
+        $saveModuleCmdParams = @{
+            Path = $RequiredModulesPath
+        }
+
+        if ($saveModuleCmd = (Get-Command -Name Save-PSResource -ErrorAction Ignore))
+        {
+            $saveModuleCmdParams.Add('TrustRepository', $true)
+            $saveModuleCmdParams.Add('Prerelease', $AllowPrerelease.IsPresent)
+            Write-Verbose -Message "Saving required modules using Save-PSResource..."
+        }
+        elseif ($saveModuleCmd = (Get-Command -Name Save-Module -ErrorAction Ignore))
+        {
+            $saveModuleCmdParams.Add('Force', $true)
+            $saveModuleCmdParams.Add('AllowPrerelease', $AllowPrerelease.IsPresent)
+            Write-Verbose -Message "Saving required modules using Save-Module..."
+        }
+        else
+        {
+            Write-Error -Message 'Neither Save-PSResource nor Save-Module is available. Please install the PowerShellGet module to save required modules.'
+            return
+        }
+
+        foreach ($moduleSpec in $requiredModuleToSave)
+        {
+            Write-Verbose -Message ("Saving module {0} with version {1}..." -f $moduleSpec.Name, $moduleSpec.Version)
+            $saveModuleCmdParamsClone = $saveModuleCmdParams.Clone()
+            $isModulePresent = Get-Module -Name $moduleSpec.Name -ListAvailable -ErrorAction Ignore | Where-Object {
+                $isValid = $true
+                if ($moduleSpec.Guid)
+                {
+                    $isValid = $_.Guid -eq $moduleSpec.Guid
+                }
+
+                if ($moduleSpec.Version)
+                {
+                    $isValid = $isValid -and $_.Version -ge [Version]$moduleSpec.Version
+                }
+                elseif ($moduleSpec.RequiredVersion)
+                {
+                    $isValid = $isValid -and $_.Version -eq [Version]$moduleSpec.RequiredVersion
+                }
+
+                $isValid
+            }
+
+            if ($isModulePresent)
+            {
+                Write-Host -Object ('    ✅ Module {0} found (v{1}).' -f $moduleSpec.Name,$isModulePresent[0].Version) -ForegroundColor Green
+                continue
+            }
+
+            try
+            {
+                $saveModuleCmdParamsClone['Name'] = $moduleSpec.Name
+                if ($moduleSpec.Version -and $saveModuleCmd.Name -eq 'Save-Module')
+                {
+                    $saveModuleCmdParamsClone['MinimumVersion'] = $moduleSpec.Version
+                }
+                elseif ($moduleSpec.Version -and $saveModuleCmd.Name -eq 'Save-PSResource')
+                {
+                    $saveModuleCmdParamsClone['Version'] = '[{0}, ]' -f $moduleSpec.Version
+                }
+
+                & $saveModuleCmd @saveModuleCmdParamsClone
+                Write-Host -Object ('    ⬇️ Module {0} saved successfully.' -f $moduleSpec.Name) -ForegroundColor Green
+            }
+            catch
+            {
+                Write-Host -Object ('    ❌ Failed to save module {0}: {1}' -f $moduleSpec.Name, $_) -ForegroundColor Red
+            }
+        }
+    }
 
     try {
         # Check if MSAL is already loaded
         $loadedAssemblies = [System.AppDomain]::CurrentDomain.GetAssemblies() | Where-Object { $_.GetName().Name -eq 'Microsoft.Identity.Client' }
 
         if ($loadedAssemblies) {
-            Write-Warning "MSAL assembly is already loaded. This may cause DLL conflicts."
-            Write-Verbose "  Loaded versions:"
+            Write-Warning -Message "MSAL assembly is already loaded. This may cause DLL conflicts."
+            Write-Verbose -Message "  Loaded versions:"
             foreach ($asm in $loadedAssemblies) {
-                Write-Verbose "  - $($asm.GetName().Version) from $($asm.Location)"
+                Write-Verbose -Message ("  - {0} from {1}" -f $asm.GetName().Version, $asm.Location)
             }
-            Write-Verbose "  Recommendation: Restart PowerShell and import ZeroTrustAssessment first."
+
+            Write-Verbose -Message "  Recommendation: Restart PowerShell and import ZeroTrustAssessment first."
         }
         else {
-            # Dot-source helper if it exists
-            $helperPath = Join-Path $PSScriptRoot "private\utility\Get-ModuleImportOrder.ps1"
+            Write-Host -Object "`r`n"
+            Write-Host -Object 'Asserting MSAL loading order for dependencies...' -ForegroundColor Green
+            $helperPath = Join-Path -Path $PSScriptRoot -ChildPath "private\utility\Get-ModuleImportOrder.ps1" -Resolve -ErrorAction Stop
+            . $helperPath
+            Write-Verbose -Message ('Module with DLLs to load: {0}' -f (([Microsoft.PowerShell.Commands.ModuleSpecification[]]$moduleManifest.RequiredModules).Name -join ', '))
+            # This method does not necessarily load the right dll (it ignores the load logic from the modules)
+            $msalToLoadInOrder = Get-ModuleImportOrder -Name $moduleManifest.RequiredModules.ModuleName
 
-            if (Test-Path $helperPath) {
-                . $helperPath
+            $msalToLoadInOrder.ForEach{
+                Write-Verbose -Message ('Loading MSAL v{0} for dependency {1} version {2}' -f $_.DLLVersion, $_.Name, $_.ModuleVersion)
+                if ([System.AppDomain]::CurrentDomain.GetAssemblies().Where{$_.GetName().Name -eq 'Microsoft.Identity.Client'}) {
+                    Write-Verbose -Message ("MSAL v{0} is already loaded, skipping." -f $_.DLLVersion)
+                }
+                else
+                {
+                    Write-Host -Object ('    ✅ Loading MSAL v{0} for dependency {1} version {2}' -f $_.DLLVersion, $_.Name, $_.ModuleVersion) -ForegroundColor Green
+                    $null = [System.Reflection.Assembly]::LoadFrom($_.DLLPath)
+                }
 
-                # Define dependencies
-                $requiredVersions = @{ 'ExchangeOnlineManagement' = '3.8.0' }
-
-                $exoModule = Get-ModuleImportOrder -Name 'ExchangeOnlineManagement' -RequiredVersions $requiredVersions
-
-                if ($exoModule -and $exoModule.DLLPath -and (Test-Path $exoModule.DLLPath)) {
-                    Write-Verbose "Pre-loading MSAL from ExchangeOnlineManagement ($($exoModule.ModuleVersion))..."
-
-                    # Load Main DLL
-                    [System.Reflection.Assembly]::LoadFrom($exoModule.DLLPath) | Out-Null
-
-                    # Load related DLLs (Brokers, etc.)
-                    $msalDir = Split-Path $exoModule.DLLPath
-                    Get-ChildItem -Path $msalDir -Filter "Microsoft.Identity.Client*.dll" -File | ForEach-Object {
-                        if ($_.Name -ne "Microsoft.Identity.Client.dll") {
-                            try {
-                                [System.Reflection.Assembly]::LoadFrom($_.FullName) | Out-Null
-                            }
-                            catch {
-                            }
-                        }
+                $brokerInteropToLoad = Get-ChildItem -Path (Split-Path -Path $_.DLLPath) -Filter "Microsoft.Identity.Client*.dll" -File | Where-Object { $_.Name -ne "Microsoft.Identity.Client.dll" }
+                foreach ($broker in $brokerInteropToLoad)
+                {
+                    Write-Debug -Message ('Loading related MSAL broker/interop assembly {0}' -f $broker.Name)
+                    try
+                    {
+                        $null = [System.Reflection.Assembly]::LoadFrom($broker.FullName)
+                        Write-Host -Object ('    ✅ Loaded {0}' -f $broker.Name) -ForegroundColor Green
+                    }
+                    catch
+                    {
+                        Write-Debug -Message ("Failed to load related MSAL assembly {0}: {1}" -f $broker.FullName, $_)
                     }
                 }
-            }
-            else {
-                Write-Verbose "Get-ModuleImportOrder.ps1 not found. Skipping dependency pre-load."
             }
         }
     }
     catch {
-        Write-Warning "Initialize-Dependencies.ps1 failed: $_"
+        Write-Warning -Message ("Initialize-Dependencies.ps1 failed: {0}" -f $_)
     }
-
 }
+
+Initialize-Dependencies @PSBoundParameters

--- a/src/powershell/ZeroTrustAssessment.psd1
+++ b/src/powershell/ZeroTrustAssessment.psd1
@@ -51,11 +51,13 @@ PowerShellVersion = '7.0'
 # ProcessorArchitecture = ''
 
 # Modules that must be imported into the global environment prior to importing this module
-RequiredModules = @(@{ModuleName = 'ExchangeOnlineManagement'; GUID = 'b5eced50-afa4-455b-847a-d8fb64140a22'; ModuleVersion = '3.8.0'; },
-               @{ModuleName = 'Microsoft.Graph.Authentication'; GUID = '883916f2-9184-46ee-b1f8-b6a2fb784cee'; ModuleVersion = '2.32.0'; },
-               @{ModuleName = 'Microsoft.Graph.Beta.Teams'; GUID = 'e264919d-7ae2-4a89-ba8b-524bd93ddc08'; ModuleVersion = '2.32.0'; },
-               @{ModuleName = 'Az.Accounts'; GUID = '17a2feff-488b-47f9-8729-e2cec094624c'; ModuleVersion = '4.0.2'; },
-               @{ModuleName = 'PSFramework'; GUID = '8028b914-132b-431f-baa9-94a6952f21ff'; ModuleVersion = '1.13.419'; })
+RequiredModules = @(
+    @{ModuleName = 'ExchangeOnlineManagement'; GUID = 'b5eced50-afa4-455b-847a-d8fb64140a22'; ModuleVersion = '3.8.0'; },     # Works on PS7
+    @{ModuleName = 'Microsoft.Graph.Authentication'; GUID = '883916f2-9184-46ee-b1f8-b6a2fb784cee'; ModuleVersion = '2.32.0'; },
+    @{ModuleName = 'Microsoft.Graph.Beta.Teams'; GUID = 'e264919d-7ae2-4a89-ba8b-524bd93ddc08'; ModuleVersion = '2.32.0'; },
+    @{ModuleName = 'Az.Accounts'; GUID = '17a2feff-488b-47f9-8729-e2cec094624c'; ModuleVersion = '4.0.2'; },
+    @{ModuleName = 'PSFramework'; GUID = '8028b914-132b-431f-baa9-94a6952f21ff'; ModuleVersion = '1.13.419'; }
+)
 
 # Assemblies that must be loaded prior to importing this module
 RequiredAssemblies = 'lib\DuckDB.NET.Data.dll'
@@ -125,6 +127,11 @@ PrivateData = @{
 
         # External dependent modules of this module
         # ExternalModuleDependencies = @()
+
+        WindowsPowerShellRequiredModules = @(
+            @{ModuleName = 'Microsoft.Online.SharePoint.PowerShell'; GUID = 'adedde5f-e77b-4682-ab3d-a4cb4ff79b83'; ModuleVersion = '16.0.26914.12004'; },
+            @{ModuleName = 'AipService'; GUID = 'e338ccc0-3333-4479-87fe-66382d33782d'; ModuleVersion = '3.0.0.1'; }
+        )
 
     } # End of PSData hashtable
 

--- a/src/powershell/private/core/Get-ZtAssessmentResults.ps1
+++ b/src/powershell/private/core/Get-ZtAssessmentResults.ps1
@@ -23,11 +23,17 @@ function Get-ZtAssessmentResults {
 		param (
 
 		)
-		if (Get-Command 'Find-Module' -ErrorAction SilentlyContinue) {
-			return (Find-Module -Name ZeroTrustAssessment).Version -as [string]
-		}
 
-		return 'Unknown'
+		if ((Get-Module -Name 'Microsoft.PowerShell.PSResourceGet') -or (Get-Command 'Find-PSResource' -ErrorAction Ignore)) {
+			(Find-PSResource -Name ZeroTrustAssessment).Version -as [string]
+		}
+		elseif (Get-Command 'Find-Module' -ErrorAction SilentlyContinue) {
+			(Find-Module -Name ZeroTrustAssessment).Version -as [string]
+		}
+		else {
+			Write-Verbose -Message "Neither PowerShellGet nor PSResourceGet is available. Cannot determine latest module version."
+		    'Unknown'
+		}
 	}
 
 	function Get-TestResultSummary {

--- a/src/powershell/private/tests/Invoke-ZtTests.ps1
+++ b/src/powershell/private/tests/Invoke-ZtTests.ps1
@@ -61,7 +61,7 @@
 		$testsToRun = $testsToRun | Where-Object { $_.Pillar -in $stablePillars }
 	}
 
-	# Separate Sync Tests (Compliance/ExchangeOnline/SharePointOnline) from Parallel Tests
+	# Separate Sync Tests (Compliance/ExchangeOnline/SharePointOnline) from Parallel Tests (because of DLL order to manage in runspaces & remoting into WPS)
 	$syncTestIds = @($testsToRun | Where-Object { $_.Pillar -eq 'Data' } | Select-Object -ExpandProperty TestId)
 	$syncTests = $testsToRun | Where-Object { $_.TestId -in $syncTestIds }
 	$parallelTests = $testsToRun | Where-Object { $_.TestId -notin $syncTestIds }


### PR DESCRIPTION
This PR resolves the preloading of the MSAL dll for every PS7 dependencies.
It also provides a step towards solving the Windows PS dependency, but leaving in draft until this is integrated.

To test this, if you don't yet have the dependencies installed you can run:

```PowerShell
&.\build\powershell\Resolve-PSDependencies.ps1 -Verbose
Import-Module  .\src\powershell\ZeroTrustAssessment.psd1
Connect-ZtAssessment -Service All -Verbose
Invoke-ZtAssessment -Preview -Pillar All
```

There are some improvements and integration to be done before marking this PR as ready:
- [x] Resolving Dependencies to pull the latest (PSResourceGet bug)
- [ ] Improve Connect-ZTAssessment to be lest verbose (some boolean returns)
- [x] Integrate the Module requirement download for WPS
- [ ] Check running OS, if non-windows, query user if continue. And warn some services are skipped. Save in config file.

Let me know if I'm missing anything.