### PR TITLE
Enhance database export functionality to include 'Network'

### DIFF
--- a/src/powershell/assets/export-tenant.config.psd1
+++ b/src/powershell/assets/export-tenant.config.psd1
@@ -78,7 +78,7 @@ Note: Avoid using the same names as used for the "General Parameters" section of
 	RelatedPropertyNames = @()
 	Type = 'Default' # PrivilegedGroup
 
-	Pillar = 'Identity'
+	Pillar = @('Identity', 'Network')
 	# Environment = $null # 'Global'
 	# IncludePlan = @('Free') # P2, Governance
 	# ExcludePlan = @('Free') # Free
@@ -91,7 +91,7 @@ Note: Avoid using the same names as used for the "General Parameters" section of
 	RelatedPropertyNames = @('oauth2PermissionGrants')
 	Type = 'Default' # PrivilegedGroup
 
-	Pillar = 'Identity'
+	Pillar = @('Identity', 'Network')
 	# Environment = $null # 'Global'
 	# IncludePlan = @('Free') # P2, Governance
 	# ExcludePlan = @('Free') # Free
@@ -117,7 +117,7 @@ Note: Avoid using the same names as used for the "General Parameters" section of
 	RelatedPropertyNames = @()
 	Type = 'Default' # PrivilegedGroup
 
-	Pillar = 'Identity'
+	Pillar = @('Identity', 'Network')
 	# Environment = $null # 'Global'
 	# IncludePlan = @() # P2, Governance
 	ExcludePlan = @('Free') # Free
@@ -130,7 +130,7 @@ Note: Avoid using the same names as used for the "General Parameters" section of
 	RelatedPropertyNames = @()
 	Type = 'Default' # PrivilegedGroup
 
-	Pillar = 'Identity'
+	Pillar = @('Identity', 'Network')
 	# Environment = $null # 'Global'
 	IncludePlan = @('Free') # P2, Governance
 	# ExcludePlan = @('Free') # Free
@@ -156,7 +156,7 @@ Note: Avoid using the same names as used for the "General Parameters" section of
 	RelatedPropertyNames = @()
 	Type = 'Default' # PrivilegedGroup
 
-	Pillar = 'Identity'
+	Pillar = @('Identity', 'Network')
 	# Environment = 'Global' # 'Global'
 	# IncludePlan = @('Free') # P2, Governance
 	# ExcludePlan = @('Free') # Free
@@ -169,7 +169,7 @@ Note: Avoid using the same names as used for the "General Parameters" section of
 	RelatedPropertyNames = @()
 	Type = 'Default' # PrivilegedGroup
 
-	Pillar = 'Identity'
+	Pillar = @('Identity', 'Network')
 	# Environment = 'Global' # 'Global'
 	# IncludePlan = @('Free') # P2, Governance
 	# ExcludePlan = @('Free') # Free
@@ -182,7 +182,7 @@ Note: Avoid using the same names as used for the "General Parameters" section of
 	RelatedPropertyNames = @()
 	Type = 'Default' # PrivilegedGroup
 
-	Pillar = 'Identity'
+	Pillar = @('Identity', 'Network')
 	# Environment = 'Global' # 'Global'
 	IncludePlan = @('P2', 'Governance') # P2, Governance
 	# ExcludePlan = @('Free') # Free
@@ -195,7 +195,7 @@ Note: Avoid using the same names as used for the "General Parameters" section of
 	RelatedPropertyNames = @()
 	Type = 'Default' # PrivilegedGroup
 
-	Pillar = 'Identity'
+	Pillar = @('Identity', 'Network')
 	# Environment = 'Global' # 'Global'
 	IncludePlan = @('P2', 'Governance') # P2, Governance
 	# ExcludePlan = @('Free') # Free
@@ -237,7 +237,7 @@ They will block their worker until their dependency is completed and could risk 
 	InputName = 'RoleAssignment'
 	Type = 'PrivilegedGroup' # PrivilegedGroup
 
-	Pillar = 'Identity'
+	Pillar = @('Identity', 'Network')
 	# Environment = 'Global' # 'Global'
 	# IncludePlan = @('P2', 'Governance') # P2, Governance
 	# ExcludePlan = @('Free') # Free
@@ -249,7 +249,7 @@ They will block their worker until their dependency is completed and could risk 
 	InputName = 'RoleEligibilityScheduleInstance'
 	Type = 'PrivilegedGroup' # PrivilegedGroup
 
