### PR TITLE
Network-25380: Global Secure Access signaling for Conditional Access is enabled

### DIFF
--- a/src/powershell/tests/Test-Assessment.25380.md
+++ b/src/powershell/tests/Test-Assessment.25380.md
@@ -1,0 +1,12 @@
+When Global Secure Access routes user traffic through Microsoft's Security Service Edge, the original source IP of the user is replaced by the proxy egress IP. If Global Secure Access signaling for Conditional Access is not enabled, Microsoft Entra ID receives the proxy IP instead of the user's IP. Conditional Access policies that rely on named locations or trusted IP ranges evaluate the proxy IP, which does not correspond to the user's location. A threat actor who compromises user credentials can sign in from any location, and the location-based Conditional Access policy will evaluate the proxy IP, not the threat actor's IP, allowing the sign-in to proceed without triggering a location-based block or step-up authentication. In addition, Microsoft Entra ID Protection risk detections that depend on source IP — such as impossible travel, unfamiliar sign-in properties, and anomalous token — operate on the proxy IP, reducing their ability to detect anomalies. Sign-in logs record the proxy IP, which prevents security operations teams from correlating sign-in events to user locations during incident response. Enabling signaling restores the original source IP to Microsoft Entra ID and Microsoft Graph, and allows Conditional Access to enforce compliant network checks, which verify that the user connects through the Global Secure Access tunnel. 
+
+**Remediation actions**
+
+1. [Enable Global Secure Access signaling for Conditional Access in the Microsoft Entra admin center under Global Secure Access > Settings > Session management > Adaptive Access](https://learn.microsoft.com/en-gb/entra/global-secure-access/how-to-source-ip-restoration)
+
+2. [Understand how Universal Conditional Access works with Global Secure Access traffic profiles](https://learn.microsoft.com/en-gb/entra/global-secure-access/concept-universal-conditional-access)
+
+3. [Configure compliant network check to require users to connect through Global Secure Access](https://learn.microsoft.com/en-gb/entra/global-secure-access/how-to-compliant-network)
+
+<!--- Results --->
+%TestResult%

--- a/src/powershell/tests/Test-Assessment.25380.md
+++ b/src/powershell/tests/Test-Assessment.25380.md
@@ -2,11 +2,11 @@ When Global Secure Access routes user traffic through Microsoft's Security Servi
 
 **Remediation actions**
 
-1. [Enable Global Secure Access signaling for Conditional Access in the Microsoft Entra admin center under Global Secure Access > Settings > Session management > Adaptive Access](https://learn.microsoft.com/en-gb/entra/global-secure-access/how-to-source-ip-restoration)
+1. [Enable Global Secure Access signaling for Conditional Access in the Microsoft Entra admin center under Global Secure Access > Settings > Session management > Adaptive Access](https://learn.microsoft.com/entra/global-secure-access/how-to-source-ip-restoration)
 
-2. [Understand how Universal Conditional Access works with Global Secure Access traffic profiles](https://learn.microsoft.com/en-gb/entra/global-secure-access/concept-universal-conditional-access)
+2. [Understand how Universal Conditional Access works with Global Secure Access traffic profiles](https://learn.microsoft.com/entra/global-secure-access/concept-universal-conditional-access)
 
-3. [Configure compliant network check to require users to connect through Global Secure Access](https://learn.microsoft.com/en-gb/entra/global-secure-access/how-to-compliant-network)
+3. [Configure compliant network check to require users to connect through Global Secure Access](https://learn.microsoft.com/entra/global-secure-access/how-to-compliant-network)
 
 <!--- Results --->
 %TestResult%

--- a/src/powershell/tests/Test-Assessment.25380.ps1
+++ b/src/powershell/tests/Test-Assessment.25380.ps1
@@ -43,18 +43,24 @@ function Test-Assessment-25380 {
     #endregion Data Collection
 
     #region Assessment Logic
-    $passed = $caSettings.signalingStatus -eq 'enabled'
-
-    if ($passed) {
-        $testResultMarkdown = "✅ Global Secure Access signaling for Conditional Access is enabled. Source IP restoration and compliant network checks are active.`n`n%TestResult%"
+    if (-not $caSettings) {
+        $passed = $false
+        $testResultMarkdown = "❌ Unable to retrieve Global Secure Access Conditional Access signaling status. The API response was null or failed.`n`n%TestResult%"
     }
     else {
-        $testResultMarkdown = "❌ Global Secure Access signaling for Conditional Access is disabled. Conditional Access policies do not receive source IP or compliant network signals.`n`n%TestResult%"
+        $passed = $caSettings.signalingStatus -eq 'enabled'
+
+        if ($passed) {
+            $testResultMarkdown = "✅ Global Secure Access signaling for Conditional Access is enabled. Source IP restoration and compliant network checks are active.`n`n%TestResult%"
+        }
+        else {
+            $testResultMarkdown = "❌ Global Secure Access signaling for Conditional Access is disabled. Conditional Access policies do not receive source IP or compliant network signals.`n`n%TestResult%"
+        }
     }
     #endregion Assessment Logic
 
     #region Report Generation
-    $signalingIcon = if ($caSettings.signalingStatus -eq 'enabled') { '✅ Enabled' } else { '❌ Disabled' }
+    $signalingIcon = if ($caSettings -and $caSettings.signalingStatus -eq 'enabled') { '✅ Enabled' } else { '❌ Disabled' }
 
     $mdInfo = "`n`n### [Global Secure Access Conditional Access settings](https://entra.microsoft.com/#view/Microsoft_Azure_Network_Access/Security.ReactView)`n"
     $mdInfo += "| Property | Value |`n"

--- a/src/powershell/tests/Test-Assessment.25380.ps1
+++ b/src/powershell/tests/Test-Assessment.25380.ps1
@@ -38,36 +38,54 @@ function Test-Assessment-25380 {
 
     # Q1: Retrieve Global Secure Access Conditional Access signaling status
     Write-ZtProgress -Activity $activity -Status 'Getting Conditional Access signaling settings'
-    $caSettings = Invoke-ZtGraphRequest -RelativeUri 'networkAccess/settings/conditionalAccess' -ApiVersion beta
-    Write-PSFMessage "Signaling status: $($caSettings.signalingStatus)" -Level Verbose
+    $caSettings = $null
+    $errorMsg = $null
+
+    try {
+        $caSettings = Invoke-ZtGraphRequest -RelativeUri 'networkAccess/settings/conditionalAccess' -ApiVersion beta -ErrorAction Stop
+        Write-PSFMessage "Signaling status: $($caSettings.signalingStatus)" -Level Verbose
+    }
+    catch {
+        $errorMsg = $_
+        Write-PSFMessage "Failed to retrieve CA signaling settings: $_" -Level Error
+    }
     #endregion Data Collection
 
     #region Assessment Logic
-    if (-not $caSettings) {
+    if ($errorMsg) {
         $passed = $false
-        $testResultMarkdown = "❌ Unable to retrieve Global Secure Access Conditional Access signaling status. The API response was null or failed.`n`n%TestResult%"
+    }
+    elseif (-not $caSettings -or -not $caSettings.signalingStatus) {
+        # null, blank or missing property likely indicates GSA is not deployed in this tenant
+        Add-ZtTestResultDetail -SkippedBecause NotApplicable
+        return
     }
     else {
         $passed = $caSettings.signalingStatus -eq 'enabled'
+    }
+    #endregion Assessment Logic
 
+    #region Report Generation
+    if ($errorMsg) {
+        $testResultMarkdown = "❌ Unable to retrieve Global Secure Access Conditional Access signaling status.`n`nError: $errorMsg"
+    }
+    else {
         if ($passed) {
             $testResultMarkdown = "✅ Global Secure Access signaling for Conditional Access is enabled. Source IP restoration and compliant network checks are active.`n`n%TestResult%"
         }
         else {
             $testResultMarkdown = "❌ Global Secure Access signaling for Conditional Access is disabled. Conditional Access policies do not receive source IP or compliant network signals.`n`n%TestResult%"
         }
+
+        $signalingIcon = if ($caSettings.signalingStatus -eq 'enabled') { '✅ Enabled' } else { '❌ Disabled' }
+
+        $mdInfo = "`n`n### [Global Secure Access Conditional Access settings](https://entra.microsoft.com/#view/Microsoft_Azure_Network_Access/Security.ReactView)`n"
+        $mdInfo += "| Property | Value |`n"
+        $mdInfo += "| :--- | :--- |`n"
+        $mdInfo += "| Signaling status | $signalingIcon |`n"
+
+        $testResultMarkdown = $testResultMarkdown -replace '%TestResult%', $mdInfo
     }
-    #endregion Assessment Logic
-
-    #region Report Generation
-    $signalingIcon = if ($caSettings -and $caSettings.signalingStatus -eq 'enabled') { '✅ Enabled' } else { '❌ Disabled' }
-
-    $mdInfo = "`n`n### [Global Secure Access Conditional Access settings](https://entra.microsoft.com/#view/Microsoft_Azure_Network_Access/Security.ReactView)`n"
-    $mdInfo += "| Property | Value |`n"
-    $mdInfo += "| :--- | :--- |`n"
-    $mdInfo += "| Signaling status | $signalingIcon |`n"
-
-    $testResultMarkdown = $testResultMarkdown -replace '%TestResult%', $mdInfo
     #endregion Report Generation
 
     $params = @{

--- a/src/powershell/tests/Test-Assessment.25380.ps1
+++ b/src/powershell/tests/Test-Assessment.25380.ps1
@@ -1,0 +1,75 @@
+<#
+.SYNOPSIS
+    Global Secure Access signaling for Conditional Access is enabled
+
+.DESCRIPTION
+    When Global Secure Access routes user traffic through Microsoft's Security Service Edge,
+    the original source IP of the user is replaced by the proxy egress IP. If signaling is not
+    enabled, Conditional Access policies that rely on named locations or trusted IP ranges evaluate
+    the proxy IP, not the user's actual location. Enabling signaling restores the original source IP
+    to Microsoft Entra ID and allows Conditional Access to enforce compliant network checks.
+
+.NOTES
+    Test ID: 25380
+    Pillar: Network
+    Risk Level: Medium
+    Category: Global Secure Access
+#>
+
+function Test-Assessment-25380 {
+    [ZtTest(
+        Category = 'Global Secure Access',
+        ImplementationCost = 'Low',
+        MinimumLicense = ('AAD_PREMIUM', 'Entra_Premium_Internet_Access'),
+        Pillar = 'Network',
+        RiskLevel = 'Medium',
+        SfiPillar = 'Protect networks',
+        TenantType = ('Workforce'),
+        TestId = 25380,
+        Title = 'Global Secure Access signaling for Conditional Access is enabled',
+        UserImpact = 'High'
+    )]
+    [CmdletBinding()]
+    param()
+
+    #region Data Collection
+    Write-PSFMessage '🟦 Start' -Tag Test -Level VeryVerbose
+    $activity = 'Checking Global Secure Access Conditional Access signaling status'
+
+    # Q1: Retrieve Global Secure Access Conditional Access signaling status
+    Write-ZtProgress -Activity $activity -Status 'Getting Conditional Access signaling settings'
+    $caSettings = Invoke-ZtGraphRequest -RelativeUri 'networkAccess/settings/conditionalAccess' -ApiVersion beta
+    Write-PSFMessage "Signaling status: $($caSettings.signalingStatus)" -Level Verbose
+    #endregion Data Collection
+
+    #region Assessment Logic
+    $passed = $caSettings.signalingStatus -eq 'enabled'
+
+    if ($passed) {
+        $testResultMarkdown = "✅ Global Secure Access signaling for Conditional Access is enabled. Source IP restoration and compliant network checks are active.`n`n%TestResult%"
+    }
+    else {
+        $testResultMarkdown = "❌ Global Secure Access signaling for Conditional Access is disabled. Conditional Access policies do not receive source IP or compliant network signals.`n`n%TestResult%"
+    }
+    #endregion Assessment Logic
+
+    #region Report Generation
+    $signalingIcon = if ($caSettings.signalingStatus -eq 'enabled') { '✅ Enabled' } else { '❌ Disabled' }
+
+    $mdInfo = "`n`n### [Global Secure Access Conditional Access settings](https://entra.microsoft.com/#view/Microsoft_Azure_Network_Access/Security.ReactView)`n"
+    $mdInfo += "| Property | Value |`n"
+    $mdInfo += "| :--- | :--- |`n"
+    $mdInfo += "| Signaling status | $signalingIcon |`n"
+
+    $testResultMarkdown = $testResultMarkdown -replace '%TestResult%', $mdInfo
+    #endregion Report Generation
+
+    $params = @{
+        TestId = '25380'
+        Title  = 'Global Secure Access signaling for Conditional Access is enabled'
+        Status = $passed
+        Result = $testResultMarkdown
+    }
+
+    Add-ZtTestResultDetail @params
+}

--- a/src/powershell/tests/Test-Assessment.25380.ps1
+++ b/src/powershell/tests/Test-Assessment.25380.ps1
@@ -53,6 +53,21 @@ function Test-Assessment-25380 {
 
     #region Assessment Logic
     if ($errorMsg) {
+        # Check if error indicates GSA is not provisioned/accessible (404, 403, etc.)
+        $httpStatusCode = $null
+        if ($errorMsg.Exception.Response.StatusCode) {
+            $httpStatusCode = [int]$errorMsg.Exception.Response.StatusCode.value__
+        }
+
+        # 404 (Not Found) or 403 (Forbidden) typically means GSA not provisioned or no permissions
+        if ($httpStatusCode -in @(404, 403)) {
+            Write-PSFMessage "GSA not accessible (HTTP $httpStatusCode) - marking as not applicable" -Level Verbose
+            Add-ZtTestResultDetail -SkippedBecause NotApplicable
+            return
+        }
+
+        # Other errors are actual failures (network issues, API problems, etc.)
+        Write-PSFMessage "Error retrieving GSA settings (not a 404/403) - marking as failed" -Level Error
         $passed = $false
     }
     elseif (-not $caSettings -or -not $caSettings.signalingStatus) {


### PR DESCRIPTION
Network-25380: Global Secure Access signaling for Conditional Access is enabled

[ISSUE#467](https://github.com/microsoft/ztspecs/issues/467)

[SPEC-25380](https://github.com/microsoft/ztspecs/blob/main/specs/network/25380.md)
