### PR TITLE
Fixing the error caused by data in wrong part of PSD1

### DIFF
--- a/build/powershell/Resolve-PSDependencies.ps1
+++ b/build/powershell/Resolve-PSDependencies.ps1
@@ -53,8 +53,8 @@ if (-not $SkipModuleInstallation.IsPresent)
     Write-Verbose -Message "Installing required modules to $OutputPath..."
     $moduleManifest = Import-PowerShellDataFile -Path $ModuleManifestPath -ErrorAction Stop
     [Microsoft.PowerShell.Commands.ModuleSpecification[]]$requiredModules = $moduleManifest.RequiredModules
-    [Microsoft.PowerShell.Commands.ModuleSpecification[]]$externalModuleDependencies = $moduleManifest.PrivateData.PSData.ExternalModuleDependencies
-    # [Microsoft.PowerShell.Commands.ModuleSpecification[]]$windowsPowerShellRequiredModules = $moduleManifest.PrivateData.PSData.WindowsPowerShellRequiredModules
+    [Microsoft.PowerShell.Commands.ModuleSpecification[]]$externalModuleDependencies = $moduleManifest.PrivateData.ExternalModuleDependencies
+    # [Microsoft.PowerShell.Commands.ModuleSpecification[]]$windowsPowerShellRequiredModules = $moduleManifest.PrivateData.WindowsPowerShellRequiredModules
 
     $requiredModuleToSave = $requiredModules.Where{$_.Name -notin $externalModuleDependencies.Name}
     # $requiredModuleToSave += $windowsPowerShellRequiredModules.Where{ $_.Name -notin $requiredModules.Name -and $_.Name -notin $externalModuleDependencies.Name }

--- a/src/powershell/Initialize-Dependencies.ps1
+++ b/src/powershell/Initialize-Dependencies.ps1
@@ -97,8 +97,8 @@ function Initialize-Dependencies {
     #region Load module Manifest
     $moduleManifest = Import-PowerShellDataFile -Path $ModuleManifestPath -ErrorAction Stop
     [Microsoft.PowerShell.Commands.ModuleSpecification[]]$requiredModules = $moduleManifest.RequiredModules
-    [Microsoft.PowerShell.Commands.ModuleSpecification[]]$externalModuleDependencies = $moduleManifest.PrivateData.PSData.ExternalModuleDependencies
-    [Microsoft.PowerShell.Commands.ModuleSpecification[]]$windowsPowerShellRequiredModules = $moduleManifest.PrivateData.PSData.WindowsPowerShellRequiredModules
+    [Microsoft.PowerShell.Commands.ModuleSpecification[]]$externalModuleDependencies = $moduleManifest.PrivateData.ExternalModuleDependencies
+    [Microsoft.PowerShell.Commands.ModuleSpecification[]]$windowsPowerShellRequiredModules = $moduleManifest.PrivateData.WindowsPowerShellRequiredModules
 
     $requiredModuleToSave = $requiredModules.Where{$_.Name -notin $externalModuleDependencies.Name}
     $requiredModuleToSave += $windowsPowerShellRequiredModules.Where{ $_.Name -notin $requiredModules.Name -and $_.Name -notin $externalModuleDependencies.Name }

--- a/src/powershell/ZeroTrustAssessment.psd1
+++ b/src/powershell/ZeroTrustAssessment.psd1
@@ -52,7 +52,6 @@ PowerShellVersion = '7.0'
 
 # Modules that must be imported into the global environment prior to importing this module
 RequiredModules = @(
-    @{ModuleName = 'ExchangeOnlineManagement'; GUID = 'b5eced50-afa4-455b-847a-d8fb64140a22'; ModuleVersion = '3.8.0'; },     # Works on PS7
     @{ModuleName = 'Microsoft.Graph.Authentication'; GUID = '883916f2-9184-46ee-b1f8-b6a2fb784cee'; ModuleVersion = '2.32.0'; },
     @{ModuleName = 'Microsoft.Graph.Beta.Teams'; GUID = 'e264919d-7ae2-4a89-ba8b-524bd93ddc08'; ModuleVersion = '2.32.0'; },
     @{ModuleName = 'Az.Accounts'; GUID = '17a2feff-488b-47f9-8729-e2cec094624c'; ModuleVersion = '4.0.2'; },
@@ -102,8 +101,13 @@ AliasesToExport = 'Invoke-ZeroTrustAssessment'
 # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
 PrivateData = @{
 
-    PSData = @{
+    WindowsPowerShellRequiredModules = @(
+        @{ModuleName = 'ExchangeOnlineManagement'; GUID = 'b5eced50-afa4-455b-847a-d8fb64140a22'; ModuleVersion = '3.9.2'; },     # Works on PS7
+        @{ModuleName = 'Microsoft.Online.SharePoint.PowerShell'; GUID = 'adedde5f-e77b-4682-ab3d-a4cb4ff79b83'; ModuleVersion = '16.0.26914.12004'; },
+        @{ModuleName = 'AipService'; GUID = 'e338ccc0-3333-4479-87fe-66382d33782d'; ModuleVersion = '3.0.0.1'; }
+    )
 
+    PSData = @{
         # Tags applied to this module. These help with module discovery in online galleries.
         Tags = 'Microsoft','Security','ZeroTrust','Entra','Intune'
 
@@ -128,10 +132,15 @@ PrivateData = @{
         # External dependent modules of this module
         # ExternalModuleDependencies = @()
 
-        WindowsPowerShellRequiredModules = @(
-            @{ModuleName = 'Microsoft.Online.SharePoint.PowerShell'; GUID = 'adedde5f-e77b-4682-ab3d-a4cb4ff79b83'; ModuleVersion = '16.0.26914.12004'; },
-            @{ModuleName = 'AipService'; GUID = 'e338ccc0-3333-4479-87fe-66382d33782d'; ModuleVersion = '3.0.0.1'; }
-        )
+        # TODO: Some tests depends for:
+            # Connected State
+            # Permissions
+            # Licensing
+
+        # What Valid reasons to skip, fail, error a test.
+
+        # TODO: Check commands because they may be dedicated based on permissions. And the current connection.
+        # TODO: Based on Licensing, you may have
 
     } # End of PSData hashtable
 


### PR DESCRIPTION
The data was in the wrong part of the PSD1 which ended with Publish-Module to incorrectly move the entries.