### PR TITLE
BugFix - Timestamp handling in Get-ZtSignInDuration function

### DIFF
--- a/src/powershell/private/tenantinfo/Get-ZtSignInDuration.ps1
+++ b/src/powershell/private/tenantinfo/Get-ZtSignInDuration.ps1
@@ -15,9 +15,9 @@ function Get-ZtSignInDuration {
 
 	$sql = @"
 select
-    datediff('minute', min(createdDateTime), max(createdDateTime)) as 'minutes',
-    datediff('hour', min(createdDateTime), max(createdDateTime)) as 'hours',
-    datediff('day', min(createdDateTime), max(createdDateTime)) as 'days',
+    datediff('minute', min(createdDateTime::TIMESTAMP), max(createdDateTime::TIMESTAMP)) as 'minutes',
+    datediff('hour', min(createdDateTime::TIMESTAMP), max(createdDateTime::TIMESTAMP)) as 'hours',
+    datediff('day', min(createdDateTime::TIMESTAMP), max(createdDateTime::TIMESTAMP)) as 'days',
 from SignIn
 "@
 


### PR DESCRIPTION
Fix #1026 

This pull request makes a minor update to the SQL query in the `Get-ZtSignInDuration` PowerShell function to improve date handling. The change ensures that the `createdDateTime` field is explicitly cast to the `TIMESTAMP` type before calculating date differences.

- Updated the SQL query in `Get-ZtSignInDuration.ps1` to cast `createdDateTime` as `TIMESTAMP` in `datediff` calculations, improving accuracy and compatibility.