### PR TITLE
Update Get-LabelPolicy to use WarningAction SilentlyContinue

### DIFF
--- a/src/powershell/tests/Test-Assessment.35004.ps1
+++ b/src/powershell/tests/Test-Assessment.35004.ps1
@@ -41,7 +41,7 @@ function Test-Assessment-35004 {
 
     try {
         # Query: Get all label policies
-        $policies = Get-LabelPolicy -ErrorAction Stop
+        $policies = Get-LabelPolicy -WarningAction SilentlyContinue -ErrorAction Stop
     }
     catch {
         $errorMsg = $_

--- a/src/powershell/tests/Test-Assessment.35014.ps1
+++ b/src/powershell/tests/Test-Assessment.35014.ps1
@@ -42,7 +42,7 @@ function Test-Assessment-35014 {
 
     try {
         # Q1: Retrieve all enabled sensitivity label policies to check attachmentaction setting
-        $enabledPolicies = Get-LabelPolicy -ErrorAction Stop | Where-Object { $_.Enabled -eq $true }
+        $enabledPolicies = Get-LabelPolicy -WarningAction SilentlyContinue -ErrorAction Stop | Where-Object { $_.Enabled -eq $true }
 
         # Q2: Retrieve all labels to check for Files & Emails scope
         Write-ZtProgress -Activity $activity -Status 'Getting sensitivity labels'

--- a/src/powershell/tests/Test-Assessment.35015.ps1
+++ b/src/powershell/tests/Test-Assessment.35015.ps1
@@ -39,7 +39,7 @@ function Test-Assessment-35015 {
 
     try {
         # Get all enabled label policies
-        $labelPolicies = Get-LabelPolicy -ErrorAction Stop | Where-Object { $_.Enabled -eq $true }
+        $labelPolicies = Get-LabelPolicy -WarningAction SilentlyContinue -ErrorAction Stop | Where-Object { $_.Enabled -eq $true }
     }
     catch {
         $errorMsg = $_

--- a/src/powershell/tests/Test-Assessment.35016.ps1
+++ b/src/powershell/tests/Test-Assessment.35016.ps1
@@ -29,7 +29,7 @@ function Test-Assessment-35016 {
     $enabledPolicies = @()
 
     try {
-        $enabledPolicies = Get-LabelPolicy -ErrorAction Stop | Where-Object { $_.Enabled -eq $true }
+        $enabledPolicies = Get-LabelPolicy -WarningAction SilentlyContinue -ErrorAction Stop | Where-Object { $_.Enabled -eq $true }
     }
     catch {
         $errorMsg = $_

--- a/src/powershell/tests/Test-Assessment.35017.ps1
+++ b/src/powershell/tests/Test-Assessment.35017.ps1
@@ -41,7 +41,7 @@ function Test-Assessment-35017 {
 
     try {
         # Q1: Retrieve all enabled sensitivity label policies to assess default label configuration
-        $enabledPolicies = Get-LabelPolicy -ErrorAction Stop | Where-Object { $_.Enabled -eq $true }
+        $enabledPolicies = Get-LabelPolicy -WarningAction SilentlyContinue -ErrorAction Stop | Where-Object { $_.Enabled -eq $true }
     }
     catch {
         $errorMsg = $_

--- a/src/powershell/tests/Test-Assessment.35018.ps1
+++ b/src/powershell/tests/Test-Assessment.35018.ps1
@@ -37,7 +37,7 @@ function Test-Assessment-35018 {
     $errorMsg = $null
 
     try {
-        $enabledPolicies = Get-LabelPolicy -ErrorAction Stop | Where-Object { $_.Enabled -eq $true }
+        $enabledPolicies = Get-LabelPolicy -WarningAction SilentlyContinue -ErrorAction Stop | Where-Object { $_.Enabled -eq $true }
     }
     catch {
         $errorMsg = $_


### PR DESCRIPTION
Update `Get-LabelPolicy` to use `-WarningAction SilentlyContinue` and suppress unwanted "Force Validate not set" warning.