### PR TITLE
adding timeout to test run

### DIFF
--- a/src/powershell/private/core/Add-ZtTestResultDetail.ps1
+++ b/src/powershell/private/core/Add-ZtTestResultDetail.ps1
@@ -67,7 +67,7 @@ function Add-ZtTestResultDetail {
 
 		[ValidateSet('NotConnectedAzure', 'NotConnectedExchange', 'NotConnectedSecurityCompliance', 'NotConnectedToService', 'NotLicensedEntraIDP1',
 		    'NotLicensedEntraIDP2', 'NotLicensedEntraIDGovernance', 'NotLicensedEntraWorkloadID', 'NotSupported', 'UnderConstruction',
-			'NotLicensedIntune', 'NoAzureAccess', 'NotApplicable', 'NotDotGovDomain', 'NoCompatibleLicenseFound'
+			'NotLicensedIntune', 'NoAzureAccess', 'NotApplicable', 'NotDotGovDomain', 'NoCompatibleLicenseFound', 'TimeoutReached'
 		)]
 		[string] $SkippedBecause,
 

--- a/src/powershell/private/core/Get-ZtSkippedReason.ps1
+++ b/src/powershell/private/core/Get-ZtSkippedReason.ps1
@@ -24,6 +24,7 @@ function Get-ZtSkippedReason {
         "NotApplicable" { "This test is not applicable to the current environment."; break}
         "NotConnectedToService" { "This test requires connection to the service(s) `"{0}`" currently disconnected.  Please use _Connect-ZtAssessment_ to connect."; break}
         "NoCompatibleLicenseFound" { "This test requires one of the following licenses: (`"{0}`").  Please ensure your tenant has the appropriate licenses to run this test."; break}
+        "TimeoutReached" { "This test was not completed because the report execution exceeded the expected time frame. This could be due to a large number of objects in the tenants. Please consider adding ``-Timeout '03:00:00:00'`` to ``Invoke-ZtAssessment``."; break}
         default { $SkippedBecause; break}
     }
 }

--- a/src/powershell/private/tests/Invoke-ZtTests.ps1
+++ b/src/powershell/private/tests/Invoke-ZtTests.ps1
@@ -20,6 +20,14 @@
 		Maximum number of tests processed in parallel.
 		Defaults to: 5
 
+	.PARAMETER LogsPath
+		Optional path to output logs for each test. If not specified, logs will not be written
+		to disk but will still be available in the database.
+
+	.PARAMETER Timeout
+		The maximum time to wait for all tests to complete before giving up and writing a warning message.
+		Defaults to: 24 hours. Adjust this value if you have a large number of tests or expect some tests to take a long time.
+
 	.PARAMETER ConnectedService
 		The services that are connected and can be used for testing.
 		This is used to skip tests that require a service connection when the service is not connected.
@@ -52,7 +60,10 @@
 		[Parameter(DontShow)]
 		[ValidateSet('Graph', 'Azure', 'AipService', 'ExchangeOnline', 'SecurityCompliance', 'SharePointOnline')]
 		[string[]]
-		$ConnectedService = $script:ConnectedService
+		$ConnectedService = $script:ConnectedService,
+
+		[TimeSpan]
+		$Timeout = '00:24:00:00'
 	)
 
 	# Get Tenant Type (AAD = Workforce, CIAM = EEID)
@@ -99,6 +110,7 @@
 	$syncTests     = $testsToRun.Where{ $_.TestId -in $syncTestIds }
 	$parallelTests = $testsToRun.Where{ $_.TestId -notin $syncTestIds }
 
+	[dateTime] $startTime = [datetime]::Now
 	$workflow = $null
 	try {
 		# Run Sync Tests in the main thread
@@ -109,7 +121,11 @@
 		# Then run Parallel Tests
 		if ($parallelTests) {
 			$workflow = Start-ZtTestExecution -Tests $parallelTests -DbPath $Database.Database -ThrottleLimit $ThrottleLimit -LogsPath $LogsPath
-			Wait-ZtTest -Workflow $workflow
+			Wait-ZtTest -Workflow $workflow -StartedAt $startTime -Timeout $Timeout
+			$workflow.Queues['Input'].ForEach{
+				Write-PSFMessage -Level Debug -Message "Test $_ was not processed before timeout was reached."
+				Add-ZtTestResultDetail -SkippedBecause TimeoutReached -TestId $_
+			}
 		}
 	}
 	finally {

--- a/src/powershell/private/tests/Start-ZtTestExecution.ps1
+++ b/src/powershell/private/tests/Start-ZtTestExecution.ps1
@@ -85,6 +85,7 @@
 			Variables     = $variables
 			CloseOutQueue = $true
 			Modules       = $modules
+			KillToStop	  = $true
 		}
 	}
 

