### PR TITLE
Fix Module version issue for graph

### DIFF
--- a/src/powershell/Initialize-Dependencies.ps1
+++ b/src/powershell/Initialize-Dependencies.ps1
@@ -100,8 +100,8 @@ function Initialize-Dependencies {
     [Microsoft.PowerShell.Commands.ModuleSpecification[]]$externalModuleDependencies = $moduleManifest.PrivateData.ExternalModuleDependencies
 
     [Microsoft.PowerShell.Commands.ModuleSpecification[]]$xPlatPowerShellRequiredModules = @(
-        @{ModuleName = 'Microsoft.Graph.Authentication'; GUID = '883916f2-9184-46ee-b1f8-b6a2fb784cee'; ModuleVersion = '2.32.0'; },
-        @{ModuleName = 'Microsoft.Graph.Beta.Teams'; GUID = 'e264919d-7ae2-4a89-ba8b-524bd93ddc08'; ModuleVersion = '2.32.0'; },
+        @{ModuleName = 'Microsoft.Graph.Authentication'; GUID = '883916f2-9184-46ee-b1f8-b6a2fb784cee'; ModuleVersion = '2.35.1'; },
+        @{ModuleName = 'Microsoft.Graph.Beta.Teams'; GUID = 'e264919d-7ae2-4a89-ba8b-524bd93ddc08'; ModuleVersion = '2.35.1'; },
         @{ModuleName = 'Az.Accounts'; GUID = '17a2feff-488b-47f9-8729-e2cec094624c'; ModuleVersion = '4.0.2'; },
         @{ModuleName = 'ExchangeOnlineManagement'; GUID = 'b5eced50-afa4-455b-847a-d8fb64140a22'; RequiredVersion = '3.9.0'; }
     )

--- a/src/powershell/ZeroTrustAssessment.psd1
+++ b/src/powershell/ZeroTrustAssessment.psd1
@@ -104,8 +104,8 @@ PrivateData = @{
     )
 
     XPlatPowerShellRequiredModules = @(
-        @{ModuleName = 'Microsoft.Graph.Authentication'; GUID = '883916f2-9184-46ee-b1f8-b6a2fb784cee'; ModuleVersion = '2.32.0'; },
-        @{ModuleName = 'Microsoft.Graph.Beta.Teams'; GUID = 'e264919d-7ae2-4a89-ba8b-524bd93ddc08'; ModuleVersion = '2.32.0'; },
+        @{ModuleName = 'Microsoft.Graph.Authentication'; GUID = '883916f2-9184-46ee-b1f8-b6a2fb784cee'; ModuleVersion = '2.35.1'; },
+        @{ModuleName = 'Microsoft.Graph.Beta.Teams'; GUID = 'e264919d-7ae2-4a89-ba8b-524bd93ddc08'; ModuleVersion = '2.35.1'; },
         @{ModuleName = 'Az.Accounts'; GUID = '17a2feff-488b-47f9-8729-e2cec094624c'; ModuleVersion = '4.0.2'; },
         @{ModuleName = 'ExchangeOnlineManagement'; GUID = 'b5eced50-afa4-455b-847a-d8fb64140a22'; RequiredVersion = '3.9.0'; }
     )


### PR DESCRIPTION
# Microsoft.Graph Authentication Failed - DLL Conflict Resolution

## Issue Summary
Microsoft.Graph.Authentication v2.32.0 caused authentication failures in `Connect-ZtAssessment` due to incompatible Microsoft.Identity.Client (MSAL) DLL version. Upgrading to v2.35.1 resolved the issue.

## Error Details

**Affected Commands:**
- `Connect-ZtAssessment`
- `Connect-ZtAssessment -Service Graph`

**Error Message:**
Connect-ZtAssessment: InteractiveBrowserCredential authentication failed: Method not found: '!0 Microsoft.Identity.Client.BaseAbstractApplicationBuilder`1.WithLogging(Microsoft.IdentityModel.Abstractions.IIdentityLogger, Boolean)'.


## Root Cause
Microsoft.Graph.Authentication v2.32.0 bundled an incompatible version of `Microsoft.Identity.Client.dll` that was missing the `WithLogging` method signature expected by the authentication flow. This created a DLL conflict during `InteractiveBrowserCredential` initialization, preventing successful authentication to Microsoft Graph services.

The ZeroTrustAssessment module uses multiple dependencies (ExchangeOnlineManagement, Az.Accounts, Microsoft.Graph) that all share Microsoft.Identity.Client.dll, making proper version compatibility critical.

## Solution Applied

**File:** `src/powershell/Initialize-Dependencies.ps1` (Lines 102-106)

**Changed from v2.32.0 to v2.35.1:**
```powershell
[Microsoft.PowerShell.Commands.ModuleSpecification[]]$xPlatPowerShellRequiredModules = @(
    @{ModuleName = 'Microsoft.Graph.Authentication'; GUID = '883916f2-9184-46ee-b1f8-b6a2fb784cee'; ModuleVersion = '2.35.1'; },
    @{ModuleName = 'Microsoft.Graph.Beta.Teams'; GUID = 'e264919d-7ae2-4a89-ba8b-524bd93ddc08'; ModuleVersion = '2.35.1'; },
    @{ModuleName = 'Az.Accounts'; GUID = '17a2feff-488b-47f9-8729-e2cec094624c'; ModuleVersion = '4.0.2'; },
    @{ModuleName = 'ExchangeOnlineManagement'; GUID = 'b5eced50-afa4-455b-847a-d8fb64140a22'; RequiredVersion = '3.9.0'; }
)
```

Resolution Results
✅ Authentication to Microsoft Graph services works correctly
✅ MSAL DLL conflicts resolved
✅ All Connect-ZtAssessment service connections functional
✅ Compatible WithLogging method signature now available

### Test Results:

**With 2.32.0:**

<img width="1020" height="172" alt="image" src="https://github.com/user-attachments/assets/6f9fc4d8-7e56-4b6d-962c-b8bba912f9f1" />


**With 2.35.1:**

connect-ZtAssessment
<img width="984" height="434" alt="image" src="https://github.com/user-attachments/assets/5f04fa56-713e-4610-bdfa-08172c2c214a" />

connect-ZtAssessment -service Graph
<img width="980" height="444" alt="image" src="https://github.com/user-attachments/assets/48d22865-7f7e-4357-a758-060221f63add" />
