### PR TITLE
35039 - Fix to enhance JSON parsing to skip non-JSON scalar values

### DIFF
--- a/src/powershell/tests/Test-Assessment.35039.ps1
+++ b/src/powershell/tests/Test-Assessment.35039.ps1
@@ -63,7 +63,7 @@ function Test-Assessment-35039 {
                                     $jsonText = $rawValue.Trim()
 
                                     # We only need object/array JSON payloads that can contain Workloads
-                                    if ($jsonText -notmatch '^\s*[\{\[]') {
+                                    if ($jsonText -notmatch '^[\{\[]') {
                                         continue
                                     }
 


### PR DESCRIPTION
35039 - Fix to enhance JSON parsing to skip non-JSON scalar values and ensure only valid object/array payloads are processed

This pull request refines the logic used to process and validate JSON values within the `Test-Assessment-35039` PowerShell test. The main improvement is to ensure only valid object or array JSON payloads are parsed, while skipping problematic scalar values and non-JSON content.

**Improvements to JSON value handling:**

* Skips parsing of scalar values like `Infinity`, `-Infinity`, and `NaN` to avoid errors when converting from JSON.
* Ensures only JSON strings that represent objects or arrays (starting with `{` or `[`) are processed, filtering out irrelevant or malformed data.
* Adds error handling to the JSON parsing step by using `-ErrorAction Stop`, improving robustness.