--- a/src/powershell/private/tests/Wait-ZtTest.ps1
+++ b/src/powershell/private/tests/Wait-ZtTest.ps1
@@ -9,6 +9,12 @@
 	.PARAMETER Workflow
 		The PSFramework Runspace Workflow executing the tests.
 
+	.PARAMETER Timeout
+		The maximum time to wait for the workflow to complete before giving up and writing a warning message
+
+	.PARAMETER StartedAt
+		The DateTime when the workflow started. This is used in combination with Timeout to determine if the workflow has exceeded the allowed time.
+
 	.EXAMPLE
 		PS C:\> Wait-ZtTest -Workflow $workflow
 
@@ -18,7 +24,13 @@
 	param (
 		[Parameter(Mandatory = $true)]
 		[PSFramework.Runspace.RSWorkflow]
-		$Workflow
+		$Workflow,
+
+		[TimeSpan]
+		$Timeout = '00:24:00:00',
+
+		[datetime]
+		$StartedAt = [DateTime]::Now
 	)
 	Begin {
 		$failedTests = @{}
@@ -27,8 +39,7 @@
 	}
 	process {
 		Write-Progress -Id $progressID -Activity "Processing $($totalCount) Tests" -PercentComplete 0
-		$lastTest = "Starting..."
-		while (-not $Workflow.Queues["Results"].Closed) {
+		while (-not $Workflow.Queues["Results"].Closed -and $Timeout -gt ([DateTime]::Now - $StartedAt)) {
 			Start-Sleep -Milliseconds 500
 
 			$failed = Get-ZtTestStatistics | Where-Object Success -eq $false
@@ -44,6 +55,10 @@
 			$status = "Completed: $($Workflow.Queues["Results"].Count) / $totalCount"
 
 			Write-Progress -Id $progressID -Activity "Processing $($totalCount) Tests" -Status $status -PercentComplete $percent
+		}
+
+		if ($Timeout -le ([DateTime]::Now - $StartedAt)) {
+			Write-PSFMessage -Level Warning -Message "Timeout of $($Timeout) reached while waiting for tests to complete. Processed $($Workflow.Queues["Results"].Count) out of $totalCount tests (left $($Workflow.Queues["Input"].Count) to process)." -Target $Workflow
 		}
 
 		Write-Progress -Id $progressID -Activity "Processing $($totalCount) Tests" -Completed

--- a/src/powershell/public/Invoke-ZtAssessment.ps1
+++ b/src/powershell/public/Invoke-ZtAssessment.ps1
@@ -41,6 +41,10 @@ Raising this number may improve performance, but risk hitting throttling limits.
 Maximum number of tests processed in parallel.
 Raising this number may improve performance, but risk hitting throttling limits.
 
+.PARAMETER Timeout
+	The maximum time to wait for all tests to complete before giving up and writing a warning message.
+	Defaults to: 24 hours. Adjust this value if you have a large number of tests or expect some tests to take a long time.
+
 .EXAMPLE
 Invoke-ZtAssessment
 
@@ -151,7 +155,10 @@ function Invoke-ZtAssessment {
 		$ExportThrottleLimit = (Get-PSFConfigValue -FullName 'ZeroTrustAssessment.ThrottleLimit.Export' -Fallback 5),
 
 		[int]
-		$TestThrottleLimit = (Get-PSFConfigValue -FullName 'ZeroTrustAssessment.ThrottleLimit.Tests' -Fallback 5)
+		$TestThrottleLimit = (Get-PSFConfigValue -FullName 'ZeroTrustAssessment.ThrottleLimit.Tests' -Fallback 5),
+
+		[TimeSpan]
+		$Timeout = '00:24:00:00'
 	)
 
 	if ($script:ConnectedService -and $script:ConnectedService.Count -le 0) {
@@ -409,7 +416,7 @@ function Invoke-ZtAssessment {
 
 	# Run the tests
 	Write-PSFMessage -Message "Stage 2: Running Tests" -Tag stage
-	Invoke-ZtTests -Database $database -Tests $Tests -Pillar $Pillar -ThrottleLimit $TestThrottleLimit -LogsPath $logsPath
+	Invoke-ZtTests -Database $database -Tests $Tests -Pillar $Pillar -ThrottleLimit $TestThrottleLimit -LogsPath $logsPath -Timeout $Timeout
 	Write-PSFMessage -Message "Stage 3: Adding Tenant Information" -Tag stage
 	Invoke-ZtTenantInfo -Database $database -Pillar $Pillar
 


### PR DESCRIPTION
The timeout is evaluated only when the parallel tests have been queued, but is calculated from the beginning of the test run.
The default is 24 hours but can be passed as parameter to `Invoke-ZtAssessment`.