### PR TITLE
Network 26879: Request Body Inspection is enabled in Application Gateway WAF - Updated Pass/Fail Logic

### DIFF
--- a/src/powershell/tests/Test-Assessment.26879.ps1
+++ b/src/powershell/tests/Test-Assessment.26879.ps1
@@ -61,7 +61,7 @@ resources
     | extend wafPolicyId = tolower(tostring(properties.firewallPolicy.id))
     | project wafPolicyId, GatewayName=name
 ) on wafPolicyId
-| summarize ApplicationGateways=make_list(GatewayName), PolicyName=any(name), subscriptionId=any(subscriptionId), PolicyId=any(id), RequestBodyCheck=any(tobool(properties.policySettings.requestBodyCheck)), EnabledState=any(tostring(properties.policySettings.state)), Mode=any(tostring(properties.policySettings.mode)) by wafPolicyId
+| summarize ApplicationGateways=make_list(GatewayName), PolicyName=any(name), subscriptionId=any(subscriptionId), PolicyId=any(id), RequestBodyCheck=any(properties.policySettings.requestBodyCheck), EnabledState=any(tostring(properties.policySettings.state)), Mode=any(tostring(properties.policySettings.mode)) by wafPolicyId
 | join kind=leftouter (
     resourcecontainers
     | where type =~ 'microsoft.resources/subscriptions'
@@ -89,14 +89,18 @@ resources
         return
     }
 
-    # Check if all policies have request body inspection enabled
-    $passed = ($policies | Where-Object { $_.RequestBodyCheck -ne $true }).Count -eq 0
+    # Check if all policies meet all three conditions: Enabled state, Prevention mode, and Request Body Check
+    $passed = ($policies | Where-Object {
+        $_.EnabledState -ne 'Enabled' -or
+        $_.Mode -ne 'Prevention' -or
+        -not $_.RequestBodyCheck
+    }).Count -eq 0
 
     if ($passed) {
-        $testResultMarkdown = "✅ All Application Gateway WAF policies attached to Application Gateways have request body inspection enabled.`n`n%TestResult%"
+        $testResultMarkdown = "✅ All Application Gateway WAF policies attached to Application Gateways are enabled, running in Prevention mode, and have request body inspection enabled.`n`n%TestResult%"
     }
     else {
-        $testResultMarkdown = "❌ One or more Application Gateway WAF policies attached to Application Gateways have request body inspection disabled.`n`n%TestResult%"
+        $testResultMarkdown = "❌ One or more Application Gateway WAF policies attached to Application Gateways are disabled, running in Detection mode, or have request body inspection disabled, leaving applications vulnerable to body-based attacks that bypass WAF rule evaluation.`n`n%TestResult%"
     }
     #endregion Assessment Logic
 
@@ -119,10 +123,10 @@ resources
         $appGwMd = @($item.ApplicationGateways | ForEach-Object { Get-SafeMarkdown $_ }) -join ', '
 
         # Calculate status indicators
-        $requestBodyCheckDisplay = if ($item.RequestBodyCheck -eq $true) { '✅ Enabled' } else { '❌ Disabled' }
+        $requestBodyCheckDisplay = if ($item.RequestBodyCheck) { '✅ Enabled' } else { '❌ Disabled' }
         $enabledStateDisplay = if ($item.EnabledState -eq 'Enabled') { '✅ Enabled' } else { '❌ Disabled' }
         $modeDisplay = if ($item.Mode -eq 'Prevention') { '✅ Prevention' } else { "⚠️ $($item.Mode)" }
-        $status = if ($item.RequestBodyCheck -eq $true) { '✅ Pass' } else { '❌ Fail' }
+        $status = if ($item.EnabledState -eq 'Enabled' -and $item.Mode -eq 'Prevention' -and $item.RequestBodyCheck) { '✅ Pass' } else { '❌ Fail' }
 
         $tableRows += "| $policyMd | $subMd | $appGwMd | $enabledStateDisplay | $modeDisplay | $requestBodyCheckDisplay | $status |`n"
     }

--- a/src/powershell/tests/Test-Assessment.26879.ps1
+++ b/src/powershell/tests/Test-Assessment.26879.ps1
@@ -61,7 +61,7 @@ resources
     | extend wafPolicyId = tolower(tostring(properties.firewallPolicy.id))
     | project wafPolicyId, GatewayName=name
 ) on wafPolicyId
-| summarize ApplicationGateways=make_list(GatewayName), PolicyName=any(name), subscriptionId=any(subscriptionId), PolicyId=any(id), RequestBodyCheck=any(properties.policySettings.requestBodyCheck), EnabledState=any(tostring(properties.policySettings.state)), Mode=any(tostring(properties.policySettings.mode)) by wafPolicyId
+| summarize ApplicationGateways=make_list(GatewayName), PolicyName=any(name), subscriptionId=any(subscriptionId), PolicyId=any(id), RequestBodyCheck=any(tobool(properties.policySettings.requestBodyCheck)), EnabledState=any(tostring(properties.policySettings.state)), Mode=any(tostring(properties.policySettings.mode)) by wafPolicyId
 | join kind=leftouter (
     resourcecontainers
     | where type =~ 'microsoft.resources/subscriptions'
@@ -93,7 +93,7 @@ resources
     $passed = ($policies | Where-Object {
         $_.EnabledState -ne 'Enabled' -or
         $_.Mode -ne 'Prevention' -or
-        -not $_.RequestBodyCheck
+        $_.RequestBodyCheck -ne $true
     }).Count -eq 0
 
     if ($passed) {
@@ -123,10 +123,10 @@ resources
         $appGwMd = @($item.ApplicationGateways | ForEach-Object { Get-SafeMarkdown $_ }) -join ', '
 
         # Calculate status indicators
-        $requestBodyCheckDisplay = if ($item.RequestBodyCheck) { '✅ Enabled' } else { '❌ Disabled' }
+        $requestBodyCheckDisplay = if ($item.RequestBodyCheck -eq $true) { '✅ Enabled' } else { '❌ Disabled' }
         $enabledStateDisplay = if ($item.EnabledState -eq 'Enabled') { '✅ Enabled' } else { '❌ Disabled' }
         $modeDisplay = if ($item.Mode -eq 'Prevention') { '✅ Prevention' } else { "⚠️ $($item.Mode)" }
-        $status = if ($item.EnabledState -eq 'Enabled' -and $item.Mode -eq 'Prevention' -and $item.RequestBodyCheck) { '✅ Pass' } else { '❌ Fail' }
+        $status = if ($item.EnabledState -eq 'Enabled' -and $item.Mode -eq 'Prevention' -and $item.RequestBodyCheck -eq $true) { '✅ Pass' } else { '❌ Fail' }
 
         $tableRows += "| $policyMd | $subMd | $appGwMd | $enabledStateDisplay | $modeDisplay | $requestBodyCheckDisplay | $status |`n"
     }


### PR DESCRIPTION
This PR updates the pass/fail evaluation logic for Application Gateway WAF policies.

Previously, the check only validated whether `policySettings.requestBodyCheck` was set to `true`. The logic has now been enhanced to also verify that `policySettings.state` is `Enabled` and `policySettings.mode` is `Prevention`.

A policy will now Pass only if all three conditions are met, and Fail if any of them are not satisfied.