### PR TITLE
Add 6 Azure security checks for Network and Data pillars (#35042-#35047)

### DIFF
--- a/src/powershell/tests/Test-Assessment.35042.md
+++ b/src/powershell/tests/Test-Assessment.35042.md
@@ -1,0 +1,48 @@
+Network Security Groups (NSGs) are a fundamental layer of defense for controlling inbound and outbound network traffic to Azure resources. Allowing inbound traffic on commonly exploited ports creates significant security risks:
+
+- **FTP (port 21)** — Transmits credentials in plaintext, vulnerable to man-in-the-middle attacks.
+- **SSH (port 22)** — While encrypted, direct internet exposure invites brute-force credential attacks.
+- **Telnet (port 23)** — Transmits all data including credentials in plaintext with no encryption.
+- **RPC (ports 135, 139)** — Remote Procedure Call ports frequently exploited for lateral movement.
+- **SMB (port 445)** — Server Message Block is a common vector for ransomware propagation (e.g., WannaCry, NotPetya).
+- **RDP (port 3389)** — Remote Desktop Protocol is one of the most targeted ports for brute-force and credential stuffing attacks.
+- **Wildcard (*)** — Allowing all ports removes all network-level protection.
+
+Zero Trust principles require that network access be explicitly verified and minimally scoped. Instead of exposing these ports directly, use secure alternatives such as Azure Bastion for RDP/SSH access, Just-in-Time (JIT) VM access through Microsoft Defender for Cloud, or Azure Private Link for service connectivity.
+
+**Remediation action**
+
+To secure NSGs with insecure inbound rules:
+
+1. Navigate to the [Azure portal Network Security Groups blade](https://portal.azure.com/#browse/Microsoft.Network%2FnetworkSecurityGroups).
+2. Select each NSG identified in the assessment results.
+3. Go to **Inbound security rules**.
+4. For each insecure rule, either **delete** the rule or **restrict** the source IP addresses to known, trusted ranges.
+5. Replace direct port exposure with secure alternatives:
+   - For RDP/SSH: Use [Azure Bastion](https://learn.microsoft.com/en-us/azure/bastion/bastion-overview) or [JIT VM Access](https://learn.microsoft.com/en-us/azure/defender-for-cloud/just-in-time-access-usage).
+   - For application connectivity: Use [Azure Private Link](https://learn.microsoft.com/en-us/azure/private-link/private-link-overview).
+
+To remove an insecure rule using the Azure CLI:
+
+```bash
+az network nsg rule delete --resource-group <resource-group> --nsg-name <nsg-name> --name <rule-name>
+```
+
+To restrict a rule to specific source IPs using Azure PowerShell:
+
+```powershell
+$nsg = Get-AzNetworkSecurityGroup -Name <nsg-name> -ResourceGroupName <resource-group>
+$rule = $nsg.SecurityRules | Where-Object { $_.Name -eq '<rule-name>' }
+$rule.SourceAddressPrefix = '<trusted-ip-range>'
+Set-AzNetworkSecurityGroup -NetworkSecurityGroup $nsg
+```
+
+For more information, refer to the following Microsoft Learn documentation:
+
+- [Network security groups overview](https://learn.microsoft.com/en-us/azure/virtual-network/network-security-groups-overview)
+- [Azure Bastion overview](https://learn.microsoft.com/en-us/azure/bastion/bastion-overview)
+- [Just-in-Time VM access in Microsoft Defender for Cloud](https://learn.microsoft.com/en-us/azure/defender-for-cloud/just-in-time-access-usage)
+- [Azure network security best practices](https://learn.microsoft.com/en-us/azure/security/fundamentals/network-best-practices)
+
+<!--- Results --->
+%TestResult%

--- a/src/powershell/tests/Test-Assessment.35042.ps1
+++ b/src/powershell/tests/Test-Assessment.35042.ps1
@@ -1,0 +1,174 @@
+<#
+.SYNOPSIS
+    Validates that Network Security Groups do not allow inbound traffic on insecure ports.
+
+.DESCRIPTION
+    This test checks all NSGs across the tenant for inbound Allow rules targeting
+    commonly exploited ports (FTP, Telnet, RDP, SSH, SMB, RPC) or wildcard (*) rules.
+    These ports are frequent attack vectors and should be restricted or replaced with
+    more secure alternatives like Azure Bastion or Just-in-Time VM Access.
+
+.NOTES
+    Test ID: 35042
+    Category: Azure Network Security
+    Required API: Azure Management API - Network Security Groups
+#>
+
+function Test-Assessment-35042 {
+    [ZtTest(
+        Category = 'Azure Network Security',
+        ImplementationCost = 'Medium',
+        MinimumLicense = ('Azure Virtual Network'),
+        Pillar = 'Network',
+        RiskLevel = 'High',
+        SfiPillar = 'Protect networks',
+        TenantType = ('Workforce', 'External'),
+        TestId = 35042,
+        Title = "Network Security Groups do not allow inbound traffic on insecure ports",
+        UserImpact = 'Medium'
+    )]
+    [CmdletBinding()]
+    param()
+
+    #region Data Collection
+    Write-PSFMessage '🟦 Start' -Tag Test -Level VeryVerbose
+
+    $activity = 'Checking NSG inbound rules for insecure ports'
+
+    # Check if connected to Azure
+    Write-ZtProgress -Activity $activity -Status 'Checking Azure connection'
+
+    $azContext = Get-AzContext -ErrorAction SilentlyContinue
+    if (-not $azContext) {
+        Write-PSFMessage 'Not connected to Azure.' -Level Warning
+        Add-ZtTestResultDetail -SkippedBecause NotConnectedAzure
+        return
+    }
+
+    Write-ZtProgress -Activity $activity -Status 'Querying Azure Resource Graph'
+
+    # Query NSGs for inbound Allow rules on insecure ports
+    # Insecure ports: FTP(21), Telnet(23), SSH(22), RDP(3389), SMB(445), RPC(135,139), Wildcard(*)
+    $argQuery = @"
+resources
+| where type =~ 'microsoft.network/networksecuritygroups'
+| join kind=leftouter (
+    resourcecontainers
+    | where type =~ 'microsoft.resources/subscriptions'
+    | project subscriptionName=name, subscriptionId
+) on subscriptionId
+| mv-expand rule = properties.securityRules
+| where rule.properties.access =~ 'Allow'
+    and rule.properties.direction =~ 'Inbound'
+| where rule.properties.destinationPortRange in ('21', '23', '22', '3389', '445', '135', '139', '*')
+| project
+    NsgName = name,
+    NsgId = id,
+    SubscriptionName = subscriptionName,
+    SubscriptionId = subscriptionId,
+    RuleName = tostring(rule.name),
+    Port = tostring(rule.properties.destinationPortRange),
+    Priority = toint(rule.properties.priority),
+    SourceAddress = tostring(rule.properties.sourceAddressPrefix)
+"@
+
+    $rules = @()
+    try {
+        $rules = @(Invoke-ZtAzureResourceGraphRequest -Query $argQuery)
+        Write-PSFMessage "ARG Query returned $($rules.Count) records" -Tag Test -Level VeryVerbose
+    }
+    catch {
+        Write-PSFMessage "Azure Resource Graph query failed: $($_.Exception.Message)" -Tag Test -Level Warning
+        Add-ZtTestResultDetail -SkippedBecause NotSupported
+        return
+    }
+    #endregion Data Collection
+
+    #region Check NSG existence
+    # Also query total NSG count to differentiate "no NSGs" from "no insecure rules"
+    $nsgCountQuery = @"
+resources
+| where type =~ 'microsoft.network/networksecuritygroups'
+| summarize Count=count()
+"@
+
+    $nsgCount = 0
+    try {
+        $nsgResult = @(Invoke-ZtAzureResourceGraphRequest -Query $nsgCountQuery)
+        if ($nsgResult.Count -gt 0) {
+            $nsgCount = $nsgResult[0].Count
+        }
+    }
+    catch {
+        Write-PSFMessage "NSG count query failed: $($_.Exception.Message)" -Tag Test -Level Warning
+    }
+
+    if ($nsgCount -eq 0) {
+        Write-PSFMessage 'No Network Security Groups found.' -Tag Test -Level Verbose
+        Add-ZtTestResultDetail -SkippedBecause NotApplicable
+        return
+    }
+    #endregion Check NSG existence
+
+    #region Assessment Logic
+    $passed = $rules.Count -eq 0
+
+    # Map port numbers to protocol names for readable output
+    $portNames = @{
+        '21'   = 'FTP'
+        '22'   = 'SSH'
+        '23'   = 'Telnet'
+        '135'  = 'RPC'
+        '139'  = 'NetBIOS'
+        '445'  = 'SMB'
+        '3389' = 'RDP'
+        '*'    = 'All Ports'
+    }
+
+    if ($passed) {
+        $testResultMarkdown = "✅ No Network Security Groups allow inbound traffic on insecure ports.`n`n%TestResult%"
+    }
+    else {
+        $testResultMarkdown = "❌ One or more Network Security Groups allow inbound traffic on insecure ports.`n`n%TestResult%"
+    }
+    #endregion Assessment Logic
+
+    #region Report Generation
+    $tableRows = ''
+    foreach ($item in $rules | Sort-Object SubscriptionName, NsgName, Priority) {
+        $nsgLink = "https://portal.azure.com/#resource$($item.NsgId)"
+        $subLink = "https://portal.azure.com/#resource/subscriptions/$($item.SubscriptionId)"
+        $nsgMd = "[$(Get-SafeMarkdown $item.NsgName)]($nsgLink)"
+        $subMd = "[$(Get-SafeMarkdown $item.SubscriptionName)]($subLink)"
+        $protocolName = if ($portNames.ContainsKey($item.Port)) { $portNames[$item.Port] } else { $item.Port }
+        $portDisplay = "❌ $($item.Port) ($protocolName)"
+        $sourceDisplay = if ($item.SourceAddress -eq '*') { 'Any' } else { $item.SourceAddress }
+
+        $tableRows += "| $nsgMd | $subMd | $(Get-SafeMarkdown $item.RuleName) | $portDisplay | $sourceDisplay | $($item.Priority) |`n"
+    }
+
+    $formatTemplate = @'
+
+
+## [{0}]({1})
+
+| NSG name | Subscription | Rule name | Port | Source | Priority |
+| :------- | :----------- | :-------- | :--: | :----- | :------: |
+{2}
+
+'@
+    $reportTitle = 'NSG insecure inbound port rules'
+    $portalLink = 'https://portal.azure.com/#browse/Microsoft.Network%2FnetworkSecurityGroups'
+    $mdInfo = $formatTemplate -f $reportTitle, $portalLink, $tableRows
+
+    $testResultMarkdown = $testResultMarkdown -replace '%TestResult%', $mdInfo
+    #endregion Report Generation
+
+    $params = @{
+        TestId = '35042'
+        Title  = 'Network Security Groups do not allow inbound traffic on insecure ports'
+        Status = $passed
+        Result = $testResultMarkdown
+    }
+    Add-ZtTestResultDetail @params
+}

--- a/src/powershell/tests/Test-Assessment.35043.md
+++ b/src/powershell/tests/Test-Assessment.35043.md
@@ -1,0 +1,43 @@
+Azure Storage Accounts handle critical data including blobs, files, queues, and tables. Enforcing TLS 1.2 as the minimum transport protocol and requiring HTTPS-only traffic are essential encryption-in-transit controls that protect data from interception and tampering.
+
+**TLS 1.0 and 1.1** have known vulnerabilities including BEAST, POODLE, and other cryptographic weaknesses. These older protocols can be exploited to decrypt traffic through downgrade attacks. Microsoft recommends TLS 1.2 as the minimum version for all Azure services.
+
+**HTTP traffic** transmits data in plaintext, allowing any network intermediary to read or modify the contents. Storage account access keys, SAS tokens, and data payloads sent over HTTP are fully exposed.
+
+Without these controls:
+- Attackers on the network path can **intercept storage account credentials** (access keys or SAS tokens) transmitted in plaintext.
+- **Data in transit** (uploads, downloads, API calls) can be read or modified by man-in-the-middle attackers.
+- **Downgrade attacks** can force connections to use weaker TLS versions with known exploits.
+- Regulatory frameworks (PCI DSS, HIPAA, SOC 2) require encryption in transit — non-compliance can result in audit failures.
+
+**Remediation action**
+
+To enforce TLS 1.2 and HTTPS-only on Storage Accounts:
+
+1. Navigate to the [Azure portal Storage Accounts blade](https://portal.azure.com/#browse/Microsoft.Storage%2FStorageAccounts).
+2. Select each Storage Account identified in the assessment results.
+3. Go to **Configuration** under **Settings**.
+4. Set **Minimum TLS version** to **Version 1.2**.
+5. Set **Secure transfer required** to **Enabled**.
+6. Click **Save**.
+
+Using the Azure CLI:
+
+```bash
+az storage account update --name <account-name> --resource-group <resource-group> --min-tls-version TLS1_2 --https-only true
+```
+
+Using Azure PowerShell:
+
+```powershell
+Set-AzStorageAccount -ResourceGroupName <resource-group> -Name <account-name> -MinimumTlsVersion TLS1_2 -EnableHttpsTrafficOnly $true
+```
+
+For more information, refer to the following Microsoft Learn documentation:
+
+- [Enforce a minimum required version of TLS for requests to a storage account](https://learn.microsoft.com/en-us/azure/storage/common/transport-layer-security-configure-minimum-version)
+- [Require secure transfer to ensure secure connections](https://learn.microsoft.com/en-us/azure/storage/common/storage-require-secure-transfer)
+- [Azure Storage security guide](https://learn.microsoft.com/en-us/azure/storage/common/storage-security-guide)
+
+<!--- Results --->
+%TestResult%

--- a/src/powershell/tests/Test-Assessment.35043.ps1
+++ b/src/powershell/tests/Test-Assessment.35043.ps1
@@ -1,0 +1,138 @@
+<#
+.SYNOPSIS
+    Validates that all Azure Storage Accounts enforce minimum TLS 1.2 and HTTPS-only traffic.
+
+.DESCRIPTION
+    This test checks all Storage Accounts across the tenant to verify they enforce
+    TLS 1.2 as the minimum transport protocol and require HTTPS for all traffic.
+    Using older TLS versions or allowing HTTP exposes data in transit to interception
+    and downgrade attacks.
+
+.NOTES
+    Test ID: 35043
+    Category: Azure Data Security
+    Required API: Azure Management API - Storage Accounts
+#>
+
+function Test-Assessment-35043 {
+    [ZtTest(
+        Category = 'Azure Data Security',
+        ImplementationCost = 'Low',
+        MinimumLicense = ('Azure Storage'),
+        Pillar = 'Data',
+        RiskLevel = 'High',
+        SfiPillar = 'Protect networks',
+        TenantType = ('Workforce', 'External'),
+        TestId = 35043,
+        Title = "Storage Accounts enforce minimum TLS 1.2 and HTTPS-only traffic",
+        UserImpact = 'Low'
+    )]
+    [CmdletBinding()]
+    param()
+
+    #region Data Collection
+    Write-PSFMessage '🟦 Start' -Tag Test -Level VeryVerbose
+
+    $activity = 'Checking Storage Account TLS and HTTPS settings'
+
+    Write-ZtProgress -Activity $activity -Status 'Checking Azure connection'
+
+    $azContext = Get-AzContext -ErrorAction SilentlyContinue
+    if (-not $azContext) {
+        Write-PSFMessage 'Not connected to Azure.' -Level Warning
+        Add-ZtTestResultDetail -SkippedBecause NotConnectedAzure
+        return
+    }
+
+    Write-ZtProgress -Activity $activity -Status 'Querying Azure Resource Graph'
+
+    $argQuery = @"
+resources
+| where type =~ 'microsoft.storage/storageaccounts'
+| join kind=leftouter (
+    resourcecontainers
+    | where type =~ 'microsoft.resources/subscriptions'
+    | project subscriptionName=name, subscriptionId
+) on subscriptionId
+| project
+    AccountName = name,
+    AccountId = id,
+    SubscriptionName = subscriptionName,
+    SubscriptionId = subscriptionId,
+    MinTlsVersion = tostring(properties.minimumTlsVersion),
+    HttpsOnly = tobool(properties.supportsHttpsTrafficOnly)
+"@
+
+    $accounts = @()
+    try {
+        $accounts = @(Invoke-ZtAzureResourceGraphRequest -Query $argQuery)
+        Write-PSFMessage "ARG Query returned $($accounts.Count) records" -Tag Test -Level VeryVerbose
+    }
+    catch {
+        Write-PSFMessage "Azure Resource Graph query failed: $($_.Exception.Message)" -Tag Test -Level Warning
+        Add-ZtTestResultDetail -SkippedBecause NotSupported
+        return
+    }
+    #endregion Data Collection
+
+    #region Assessment Logic
+    if ($accounts.Count -eq 0) {
+        Write-PSFMessage 'No Storage Accounts found.' -Tag Test -Level Verbose
+        Add-ZtTestResultDetail -SkippedBecause NotApplicable
+        return
+    }
+
+    $nonCompliant = @($accounts | Where-Object {
+        $_.MinTlsVersion -ne 'TLS1_2' -or $_.HttpsOnly -ne $true
+    })
+
+    $passed = $nonCompliant.Count -eq 0
+
+    if ($passed) {
+        $testResultMarkdown = "✅ All Storage Accounts enforce **TLS 1.2** and **HTTPS-only** traffic.`n`n%TestResult%"
+    }
+    else {
+        $testResultMarkdown = "❌ One or more Storage Accounts do not enforce **TLS 1.2** or **HTTPS-only** traffic.`n`n%TestResult%"
+    }
+    #endregion Assessment Logic
+
+    #region Report Generation
+    $tableRows = ''
+    foreach ($item in $accounts | Sort-Object SubscriptionName, AccountName) {
+        $accountLink = "https://portal.azure.com/#resource$($item.AccountId)"
+        $subLink = "https://portal.azure.com/#resource/subscriptions/$($item.SubscriptionId)"
+        $accountMd = "[$(Get-SafeMarkdown $item.AccountName)]($accountLink)"
+        $subMd = "[$(Get-SafeMarkdown $item.SubscriptionName)]($subLink)"
+
+        $tlsDisplay = if ($item.MinTlsVersion -eq 'TLS1_2') { '✅ TLS 1.2' } else { "❌ $($item.MinTlsVersion)" }
+        $httpsDisplay = if ($item.HttpsOnly -eq $true) { '✅ Enabled' } else { '❌ Disabled' }
+        $overallStatus = if ($item.MinTlsVersion -eq 'TLS1_2' -and $item.HttpsOnly -eq $true) { '✅' } else { '❌' }
+
+        $tableRows += "| $accountMd | $subMd | $tlsDisplay | $httpsDisplay | $overallStatus |`n"
+    }
+
+    $formatTemplate = @'
+
+
+## [{0}]({1})
+
+| Storage account | Subscription | Min TLS version | HTTPS only | Status |
+| :-------------- | :----------- | :-------------: | :--------: | :----: |
+{2}
+
+'@
+    $reportTitle = 'Storage Account encryption in transit'
+    $portalLink = 'https://portal.azure.com/#browse/Microsoft.Storage%2FStorageAccounts'
+    $mdInfo = $formatTemplate -f $reportTitle, $portalLink, $tableRows
+
+    $testResultMarkdown = $testResultMarkdown -replace '%TestResult%', $mdInfo
+    #endregion Report Generation
+
+    $params = @{
+        TestId = '35043'
+        Title  = 'Storage Accounts enforce minimum TLS 1.2 and HTTPS-only traffic'
+        Status = $passed
+        Result = $testResultMarkdown
+    }
+    Add-ZtTestResultDetail @params
+}

--- a/src/powershell/tests/Test-Assessment.35044.md
+++ b/src/powershell/tests/Test-Assessment.35044.md
@@ -1,0 +1,51 @@
+Azure Storage Accounts can contain highly sensitive data including application data, backups, logs, and documents. If public blob access is enabled or network rules are permissive, this data may be accessible to anyone on the internet without authentication.
+
+**Public blob access** allows anonymous users to read data from blob containers that have their access level set to "Blob" or "Container". Even if no containers are currently public, leaving this setting enabled at the account level creates risk — a single misconfigured container can expose all its contents.
+
+**Network default action set to Allow** means the storage account accepts connections from any IP address on the internet. Combined with valid access keys or SAS tokens, this allows data access from anywhere. A Zero Trust approach requires network access to be denied by default and explicitly allowed only for trusted networks, services, or private endpoints.
+
+Without these controls:
+- **Data breaches** from publicly accessible blob containers (a common source of cloud data leaks).
+- **Credential-based attacks** where stolen access keys or SAS tokens can be used from any location.
+- **Lateral movement** where an attacker who compromises one resource can access storage from anywhere.
+- **Compliance violations** with frameworks requiring network-level access controls (PCI DSS, HIPAA, NIST 800-53).
+
+**Remediation action**
+
+To disable public blob access and restrict network access:
+
+1. Navigate to the [Azure portal Storage Accounts blade](https://portal.azure.com/#browse/Microsoft.Storage%2FStorageAccounts).
+2. Select each Storage Account identified in the assessment results.
+3. Go to **Configuration** under **Settings** and set **Allow Blob anonymous access** to **Disabled**.
+4. Go to **Networking** under **Security + networking**.
+5. Set **Public network access** to **Enabled from selected virtual networks and IP addresses** or **Disabled**.
+6. If using selected networks, add the required virtual networks and IP address ranges.
+7. Consider enabling **Private endpoints** for secure access from virtual networks.
+
+Using the Azure CLI:
+
+```bash
+# Disable public blob access
+az storage account update --name <account-name> --resource-group <resource-group> --allow-blob-public-access false
+
+# Set network default action to Deny
+az storage account update --name <account-name> --resource-group <resource-group> --default-action Deny
+```
+
+Using Azure PowerShell:
+
+```powershell
+# Disable public blob access and set network default to Deny
+Set-AzStorageAccount -ResourceGroupName <resource-group> -Name <account-name> -AllowBlobPublicAccess $false
+Update-AzStorageAccountNetworkRuleSet -ResourceGroupName <resource-group> -Name <account-name> -DefaultAction Deny
+```
+
+For more information, refer to the following Microsoft Learn documentation:
+
+- [Remediate anonymous public read access to blob data](https://learn.microsoft.com/en-us/azure/storage/blobs/anonymous-read-access-prevent)
+- [Configure Azure Storage firewalls and virtual networks](https://learn.microsoft.com/en-us/azure/storage/common/storage-network-security)
+- [Use private endpoints for Azure Storage](https://learn.microsoft.com/en-us/azure/storage/common/storage-private-endpoints)
+- [Azure Storage security guide](https://learn.microsoft.com/en-us/azure/storage/common/storage-security-guide)
+
+<!--- Results --->
+%TestResult%

--- a/src/powershell/tests/Test-Assessment.35044.ps1
+++ b/src/powershell/tests/Test-Assessment.35044.ps1
@@ -1,0 +1,140 @@
+<#
+.SYNOPSIS
+    Validates that Azure Storage Accounts have public blob access disabled and network default action set to Deny.
+
+.DESCRIPTION
+    This test checks all Storage Accounts across the tenant to verify that anonymous
+    public blob access is disabled and the network ACL default action is set to Deny.
+    These are core Zero Trust controls ensuring storage is not accessible to the
+    public internet by default.
+
+.NOTES
+    Test ID: 35044
+    Category: Azure Data Security
+    Required API: Azure Management API - Storage Accounts
+#>
+
+function Test-Assessment-35044 {
+    [ZtTest(
+        Category = 'Azure Data Security',
+        ImplementationCost = 'Medium',
+        MinimumLicense = ('Azure Storage'),
+        Pillar = 'Data',
+        RiskLevel = 'High',
+        SfiPillar = 'Protect networks',
+        TenantType = ('Workforce', 'External'),
+        TestId = 35044,
+        Title = "Storage Accounts have public access disabled and network rules configured",
+        UserImpact = 'Medium'
+    )]
+    [CmdletBinding()]
+    param()
+
+    #region Data Collection
+    Write-PSFMessage '🟦 Start' -Tag Test -Level VeryVerbose
+
+    $activity = 'Checking Storage Account public access and network rules'
+
+    Write-ZtProgress -Activity $activity -Status 'Checking Azure connection'
+
+    $azContext = Get-AzContext -ErrorAction SilentlyContinue
+    if (-not $azContext) {
+        Write-PSFMessage 'Not connected to Azure.' -Level Warning
+        Add-ZtTestResultDetail -SkippedBecause NotConnectedAzure
+        return
+    }
+
+    Write-ZtProgress -Activity $activity -Status 'Querying Azure Resource Graph'
+
+    $argQuery = @"
+resources
+| where type =~ 'microsoft.storage/storageaccounts'
+| join kind=leftouter (
+    resourcecontainers
+    | where type =~ 'microsoft.resources/subscriptions'
+    | project subscriptionName=name, subscriptionId
+) on subscriptionId
+| project
+    AccountName = name,
+    AccountId = id,
+    SubscriptionName = subscriptionName,
+    SubscriptionId = subscriptionId,
+    AllowBlobPublicAccess = tobool(properties.allowBlobPublicAccess),
+    NetworkDefaultAction = tostring(properties.networkAcls.defaultAction),
+    PublicNetworkAccess = tostring(properties.publicNetworkAccess)
+"@
+
+    $accounts = @()
+    try {
+        $accounts = @(Invoke-ZtAzureResourceGraphRequest -Query $argQuery)
+        Write-PSFMessage "ARG Query returned $($accounts.Count) records" -Tag Test -Level VeryVerbose
+    }
+    catch {
+        Write-PSFMessage "Azure Resource Graph query failed: $($_.Exception.Message)" -Tag Test -Level Warning
+        Add-ZtTestResultDetail -SkippedBecause NotSupported
+        return
+    }
+    #endregion Data Collection
+
+    #region Assessment Logic
+    if ($accounts.Count -eq 0) {
+        Write-PSFMessage 'No Storage Accounts found.' -Tag Test -Level Verbose
+        Add-ZtTestResultDetail -SkippedBecause NotApplicable
+        return
+    }
+
+    $nonCompliant = @($accounts | Where-Object {
+        $_.AllowBlobPublicAccess -eq $true -or $_.NetworkDefaultAction -ne 'Deny'
+    })
+
+    $passed = $nonCompliant.Count -eq 0
+
+    if ($passed) {
+        $testResultMarkdown = "✅ All Storage Accounts have **public blob access disabled** and **network default action set to Deny**.`n`n%TestResult%"
+    }
+    else {
+        $testResultMarkdown = "❌ One or more Storage Accounts allow **public blob access** or have **permissive network rules**.`n`n%TestResult%"
+    }
+    #endregion Assessment Logic
+
+    #region Report Generation
+    $tableRows = ''
+    foreach ($item in $accounts | Sort-Object SubscriptionName, AccountName) {
+        $accountLink = "https://portal.azure.com/#resource$($item.AccountId)"
+        $subLink = "https://portal.azure.com/#resource/subscriptions/$($item.SubscriptionId)"
+        $accountMd = "[$(Get-SafeMarkdown $item.AccountName)]($accountLink)"
+        $subMd = "[$(Get-SafeMarkdown $item.SubscriptionName)]($subLink)"
+
+        $publicAccessDisplay = if ($item.AllowBlobPublicAccess -ne $true) { '✅ Disabled' } else { '❌ Enabled' }
+        $networkDisplay = if ($item.NetworkDefaultAction -eq 'Deny') { '✅ Deny' } else { '❌ Allow' }
+        $publicNetworkDisplay = if ($item.PublicNetworkAccess -eq 'Disabled') { '✅ Disabled' } else { $item.PublicNetworkAccess }
+        $overallStatus = if ($item.AllowBlobPublicAccess -ne $true -and $item.NetworkDefaultAction -eq 'Deny') { '✅' } else { '❌' }
+
+        $tableRows += "| $accountMd | $subMd | $publicAccessDisplay | $networkDisplay | $publicNetworkDisplay | $overallStatus |`n"
+    }
+
+    $formatTemplate = @'
+
+
+## [{0}]({1})
+
+| Storage account | Subscription | Public blob access | Network default | Public network | Status |
+| :-------------- | :----------- | :----------------: | :-------------: | :------------: | :----: |
+{2}
+
+'@
+    $reportTitle = 'Storage Account network restrictions'
+    $portalLink = 'https://portal.azure.com/#browse/Microsoft.Storage%2FStorageAccounts'
+    $mdInfo = $formatTemplate -f $reportTitle, $portalLink, $tableRows
+
+    $testResultMarkdown = $testResultMarkdown -replace '%TestResult%', $mdInfo
+    #endregion Report Generation
+
+    $params = @{
+        TestId = '35044'
+        Title  = 'Storage Accounts have public access disabled and network rules configured'
+        Status = $passed
+        Result = $testResultMarkdown
+    }
+    Add-ZtTestResultDetail @params
+}

--- a/src/powershell/tests/Test-Assessment.35045.md
+++ b/src/powershell/tests/Test-Assessment.35045.md
@@ -1,0 +1,59 @@
+Azure SQL Server supports two authentication methods: SQL authentication (username/password) and Microsoft Entra ID (formerly Azure AD) authentication. When SQL authentication is enabled alongside Entra ID, the server accepts shared passwords that bypass critical Zero Trust controls.
+
+**SQL authentication** uses static username/password credentials that:
+- Cannot enforce **multi-factor authentication (MFA)**.
+- Are not subject to **Conditional Access policies** (location, device compliance, risk-based controls).
+- Have no centralized **lifecycle management** — passwords don't expire automatically and access isn't revoked when employees leave.
+- Are often **shared** between developers, applications, and scripts, making credential rotation difficult.
+- Can be **brute-forced** if the server is accessible from the internet.
+
+**Entra ID-only authentication** eliminates these risks by requiring all connections to authenticate through Microsoft Entra ID, which provides:
+- Multi-factor authentication enforcement.
+- Conditional Access policy evaluation.
+- Centralized identity governance and access reviews.
+- Managed identities for application-to-database connections (no credentials to manage).
+
+Without Entra ID-only authentication:
+- **Credential theft** of SQL passwords provides persistent database access that is difficult to detect.
+- **No MFA protection** on database connections, even for administrative access.
+- **Compliance gaps** with frameworks requiring strong authentication (NIST 800-53, PCI DSS, SOC 2).
+
+**Remediation action**
+
+To enable Entra ID-only authentication on Azure SQL Servers:
+
+1. Navigate to the [Azure portal SQL Servers blade](https://portal.azure.com/#browse/Microsoft.Sql%2Fservers).
+2. Select each SQL Server identified in the assessment results.
+3. Go to **Microsoft Entra ID** under **Settings**.
+4. Ensure a **Microsoft Entra admin** is configured.
+5. Check **Support only Microsoft Entra authentication for this server**.
+6. Click **Save**.
+
+**Important**: Before enabling Entra ID-only authentication, ensure all applications and users are configured to authenticate using Entra ID credentials or managed identities.
+
+Using the Azure CLI:
+
+```bash
+# Set the Entra ID admin
+az sql server ad-admin create --resource-group <resource-group> --server-name <server-name> --display-name <admin-name> --object-id <admin-object-id>
+
+# Enable Entra ID-only authentication
+az sql server ad-only-auth enable --resource-group <resource-group> --name <server-name>
+```
+
+Using Azure PowerShell:
+
+```powershell
+# Enable Entra ID-only authentication
+Enable-AzSqlServerActiveDirectoryOnlyAuthentication -ResourceGroupName <resource-group> -ServerName <server-name>
+```
+
+For more information, refer to the following Microsoft Learn documentation:
+
+- [Microsoft Entra-only authentication with Azure SQL](https://learn.microsoft.com/en-us/azure/azure-sql/database/authentication-azure-ad-only-authentication)
+- [Configure Microsoft Entra authentication for Azure SQL](https://learn.microsoft.com/en-us/azure/azure-sql/database/authentication-aad-configure)
+- [Use managed identities to access Azure SQL Database](https://learn.microsoft.com/en-us/azure/azure-sql/database/authentication-azure-ad-user-assigned-managed-identity)
+- [Azure SQL security best practices](https://learn.microsoft.com/en-us/azure/azure-sql/database/security-best-practice)
+
+<!--- Results --->
+%TestResult%

--- a/src/powershell/tests/Test-Assessment.35045.ps1
+++ b/src/powershell/tests/Test-Assessment.35045.ps1
@@ -1,0 +1,139 @@
+<#
+.SYNOPSIS
+    Validates that all Azure SQL Servers have Microsoft Entra ID-only authentication enabled.
+
+.DESCRIPTION
+    This test checks all Azure SQL Servers to verify that Entra ID-only authentication
+    is enabled, eliminating SQL authentication with shared passwords. This enforces
+    identity-based access with MFA, conditional access, and centralized lifecycle
+    management — core Zero Trust principles.
+
+.NOTES
+    Test ID: 35045
+    Category: Azure Data Security
+    Required API: Azure Management API - SQL Servers
+#>
+
+function Test-Assessment-35045 {
+    [ZtTest(
+        Category = 'Azure Data Security',
+        ImplementationCost = 'Medium',
+        MinimumLicense = ('Azure SQL Database'),
+        Pillar = 'Data',
+        RiskLevel = 'High',
+        SfiPillar = 'Protect identities and secrets',
+        TenantType = ('Workforce', 'External'),
+        TestId = 35045,
+        Title = "Azure SQL Servers have Entra ID-only authentication enabled",
+        UserImpact = 'Medium'
+    )]
+    [CmdletBinding()]
+    param()
+
+    #region Data Collection
+    Write-PSFMessage '🟦 Start' -Tag Test -Level VeryVerbose
+
+    $activity = 'Checking Azure SQL Server Entra ID-only authentication'
+
+    Write-ZtProgress -Activity $activity -Status 'Checking Azure connection'
+
+    $azContext = Get-AzContext -ErrorAction SilentlyContinue
+    if (-not $azContext) {
+        Write-PSFMessage 'Not connected to Azure.' -Level Warning
+        Add-ZtTestResultDetail -SkippedBecause NotConnectedAzure
+        return
+    }
+
+    Write-ZtProgress -Activity $activity -Status 'Querying Azure Resource Graph'
+
+    $argQuery = @"
+resources
+| where type =~ 'microsoft.sql/servers'
+| join kind=leftouter (
+    resourcecontainers
+    | where type =~ 'microsoft.resources/subscriptions'
+    | project subscriptionName=name, subscriptionId
+) on subscriptionId
+| project
+    ServerName = name,
+    ServerId = id,
+    SubscriptionName = subscriptionName,
+    SubscriptionId = subscriptionId,
+    EntraOnlyAuth = tobool(properties.administrators.azureADOnlyAuthentication),
+    EntraAdminLogin = tostring(properties.administrators.login),
+    EntraAdminType = tostring(properties.administrators.administratorType)
+"@
+
+    $servers = @()
+    try {
+        $servers = @(Invoke-ZtAzureResourceGraphRequest -Query $argQuery)
+        Write-PSFMessage "ARG Query returned $($servers.Count) records" -Tag Test -Level VeryVerbose
+    }
+    catch {
+        Write-PSFMessage "Azure Resource Graph query failed: $($_.Exception.Message)" -Tag Test -Level Warning
+        Add-ZtTestResultDetail -SkippedBecause NotSupported
+        return
+    }
+    #endregion Data Collection
+
+    #region Assessment Logic
+    if ($servers.Count -eq 0) {
+        Write-PSFMessage 'No Azure SQL Servers found.' -Tag Test -Level Verbose
+        Add-ZtTestResultDetail -SkippedBecause NotApplicable
+        return
+    }
+
+    $nonCompliant = @($servers | Where-Object {
+        $_.EntraOnlyAuth -ne $true
+    })
+
+    $passed = $nonCompliant.Count -eq 0
+
+    if ($passed) {
+        $testResultMarkdown = "✅ All Azure SQL Servers have **Entra ID-only authentication** enabled.`n`n%TestResult%"
+    }
+    else {
+        $testResultMarkdown = "❌ One or more Azure SQL Servers allow **SQL authentication** in addition to Entra ID.`n`n%TestResult%"
+    }
+    #endregion Assessment Logic
+
+    #region Report Generation
+    $tableRows = ''
+    foreach ($item in $servers | Sort-Object SubscriptionName, ServerName) {
+        $serverLink = "https://portal.azure.com/#resource$($item.ServerId)"
+        $subLink = "https://portal.azure.com/#resource/subscriptions/$($item.SubscriptionId)"
+        $serverMd = "[$(Get-SafeMarkdown $item.ServerName)]($serverLink)"
+        $subMd = "[$(Get-SafeMarkdown $item.SubscriptionName)]($subLink)"
+
+        $authDisplay = if ($item.EntraOnlyAuth -eq $true) { '✅ Entra ID only' } else { '❌ SQL auth allowed' }
+        $adminDisplay = if ($item.EntraAdminLogin) { Get-SafeMarkdown $item.EntraAdminLogin } else { '⚠️ Not configured' }
+        $overallStatus = if ($item.EntraOnlyAuth -eq $true) { '✅' } else { '❌' }
+
+        $tableRows += "| $serverMd | $subMd | $authDisplay | $adminDisplay | $overallStatus |`n"
+    }
+
+    $formatTemplate = @'
+
+
+## [{0}]({1})
+
+| SQL Server | Subscription | Authentication | Entra admin | Status |
+| :--------- | :----------- | :------------: | :---------- | :----: |
+{2}
+
+'@
+    $reportTitle = 'Azure SQL Server authentication'
+    $portalLink = 'https://portal.azure.com/#browse/Microsoft.Sql%2Fservers'
+    $mdInfo = $formatTemplate -f $reportTitle, $portalLink, $tableRows
+
+    $testResultMarkdown = $testResultMarkdown -replace '%TestResult%', $mdInfo
+    #endregion Report Generation
+
+    $params = @{
+        TestId = '35045'
+        Title  = 'Azure SQL Servers have Entra ID-only authentication enabled'
+        Status = $passed
+        Result = $testResultMarkdown
+    }
+    Add-ZtTestResultDetail @params
+}

--- a/src/powershell/tests/Test-Assessment.35046.md
+++ b/src/powershell/tests/Test-Assessment.35046.md
@@ -1,0 +1,65 @@
+Microsoft Defender for Cloud provides advanced threat detection and security monitoring for Azure data services. When Defender plans are not enabled (set to "Free" tier), organizations lose critical security capabilities including real-time threat detection, vulnerability assessment, and anomaly detection for their data workloads.
+
+The following Defender for Cloud data service plans provide distinct protection:
+
+- **Defender for Storage** — Detects unusual access patterns, suspicious data exfiltration, malware uploads, and anomalous blob/file operations. Includes malware scanning and sensitive data threat detection.
+- **Defender for Azure SQL** — Identifies SQL injection attacks, anomalous database access, brute-force attempts, and suspicious database activities. Includes vulnerability assessment to find misconfigurations.
+- **Defender for Cosmos DB** — Detects potential SQL injection, known bad actors, suspicious access patterns, and potential exploitation of compromised identities to access databases.
+- **Defender for SQL on VMs** — Extends SQL protection to SQL Server instances running on Azure Virtual Machines with the same threat detection and vulnerability assessment capabilities.
+- **Defender for Open-Source Relational Databases** — Protects Azure Database for PostgreSQL, MySQL, and MariaDB with anomaly detection and threat intelligence.
+
+Without these plans enabled:
+- **No threat detection** for data-layer attacks such as SQL injection, credential stuffing, or data exfiltration.
+- **No vulnerability assessment** to identify misconfigurations in database security settings.
+- **No anomaly detection** for unusual data access patterns that may indicate compromised credentials.
+- **Delayed incident response** due to lack of automated security alerts for data services.
+
+**Remediation action**
+
+To enable Defender for Cloud plans for data services:
+
+1. Navigate to the [Azure portal Defender for Cloud pricing blade](https://portal.azure.com/#blade/Microsoft_Azure_Security/SecurityMenuBlade/pricingTier).
+2. For each subscription, enable the following plans by setting them to **On** (Standard tier):
+   - **Storage Accounts**
+   - **SQL Servers**
+   - **Cosmos DB**
+   - **SQL Server on VMs**
+   - **Open-Source Relational Databases**
+3. Click **Save** for each subscription.
+
+Using the Azure CLI:
+
+```bash
+# Enable Defender for Storage
+az security pricing create --name StorageAccounts --tier Standard
+
+# Enable Defender for Azure SQL
+az security pricing create --name SqlServers --tier Standard
+
+# Enable Defender for Cosmos DB
+az security pricing create --name CosmosDbs --tier Standard
+
+# Enable Defender for SQL on VMs
+az security pricing create --name SqlServerVirtualMachines --tier Standard
+```
+
+Using Azure PowerShell:
+
+```powershell
+# Enable Defender plans for data services
+Set-AzSecurityPricing -Name 'StorageAccounts' -PricingTier 'Standard'
+Set-AzSecurityPricing -Name 'SqlServers' -PricingTier 'Standard'
+Set-AzSecurityPricing -Name 'CosmosDbs' -PricingTier 'Standard'
+Set-AzSecurityPricing -Name 'SqlServerVirtualMachines' -PricingTier 'Standard'
+```
+
+For more information, refer to the following Microsoft Learn documentation:
+
+- [Microsoft Defender for Cloud overview](https://learn.microsoft.com/en-us/azure/defender-for-cloud/defender-for-cloud-introduction)
+- [Defender for Storage overview](https://learn.microsoft.com/en-us/azure/defender-for-cloud/defender-for-storage-introduction)
+- [Defender for Azure SQL overview](https://learn.microsoft.com/en-us/azure/defender-for-cloud/defender-for-sql-introduction)
+- [Defender for Cosmos DB overview](https://learn.microsoft.com/en-us/azure/defender-for-cloud/concept-defender-for-cosmos)
+- [Enable Defender for Cloud plans](https://learn.microsoft.com/en-us/azure/defender-for-cloud/enable-enhanced-security)
+
+<!--- Results --->
+%TestResult%

--- a/src/powershell/tests/Test-Assessment.35046.ps1
+++ b/src/powershell/tests/Test-Assessment.35046.ps1
@@ -1,0 +1,144 @@
+<#
+.SYNOPSIS
+    Validates that Microsoft Defender for Cloud is enabled for data services (Storage, SQL, Cosmos DB).
+
+.DESCRIPTION
+    This test checks whether Defender for Cloud threat protection plans are enabled
+    (Standard tier) for data-related Azure services including Storage Accounts,
+    SQL Servers, Cosmos DB, and SQL Server on Virtual Machines. These plans provide
+    advanced threat detection, vulnerability assessment, and anomaly detection for
+    data workloads.
+
+.NOTES
+    Test ID: 35046
+    Category: Azure Data Security
+    Required API: Azure Management API - Security Pricings
+#>
+
+function Test-Assessment-35046 {
+    [ZtTest(
+        Category = 'Azure Data Security',
+        ImplementationCost = 'Medium',
+        MinimumLicense = ('Microsoft Defender for Cloud'),
+        Pillar = 'Data',
+        RiskLevel = 'High',
+        SfiPillar = 'Detect and respond to threats',
+        TenantType = ('Workforce', 'External'),
+        TestId = 35046,
+        Title = "Defender for Cloud is enabled for data services",
+        UserImpact = 'Low'
+    )]
+    [CmdletBinding()]
+    param()
+
+    #region Data Collection
+    Write-PSFMessage '🟦 Start' -Tag Test -Level VeryVerbose
+
+    $activity = 'Checking Defender for Cloud data service plans'
+
+    Write-ZtProgress -Activity $activity -Status 'Checking Azure connection'
+
+    $azContext = Get-AzContext -ErrorAction SilentlyContinue
+    if (-not $azContext) {
+        Write-PSFMessage 'Not connected to Azure.' -Level Warning
+        Add-ZtTestResultDetail -SkippedBecause NotConnectedAzure
+        return
+    }
+
+    Write-ZtProgress -Activity $activity -Status 'Querying Azure Resource Graph'
+
+    # Query Defender for Cloud pricing tiers for data-related services
+    $argQuery = @"
+securityresources
+| where type =~ 'microsoft.security/pricings'
+| where name in~ ('StorageAccounts', 'SqlServers', 'CosmosDbs', 'SqlServerVirtualMachines', 'OpenSourceRelationalDatabases')
+| project
+    PlanName = name,
+    PlanId = id,
+    SubscriptionId = subscriptionId,
+    PricingTier = tostring(properties.pricingTier),
+    SubPlan = tostring(properties.subPlan),
+    FreeTrialRemaining = tostring(properties.freeTrialRemainingTime)
+"@
+
+    $plans = @()
+    try {
+        $plans = @(Invoke-ZtAzureResourceGraphRequest -Query $argQuery)
+        Write-PSFMessage "ARG Query returned $($plans.Count) records" -Tag Test -Level VeryVerbose
+    }
+    catch {
+        Write-PSFMessage "Azure Resource Graph query failed: $($_.Exception.Message)" -Tag Test -Level Warning
+        Add-ZtTestResultDetail -SkippedBecause NotSupported
+        return
+    }
+    #endregion Data Collection
+
+    #region Assessment Logic
+    if ($plans.Count -eq 0) {
+        Write-PSFMessage 'No Defender for Cloud pricing data found.' -Tag Test -Level Verbose
+        Add-ZtTestResultDetail -SkippedBecause NotApplicable
+        return
+    }
+
+    $nonCompliant = @($plans | Where-Object {
+        $_.PricingTier -ne 'Standard'
+    })
+
+    $passed = $nonCompliant.Count -eq 0
+
+    # Friendly display names for plan names
+    $planDisplayNames = @{
+        'StorageAccounts'               = 'Defender for Storage'
+        'SqlServers'                    = 'Defender for Azure SQL'
+        'CosmosDbs'                     = 'Defender for Cosmos DB'
+        'SqlServerVirtualMachines'      = 'Defender for SQL on VMs'
+        'OpenSourceRelationalDatabases' = 'Defender for Open-Source DBs'
+    }
+
+    if ($passed) {
+        $testResultMarkdown = "✅ **Defender for Cloud** is enabled (Standard tier) for all data services.`n`n%TestResult%"
+    }
+    else {
+        $testResultMarkdown = "❌ One or more **Defender for Cloud** data service plans are not enabled.`n`n%TestResult%"
+    }
+    #endregion Assessment Logic
+
+    #region Report Generation
+    $tableRows = ''
+    foreach ($item in $plans | Sort-Object SubscriptionId, PlanName) {
+        $subLink = "https://portal.azure.com/#resource/subscriptions/$($item.SubscriptionId)"
+        $subMd = "[$(Get-SafeMarkdown $item.SubscriptionId)]($subLink)"
+        $displayName = if ($planDisplayNames.ContainsKey($item.PlanName)) { $planDisplayNames[$item.PlanName] } else { $item.PlanName }
+
+        $tierDisplay = if ($item.PricingTier -eq 'Standard') { '✅ Standard' } else { '❌ Free' }
+        $subPlanDisplay = if ($item.SubPlan) { $item.SubPlan } else { 'N/A' }
+        $overallStatus = if ($item.PricingTier -eq 'Standard') { '✅' } else { '❌' }
+
+        $tableRows += "| $displayName | $subMd | $tierDisplay | $subPlanDisplay | $overallStatus |`n"
+    }
+
+    $formatTemplate = @'
+
+
+## [{0}]({1})
+
+| Defender plan | Subscription | Pricing tier | Sub-plan | Status |
+| :------------ | :----------- | :----------: | :------- | :----: |
+{2}
+
+'@
+    $reportTitle = 'Defender for Cloud data service plans'
+    $portalLink = 'https://portal.azure.com/#blade/Microsoft_Azure_Security/SecurityMenuBlade/pricingTier'
+    $mdInfo = $formatTemplate -f $reportTitle, $portalLink, $tableRows
+
+    $testResultMarkdown = $testResultMarkdown -replace '%TestResult%', $mdInfo
+    #endregion Report Generation
+
+    $params = @{
+        TestId = '35046'
+        Title  = 'Defender for Cloud is enabled for data services'
+        Status = $passed
+        Result = $testResultMarkdown
+    }
+    Add-ZtTestResultDetail @params
+}

--- a/src/powershell/tests/Test-Assessment.35047.md
+++ b/src/powershell/tests/Test-Assessment.35047.md
@@ -1,0 +1,53 @@
+Recovery Services Vaults store backup data for Azure VMs, SQL databases, file shares, and on-premises workloads. Without immutability and soft-delete protections, backup data is vulnerable to deletion by ransomware, malicious insiders, or compromised administrator accounts — the exact scenarios where backups are most needed.
+
+**Immutability** prevents backup data from being modified or deleted before a specified retention period expires. When immutability is enabled, even subscription owners and Microsoft support cannot delete backup data prematurely. When set to "Locked" state, immutability becomes irreversible and provides the highest level of protection.
+
+**Soft-delete** retains deleted backup data for an additional retention period (default 14 days) after deletion, allowing recovery from accidental or malicious deletion. Without soft-delete, deleting a backup item permanently removes all recovery points immediately.
+
+Without these protections:
+- **Ransomware** operators routinely target backups for deletion before encrypting production data, eliminating the primary recovery mechanism.
+- **Compromised admin accounts** can permanently delete backup data, leaving no path to recovery.
+- **Accidental deletion** of backup policies or protected items results in immediate, irreversible loss of all recovery points.
+- **Insider threats** can destroy backup data to cover tracks after data theft or sabotage.
+
+**Remediation action**
+
+To enable immutability and soft-delete on Recovery Services Vaults:
+
+1. Navigate to the [Azure portal Recovery Services Vaults blade](https://portal.azure.com/#browse/Microsoft.RecoveryServices%2Fvaults).
+2. Select each vault identified in the assessment results.
+3. Go to **Properties** under **Settings**.
+4. Under **Security Settings**, click **Update**.
+5. Enable **Soft delete** for backup items.
+6. Enable **Immutability** and set the appropriate retention period.
+7. Click **Update** to save.
+
+**Note**: Once immutability is set to "Locked" state, it cannot be reversed. Start with "Enabled" state and move to "Locked" after validating configuration.
+
+Using the Azure CLI:
+
+```bash
+# Enable soft-delete (enabled by default on new vaults)
+az backup vault backup-properties set --name <vault-name> --resource-group <resource-group> --soft-delete-feature-state Enable
+
+# Enable immutability
+az backup vault backup-properties set --name <vault-name> --resource-group <resource-group> --is-immutability-enabled true
+```
+
+Using Azure PowerShell:
+
+```powershell
+# Enable soft-delete and immutability
+Set-AzRecoveryServicesVaultProperty -VaultId <vault-id> -SoftDeleteFeatureState Enable
+Update-AzRecoveryServicesVault -ResourceGroupName <resource-group> -Name <vault-name> -ImmutabilityState Unlocked
+```
+
+For more information, refer to the following Microsoft Learn documentation:
+
+- [Soft delete for Azure Backup](https://learn.microsoft.com/en-us/azure/backup/backup-azure-security-feature-cloud)
+- [Immutable vaults for Azure Backup](https://learn.microsoft.com/en-us/azure/backup/backup-azure-immutable-vault-concept)
+- [Security features for protecting hybrid backups](https://learn.microsoft.com/en-us/azure/backup/security-overview)
+- [Best practices for Azure Backup](https://learn.microsoft.com/en-us/azure/backup/guidance-best-practices)
+
+<!--- Results --->
+%TestResult%

--- a/src/powershell/tests/Test-Assessment.35047.ps1
+++ b/src/powershell/tests/Test-Assessment.35047.ps1
@@ -1,0 +1,143 @@
+<#
+.SYNOPSIS
+    Validates that Recovery Services Vaults have immutability and soft-delete enabled.
+
+.DESCRIPTION
+    This test checks all Recovery Services Vaults across the tenant to verify that
+    immutability settings and soft-delete are enabled. These are critical ransomware
+    resilience controls that prevent attackers from deleting or modifying backup data
+    even with compromised admin credentials.
+
+.NOTES
+    Test ID: 35047
+    Category: Azure Data Security
+    Required API: Azure Management API - Recovery Services Vaults
+#>
+
+function Test-Assessment-35047 {
+    [ZtTest(
+        Category = 'Azure Data Security',
+        ImplementationCost = 'Low',
+        MinimumLicense = ('Azure Backup'),
+        Pillar = 'Data',
+        RiskLevel = 'High',
+        SfiPillar = 'Protect networks',
+        TenantType = ('Workforce', 'External'),
+        TestId = 35047,
+        Title = "Recovery Services Vaults have immutability and soft-delete enabled",
+        UserImpact = 'Low'
+    )]
+    [CmdletBinding()]
+    param()
+
+    #region Data Collection
+    Write-PSFMessage '🟦 Start' -Tag Test -Level VeryVerbose
+
+    $activity = 'Checking Recovery Services Vault immutability and soft-delete'
+
+    Write-ZtProgress -Activity $activity -Status 'Checking Azure connection'
+
+    $azContext = Get-AzContext -ErrorAction SilentlyContinue
+    if (-not $azContext) {
+        Write-PSFMessage 'Not connected to Azure.' -Level Warning
+        Add-ZtTestResultDetail -SkippedBecause NotConnectedAzure
+        return
+    }
+
+    Write-ZtProgress -Activity $activity -Status 'Querying Azure Resource Graph'
+
+    $argQuery = @"
+resources
+| where type =~ 'microsoft.recoveryservices/vaults'
+| join kind=leftouter (
+    resourcecontainers
+    | where type =~ 'microsoft.resources/subscriptions'
+    | project subscriptionName=name, subscriptionId
+) on subscriptionId
+| project
+    VaultName = name,
+    VaultId = id,
+    SubscriptionName = subscriptionName,
+    SubscriptionId = subscriptionId,
+    ImmutabilityState = tostring(properties.securitySettings.immutabilitySettings.state),
+    SoftDeleteState = tostring(properties.securitySettings.softDeleteSettings.softDeleteState),
+    SoftDeleteRetentionDays = toint(properties.securitySettings.softDeleteSettings.softDeleteRetentionPeriodInDays)
+"@
+
+    $vaults = @()
+    try {
+        $vaults = @(Invoke-ZtAzureResourceGraphRequest -Query $argQuery)
+        Write-PSFMessage "ARG Query returned $($vaults.Count) records" -Tag Test -Level VeryVerbose
+    }
+    catch {
+        Write-PSFMessage "Azure Resource Graph query failed: $($_.Exception.Message)" -Tag Test -Level Warning
+        Add-ZtTestResultDetail -SkippedBecause NotSupported
+        return
+    }
+    #endregion Data Collection
+
+    #region Assessment Logic
+    if ($vaults.Count -eq 0) {
+        Write-PSFMessage 'No Recovery Services Vaults found.' -Tag Test -Level Verbose
+        Add-ZtTestResultDetail -SkippedBecause NotApplicable
+        return
+    }
+
+    # A vault is compliant if immutability is enabled (Enabled or Locked) and soft-delete is enabled
+    $nonCompliant = @($vaults | Where-Object {
+        ($_.ImmutabilityState -ne 'Enabled' -and $_.ImmutabilityState -ne 'Locked') -or
+        ($_.SoftDeleteState -ne 'Enabled' -and $_.SoftDeleteState -ne 'AlwaysOn')
+    })
+
+    $passed = $nonCompliant.Count -eq 0
+
+    if ($passed) {
+        $testResultMarkdown = "✅ All Recovery Services Vaults have **immutability** and **soft-delete** enabled.`n`n%TestResult%"
+    }
+    else {
+        $testResultMarkdown = "❌ One or more Recovery Services Vaults do not have **immutability** or **soft-delete** enabled.`n`n%TestResult%"
+    }
+    #endregion Assessment Logic
+
+    #region Report Generation
+    $tableRows = ''
+    foreach ($item in $vaults | Sort-Object SubscriptionName, VaultName) {
+        $vaultLink = "https://portal.azure.com/#resource$($item.VaultId)"
+        $subLink = "https://portal.azure.com/#resource/subscriptions/$($item.SubscriptionId)"
+        $vaultMd = "[$(Get-SafeMarkdown $item.VaultName)]($vaultLink)"
+        $subMd = "[$(Get-SafeMarkdown $item.SubscriptionName)]($subLink)"
+
+        $immutabilityDisplay = if ($item.ImmutabilityState -in @('Enabled', 'Locked')) { "✅ $($item.ImmutabilityState)" } else { "❌ $($item.ImmutabilityState)" }
+        $softDeleteDisplay = if ($item.SoftDeleteState -in @('Enabled', 'AlwaysOn')) { "✅ $($item.SoftDeleteState)" } else { "❌ $($item.SoftDeleteState)" }
+        $retentionDisplay = if ($item.SoftDeleteRetentionDays) { "$($item.SoftDeleteRetentionDays) days" } else { 'N/A' }
+        $isCompliant = ($item.ImmutabilityState -in @('Enabled', 'Locked')) -and ($item.SoftDeleteState -in @('Enabled', 'AlwaysOn'))
+        $overallStatus = if ($isCompliant) { '✅' } else { '❌' }
+
+        $tableRows += "| $vaultMd | $subMd | $immutabilityDisplay | $softDeleteDisplay | $retentionDisplay | $overallStatus |`n"
+    }
+
+    $formatTemplate = @'
+
+
+## [{0}]({1})
+
+| Vault name | Subscription | Immutability | Soft-delete | Retention | Status |
+| :--------- | :----------- | :----------: | :---------: | :-------: | :----: |
+{2}
+
+'@
+    $reportTitle = 'Recovery Services Vault protection'
+    $portalLink = 'https://portal.azure.com/#browse/Microsoft.RecoveryServices%2Fvaults'
+    $mdInfo = $formatTemplate -f $reportTitle, $portalLink, $tableRows
+
+    $testResultMarkdown = $testResultMarkdown -replace '%TestResult%', $mdInfo
+    #endregion Report Generation
+
+    $params = @{
+        TestId = '35047'
+        Title  = 'Recovery Services Vaults have immutability and soft-delete enabled'
+        Status = $passed
+        Result = $testResultMarkdown
+    }
+    Add-ZtTestResultDetail @params
+}


### PR DESCRIPTION
## Summary

Adds 6 new Azure security checks across the **Network** and **Data** preview pillars, expanding coverage for Azure infrastructure-level security posture.

## New Checks

| Test ID | Pillar | Category | Title | Risk |
|---------|--------|----------|-------|------|
| **35042** | Network | Azure Network Security | NSG insecure inbound port detection | High |
| **35043** | Data | Azure Data Security | Storage Account TLS 1.2 and HTTPS-only enforcement | High |
| **35044** | Data | Azure Data Security | Storage Account public blob access and network rules | High |
| **35045** | Data | Azure Data Security | Azure SQL Server Entra ID-only authentication | High |
| **35046** | Data | Azure Data Security | Defender for Cloud enabled for data services | High |
| **35047** | Data | Azure Data Security | Recovery Services Vault immutability and soft-delete | High |

## Details

### 35042 — NSG Insecure Inbound Port Detection (Network)
Queries all NSGs for inbound Allow rules on commonly exploited ports: FTP (21), Telnet (23), SSH (22), RDP (3389), SMB (445), RPC (135/139), and wildcard (\*). Reports each insecure rule with NSG name, rule name, port, source, and priority.

### 35043 — Storage Account TLS/HTTPS (Data)
Validates all Storage Accounts enforce minimum TLS 1.2 and HTTPS-only traffic. Reports per-account TLS version and HTTPS status.

### 35044 — Storage Account Network Restrictions (Data)
Checks that public blob access is disabled (\llowBlobPublicAccess=false\) and network ACL default action is Deny. Reports per-account public access and network rule settings.

### 35045 — SQL Entra ID-Only Authentication (Data)
Validates all Azure SQL Servers have Entra ID-only authentication enabled, eliminating SQL auth with shared passwords. Reports per-server auth mode and Entra admin configuration.

### 35046 — Defender for Cloud Data Plans (Data)
Verifies Defender for Cloud protection plans are enabled (Standard tier) for Storage Accounts, SQL Servers, Cosmos DB, SQL Server VMs, and Open-Source Relational Databases. Reports per-plan tier status.

### 35047 — Recovery Services Vault Protection (Data)
Checks that all Recovery Services Vaults have immutability and soft-delete enabled — critical ransomware resilience controls. Reports per-vault immutability state, soft-delete state, and retention period.

## Implementation Pattern

All 6 checks follow the same established pattern:
- \[ZtTest()]\ attribute with all required metadata (TestId, Title, Pillar, TenantType, ImplementationCost, RiskLevel, UserImpact)
- Azure Resource Graph queries via \Invoke-ZtAzureResourceGraphRequest\
- Per-resource markdown report tables with Azure Portal deep links
- Skip scenarios: \NotConnectedAzure\, \NotSupported\, \NotApplicable\
- Companion \.md\ files with remediation guidance, Azure CLI/PowerShell commands, and Microsoft Learn links

## Files Added (12 files)

| File | Purpose |
|------|---------|
| \src/powershell/tests/Test-Assessment.35042.ps1\ | NSG insecure ports check |
| \src/powershell/tests/Test-Assessment.35042.md\ | NSG remediation guidance |
| \src/powershell/tests/Test-Assessment.35043.ps1\ | Storage TLS/HTTPS check |
| \src/powershell/tests/Test-Assessment.35043.md\ | Storage TLS remediation |
| \src/powershell/tests/Test-Assessment.35044.ps1\ | Storage network rules check |
| \src/powershell/tests/Test-Assessment.35044.md\ | Storage network remediation |
| \src/powershell/tests/Test-Assessment.35045.ps1\ | SQL Entra auth check |
| \src/powershell/tests/Test-Assessment.35045.md\ | SQL auth remediation |
| \src/powershell/tests/Test-Assessment.35046.ps1\ | Defender data plans check |
| \src/powershell/tests/Test-Assessment.35046.md\ | Defender plans remediation |
| \src/powershell/tests/Test-Assessment.35047.ps1\ | Backup vault protection check |
| \src/powershell/tests/Test-Assessment.35047.md\ | Backup vault remediation |

## Motivation

These checks were adapted from an independent Azure security posture assessment tool covering gaps not currently addressed by the Zero Trust Assessment. The existing 40 Data pillar tests focus entirely on Purview/M365 information protection — these 5 new Data checks add Azure infrastructure-level data security coverage. The Network check fills a fundamental gap in NSG hygiene.

---

### Compliance Checklist
- [x] One function per file
- [x] \[ZtTest()]\ with all required metadata fields
- [x] Matching \.ps1\ and \.md\ file pairs
- [x] No trailing whitespace
- [x] No syntax errors
- [x] No banned commands
- [x] Unique function names
- [x] Uses \Invoke-ZtAzureResourceGraphRequest\ for ARG queries
- [x] Uses \Get-SafeMarkdown\ for safe markdown rendering
- [x] Handles all skip scenarios
- [x] Remediation \.md\ files with \%TestResult%\ placeholder