-	Pillar = 'Identity'
+	Pillar = @('Identity', 'Network')
 	# Environment = 'Global' # 'Global'
 	IncludePlan = @('P2', 'Governance') # P2, Governance
 	# ExcludePlan = @('Free') # Free
@@ -262,7 +262,7 @@ They will block their worker until their dependency is completed and could risk 
 	InputName = 'RoleAssignmentScheduleInstance'
 	Type = 'PrivilegedGroup' # PrivilegedGroup
 
-	Pillar = 'Identity'
+	Pillar = @('Identity', 'Network')
 	# Environment = 'Global' # 'Global'
 	IncludePlan = @('P2', 'Governance') # P2, Governance
 	# ExcludePlan = @('Free') # Free

--- a/src/powershell/private/db/engine/Connect-Database.ps1
+++ b/src/powershell/private/db/engine/Connect-Database.ps1
@@ -60,7 +60,13 @@
 
 	Write-PSFMessage -Level System -Message 'Establishing a DuckDB connection against {0}' -StringValues $Path -Tag DB
     $database = [DuckDB.NET.Data.DuckDBConnection]::new("Data Source=$Path")
-    $database.Open()
+    try {
+        $database.Open()
+    }
+    catch {
+        $database.Dispose()
+        throw
+    }
     if ($PassThru -or $Transient) {$database}
 	if (-not $Transient) {
 		if ($script:_DatabaseConnection) {

--- a/src/powershell/private/export/Export-Database.ps1
+++ b/src/powershell/private/export/Export-Database.ps1
@@ -94,7 +94,7 @@ function Export-Database {
 		)
 
 		$sql = @"
-create view vwRole
+create or replace view vwRole
 as
 
 "@
@@ -162,6 +162,21 @@ as
 	if ($Pillar -in ('All', 'Devices')) {
 		Import-EntraTable -Database $database -ExportPath $ExportPath -TableName 'Device'
 		Import-EntraTable -Database $database -ExportPath $ExportPath -TableName 'ConfigurationPolicy'
+	}
+
+	if ($Pillar -in ('All', 'Network')) {
+		Import-EntraTable -Database $database -ExportPath $ExportPath -TableName 'User'
+		Import-EntraTable -Database $database -ExportPath $ExportPath -TableName 'Application'
+		Import-EntraTable -Database $database -ExportPath $ExportPath -TableName 'ServicePrincipal'
+		Import-EntraTable -Database $database -ExportPath $ExportPath -TableName 'RoleDefinition'
+		Import-EntraTable -Database $database -ExportPath $ExportPath -TableName 'RoleAssignment'
+		Import-EntraTable -Database $database -ExportPath $ExportPath -TableName 'RoleAssignmentGroup'
+		Import-EntraTable -Database $database -ExportPath $ExportPath -TableName 'RoleAssignmentScheduleInstance'
+		Import-EntraTable -Database $database -ExportPath $ExportPath -TableName 'RoleAssignmentScheduleInstanceGroup'
+		Import-EntraTable -Database $database -ExportPath $ExportPath -TableName 'RoleEligibilityScheduleInstance'
+		Import-EntraTable -Database $database -ExportPath $ExportPath -TableName 'RoleEligibilityScheduleInstanceGroup'
+
+		New-ViewRole -Database $database
 	}
 
 	$database

--- a/src/powershell/private/export/Export-ZtTenantData.ps1
+++ b/src/powershell/private/export/Export-ZtTenantData.ps1
@@ -85,6 +85,7 @@ function Export-ZtTenantData {
 		Stop-PSFFunction -Message "Error resuming export! Previously exported data was created for another tenant then the currently connected one! Previous: $($previousTenantID) | Current: $($graphContext.TenantId)" -EnableException $true -Cmdlet $PSCmdlet
 	}
 	Set-ZtConfig -ExportPath $ExportPath -Property TenantID -Value $graphContext.TenantId
+	Set-ZtConfig -ExportPath $ExportPath -Property Pillar -Value $Pillar
 
 
 	# Data that may be inserted into configured exports with placeholders
@@ -111,7 +112,7 @@ https://github.com/microsoft/zerotrustassessment/issues
 "@ -Target $exportCfg -Tag config, error, fail, devfail
 			continue
 		}
-		if ($Pillar -notcontains 'All' -and $Pillar -notcontains $exportCfg.Pillar) { continue }
+		if ($Pillar -ne 'All' -and $exportCfg.Pillar -notcontains $Pillar) { continue }
 		if ($exportCfg.Environment -and $exportCfg.Environment -notcontains $azureEnvironment) { continue }
 		if ($exportCfg.IncludePlan -and $entraIDPlan -notin $exportCfg.IncludePlan) { continue }
 		if ($exportCfg.ExcludePlan -and $entraIDPlan -in $exportCfg.IncludePlan) { continue }

--- a/src/powershell/public/Invoke-ZtAssessment.ps1
+++ b/src/powershell/public/Invoke-ZtAssessment.ps1
@@ -64,7 +64,7 @@ Invoke-ZtAssessment -Path "C:\Reports\ZT" -Days 7 -ShowLog
 Run the Zero Trust Assessment with a custom output path, querying 7 days of logs, and showing detailed logging.
 
 .PARAMETER Pillar
-The Zero Trust pillar to assess. Valid values are 'All', 'Identity', or 'Devices'. Defaults to 'All' which runs all tests.
+The Zero Trust pillar to assess. Valid values are 'All', 'Identity', 'Devices', 'Network', or 'Data'. Defaults to 'All' which runs all tests.
 
 .EXAMPLE
 Invoke-ZtAssessment -ConfigurationFile "C:\Config\zt-config.json"
@@ -346,6 +346,10 @@ function Invoke-ZtAssessment {
 		return
 	}
 
+	# Resolve to absolute paths so .NET APIs (DuckDB, System.IO) use the correct location.
+	# .NET resolves relative paths against [Environment]::CurrentDirectory, which can differ
+	# from PowerShell's Get-Location after Set-Location / cd.
+	$Path = $PSCmdlet.GetUnresolvedProviderPathFromPSPath($Path)
 	$exportPath = Join-Path $Path "zt-export"
 	$dbPath = Join-Path $exportPath 'db' 'zt.db'
 
@@ -428,6 +432,17 @@ function Invoke-ZtAssessment {
 	if ($Resume) {
 		if (-not (Test-Path $dbPath -PathType Leaf)) {
 			throw "Resume requested, but no existing database was found at '$dbPath'. Run without -Resume first, or restore the previous export/database."
+		}
+
+		# Guard: verify the requested pillar is compatible with the exported data
+		$exportedPillar = Get-ZtConfig -ExportPath $exportPath -Property Pillar
+		if ($exportedPillar -and $exportedPillar -ne $Pillar) {
+			if ($Pillar -eq 'All' -and $exportedPillar -ne 'All') {
+				throw "Resume requested with -Pillar All, but the existing export only contains '$exportedPillar' data. Run without -Resume to export all pillars."
+			}
+			if ($exportedPillar -ne 'All' -and $Pillar -ne $exportedPillar) {
+				throw "Resume requested with -Pillar $Pillar, but the existing export was created with -Pillar $exportedPillar. Run without -Resume or use -Pillar $exportedPillar."
+			}
 		}
 
 		Write-PSFMessage -Message "Stage 1: Reusing Existing Export and Database" -Tag stage


### PR DESCRIPTION
This pull request extends the "Network" pillar support throughout the Zero Trust Assessment PowerShell scripts and configuration, ensuring that data export, database import, and resume logic all correctly handle the "Network" pillar. It also improves error handling and path resolution for database operations.

Key changes:

**Network Pillar Integration:**

* Updated all relevant entries in `export-tenant.config.psd1` so that the `Pillar` property now includes both `'Identity'` and `'Network'` where appropriate, enabling export and assessment of "Network" pillar data.
* Modified `Export-Database.ps1` to import all "Network" pillar-related tables and create views when the pillar is "Network" or "All".
* Updated parameter documentation to list "Network" as a valid pillar option in `Invoke-ZtAssessment.ps1`.

**Export/Resume Logic Improvements:**

* Added logic to store the pillar used during export in the config and to check for pillar compatibility when resuming an export, preventing mismatches between requested and existing data. [[1]](diffhunk://#diff-5d65e65fea129e5e7087738ad711e6d648e109fcdcbcdce72425eb685314d405R88) [[2]](diffhunk://#diff-229324f00e6bd3960e55fb257e3bb6d5af6be8a13ec1c9a8f460c4c71f3ef416R437-R447)

**Database and Path Handling:**

* Ensured that paths are resolved to absolute paths before being used by .NET APIs to avoid issues with relative paths in `Invoke-ZtAssessment.ps1`.
* Improved error handling in `Connect-Database.ps1` to dispose of DuckDB connections if opening fails.

**Database Export Enhancements:**

* Changed view creation in `Export-Database.ps1` to use `create or replace view` for idempotency.

**Export Filtering Logic:**

* Fixed logic for filtering exports by pillar to correctly handle the new pillar array structure.