### PR TITLE
Fix handling of empty SignIn table in Get-ZtSignInDuration function

### DIFF
--- a/src/powershell/private/tenantinfo/Get-ZtSignInDuration.ps1
+++ b/src/powershell/private/tenantinfo/Get-ZtSignInDuration.ps1
@@ -23,6 +23,12 @@ from SignIn
 
 	$results = Invoke-DatabaseQuery -Database $Database -Sql $sql
 
+	# Handle empty SignIn table (e.g., when export times out)
+	if ($null -eq $results -or $results.minutes -is [System.DBNull]) {
+		$script:__ZtSession.SignInLogDuration = "0 duration"
+		return $script:__ZtSession.SignInLogDuration
+	}
+
 	$duration = 0
 	if ($results.days -gt 0) {
 		$duration = $results.days


### PR DESCRIPTION
This pull request adds error handling to the `Get-ZtSignInDuration.ps1` script to address cases where the `SignIn` table is empty, such as when an export operation times out.

Error handling improvements:

* Added a check for empty or null results from the `SignIn` table, setting `SignInLogDuration` to `"0 duration"` and returning early if no data is found.