### PR TITLE
Add check: Key Vaults have soft-delete and purge protection enabled (#35041)

### DIFF
--- a/src/powershell/tests/Test-Assessment.35041.md
+++ b/src/powershell/tests/Test-Assessment.35041.md
@@ -1,0 +1,44 @@
+Azure Key Vault provides centralized management of cryptographic keys, certificates, and secrets. Soft-delete and purge protection are critical recovery safeguards that prevent permanent loss of vault contents due to accidental or malicious deletion.
+
+**Soft-delete** ensures that deleted vaults and their contents (keys, secrets, certificates) are retained in a recoverable state for a configurable retention period (7–90 days). Without soft-delete, deletion is immediate and irreversible.
+
+**Purge protection** adds an additional layer by preventing even privileged users from permanently purging (force-deleting) a soft-deleted vault before the retention period expires. This is essential for protecting against insider threats and compromised admin accounts.
+
+Without these safeguards:
+- Accidental deletion of a Key Vault results in **permanent loss** of all keys, secrets, and certificates.
+- Applications relying on the vault for encryption, TLS certificates, or connection strings experience **immediate outages**.
+- Recovery may be **impossible**, requiring re-creation of all cryptographic material and reconfiguration of dependent services.
+- A compromised administrator account could **permanently destroy** critical security material.
+
+Note: As of February 2025, Azure enforces soft-delete by default on all new Key Vaults. However, older vaults created before this enforcement may still have soft-delete disabled, and purge protection must always be explicitly enabled.
+
+**Remediation action**
+
+To enable soft-delete and purge protection on existing Key Vaults:
+
+1. Navigate to the [Azure portal Key Vaults blade](https://portal.azure.com/#browse/Microsoft.KeyVault%2Fvaults).
+2. Select each Key Vault and go to **Properties**.
+3. Verify that **Soft-delete** is enabled.
+4. Enable **Purge protection** if it is not already active.
+
+Alternatively, use the Azure CLI:
+
+```bash
+az keyvault update --name <vault-name> --enable-soft-delete true --enable-purge-protection true
+```
+
+Or Azure PowerShell:
+
+```powershell
+Update-AzKeyVault -VaultName <vault-name> -EnableSoftDelete $true -EnablePurgeProtection $true
+```
+
+For more information, refer to the following Microsoft Learn documentation:
+
+- [Azure Key Vault soft-delete overview](https://learn.microsoft.com/en-us/azure/key-vault/general/soft-delete-overview)
+- [Azure Key Vault security features](https://learn.microsoft.com/en-us/azure/key-vault/general/security-features)
+- [Best practices for using Azure Key Vault](https://learn.microsoft.com/en-us/azure/key-vault/general/best-practices)
+- [Azure Key Vault recovery management with soft-delete and purge protection](https://learn.microsoft.com/en-us/azure/key-vault/general/key-vault-recovery)
+
+<!--- Results --->
+%TestResult%

--- a/src/powershell/tests/Test-Assessment.35041.ps1
+++ b/src/powershell/tests/Test-Assessment.35041.ps1
@@ -1,0 +1,155 @@
+<#
+.SYNOPSIS
+    Validates that all Azure Key Vaults have soft-delete and purge protection enabled.
+
+.DESCRIPTION
+    This test checks if all Azure Key Vaults in the tenant have soft-delete enabled
+    and purge protection configured. Without these safeguards, accidental or malicious
+    deletion of Key Vaults can result in permanent loss of cryptographic keys,
+    certificates, and secrets, potentially causing widespread service outages.
+
+.NOTES
+    Test ID: 35041
+    Category: Azure Network Security
+    Required API: Azure Management API - Key Vaults
+#>
+
+function Test-Assessment-35041 {
+    [ZtTest(
+        Category = 'Azure Network Security',
+        ImplementationCost = 'Low',
+        MinimumLicense = ('Azure Key Vault'),
+        Pillar = 'Network',
+        RiskLevel = 'High',
+        SfiPillar = 'Protect networks',
+        TenantType = ('Workforce'),
+        TestId = 35041,
+        Title = 'Key Vaults have soft-delete and purge protection enabled',
+        UserImpact = 'Low'
+    )]
+    [CmdletBinding()]
+    param()
+
+    #region Data Collection
+    Write-PSFMessage '🟦 Start' -Tag Test -Level VeryVerbose
+
+    $activity = 'Checking Key Vault soft-delete and purge protection'
+
+    # Check if connected to Azure
+    Write-ZtProgress -Activity $activity -Status 'Checking Azure connection'
+
+    $azContext = Get-AzContext -ErrorAction SilentlyContinue
+    if (-not $azContext) {
+        Write-PSFMessage 'Not connected to Azure.' -Level Warning
+        Add-ZtTestResultDetail -SkippedBecause NotConnectedAzure
+        return
+    }
+
+    Write-ZtProgress -Activity $activity -Status 'Querying Azure Resource Graph'
+
+    # Query all Key Vaults with their soft-delete and purge protection settings
+    $argQuery = @"
+resources
+| where type =~ 'microsoft.keyvault/vaults'
+| join kind=leftouter (
+    resourcecontainers
+    | where type =~ 'microsoft.resources/subscriptions'
+    | project subscriptionName=name, subscriptionId
+) on subscriptionId
+| project
+    VaultName = name,
+    VaultId = id,
+    SubscriptionName = subscriptionName,
+    SubscriptionId = subscriptionId,
+    Location = location,
+    SoftDeleteEnabled = tobool(properties.enableSoftDelete),
+    PurgeProtectionEnabled = tobool(properties.enablePurgeProtection),
+    SoftDeleteRetentionDays = toint(properties.softDeleteRetentionInDays)
+"@
+
+    $vaults = @()
+    try {
+        $vaults = @(Invoke-ZtAzureResourceGraphRequest -Query $argQuery)
+        Write-PSFMessage "ARG Query returned $($vaults.Count) records" -Tag Test -Level VeryVerbose
+    }
+    catch {
+        Write-PSFMessage "Azure Resource Graph query failed: $($_.Exception.Message)" -Tag Test -Level Warning
+        Add-ZtTestResultDetail -SkippedBecause NotSupported
+        return
+    }
+    #endregion Data Collection
+
+    #region Assessment Logic
+    $passed = $false
+
+    # Skip test if no Key Vaults found
+    if ($vaults.Count -eq 0) {
+        Write-PSFMessage 'No Key Vaults found.' -Tag Test -Level Verbose
+        Add-ZtTestResultDetail -SkippedBecause NotApplicable
+        return
+    }
+
+    # Check if all vaults have both soft-delete and purge protection enabled
+    $nonCompliantVaults = @($vaults | Where-Object {
+        $_.SoftDeleteEnabled -ne $true -or $_.PurgeProtectionEnabled -ne $true
+    })
+
+    $passed = $nonCompliantVaults.Count -eq 0
+
+    if ($passed) {
+        $testResultMarkdown = "✅ All Key Vaults have **soft-delete** and **purge protection** enabled.`n`n%TestResult%"
+    }
+    else {
+        $testResultMarkdown = "❌ One or more Key Vaults do not have **soft-delete** or **purge protection** enabled.`n`n%TestResult%"
+    }
+    #endregion Assessment Logic
+
+    #region Report Generation
+    $mdInfo = ''
+
+    # Table title
+    $reportTitle = 'Key Vault recovery protection'
+    $portalLink = 'https://portal.azure.com/#browse/Microsoft.KeyVault%2Fvaults'
+
+    # Prepare table rows
+    $tableRows = ''
+    foreach ($item in $vaults | Sort-Object SubscriptionName, VaultName) {
+        $vaultLink = "https://portal.azure.com/#resource$($item.VaultId)"
+        $subLink = "https://portal.azure.com/#resource/subscriptions/$($item.SubscriptionId)"
+        $vaultMd = "[$(Get-SafeMarkdown $item.VaultName)]($vaultLink)"
+        $subMd = "[$(Get-SafeMarkdown $item.SubscriptionName)]($subLink)"
+
+        # Calculate status indicators
+        $softDeleteDisplay = if ($item.SoftDeleteEnabled -eq $true) { '✅ Enabled' } else { '❌ Disabled' }
+        $purgeProtectionDisplay = if ($item.PurgeProtectionEnabled -eq $true) { '✅ Enabled' } else { '❌ Disabled' }
+        $retentionDisplay = if ($item.SoftDeleteRetentionDays) { "$($item.SoftDeleteRetentionDays) days" } else { 'N/A' }
+        $overallStatus = if ($item.SoftDeleteEnabled -eq $true -and $item.PurgeProtectionEnabled -eq $true) { '✅' } else { '❌' }
+
+        $tableRows += "| $vaultMd | $subMd | $softDeleteDisplay | $purgeProtectionDisplay | $retentionDisplay | $overallStatus |`n"
+    }
+
+    $formatTemplate = @'
+
+
+## [{0}]({1})
+
+| Vault name | Subscription | Soft-delete | Purge protection | Retention | Status |
+| :--------- | :----------- | :---------: | :--------------: | :-------: | :----: |
+{2}
+
+'@
+
+    $mdInfo = $formatTemplate -f $reportTitle, $portalLink, $tableRows
+
+    $testResultMarkdown = $testResultMarkdown -replace '%TestResult%', $mdInfo
+    #endregion Report Generation
+
+    $params = @{
+        TestId = '35041'
+        Title  = 'Key Vaults have soft-delete and purge protection enabled'
+        Status = $passed
+        Result = $testResultMarkdown
+    }
+
+    Add-ZtTestResultDetail @params
+}


### PR DESCRIPTION
## Summary

Adds a new Azure Network Security check (Test ID: **35041**) that validates all Azure Key Vaults have **soft-delete** and **purge protection** enabled.

## Details

| Attribute | Value |
|---|---|
| **Test ID** | 35041 |
| **Pillar** | Network |
| **Category** | Azure Network Security |
| **Risk Level** | High |
| **Implementation Cost** | Low |
| **User Impact** | Low |

### What it checks
Uses Azure Resource Graph to query all Key Vaults across subscriptions and verifies:
- **Soft-delete** is enabled (prevents permanent deletion)
- **Purge protection** is enabled (prevents force-purge during retention period)

### Report output
Generates a per-vault compliance table with:
- Vault name (linked to Azure Portal)
- Subscription name
- Soft-delete status
- Purge protection status
- Retention period (days)
- Overall compliance status

### Files added
- \src/powershell/tests/Test-Assessment.35041.ps1\ - Assessment logic
- \src/powershell/tests/Test-Assessment.35041.md\ - Remediation guidance with Azure CLI/PowerShell commands and Microsoft Learn links

### Why this matters
Without soft-delete and purge protection, accidental or malicious deletion of Key Vaults results in permanent, irrecoverable loss of cryptographic keys, certificates, and secrets - potentially causing widespread service outages.

### Motivation
This check was adapted from an independent Azure security posture assessment tool covering gaps not currently addressed by the Zero Trust Assessment. The ARG query and assessment logic have been converted to follow the official test format (\[ZtTest()]\ attribute, \Invoke-ZtAzureResourceGraphRequest\, markdown report generation, companion \.md\ remediation file).

---

- [x] Follows one-function-per-file convention
- [x] Includes \[ZtTest()]\ attribute with all required metadata
- [x] Companion \.md\ file with \%TestResult%\ placeholder
- [x] No trailing whitespace
- [x] No syntax errors
- [x] Uses \Invoke-ZtAzureResourceGraphRequest\ for ARG queries
- [ ] Handles skip scenarios (NotConnectedAzure, NotSupported, NotApplicable)