### PR TITLE
Added Compatible License attribute for network tests (GSA)

### DIFF
--- a/src/powershell/private/tests/Invoke-ZtTests.ps1
+++ b/src/powershell/private/tests/Invoke-ZtTests.ps1
@@ -108,7 +108,7 @@
 	# Filter based on Compatible licenses
 	$skippedTestsForLicense = $testsToRun.Where{$_.CompatibleLicense.Count -gt 0 -and (-not (Test-ZtLicense -CompatibleLicense $_.CompatibleLicense)) }
 	$skippedTestsForLicense.ForEach{
-		Write-Warning -Message ('Test {0} is skipped because no compatible license was found' -f $_.TestId)
+		Write-PSFMessage -Message ('Test {0} is skipped because no compatible license was found' -f $_.TestId) -Level Verbose
 		Add-ZtTestResultDetail -SkippedBecause NoCompatibleLicenseFound -TestId $_.TestId
 	}
 

--- a/src/powershell/tests/Test-Assessment.25371.ps1
+++ b/src/powershell/tests/Test-Assessment.25371.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Validates that Universal Continuous Access Evaluation (Universal CAE) is enabled for network access.
 
@@ -23,6 +23,7 @@ function Test-Assessment-25371 {
     	Category = 'Global Secure Access',
     	ImplementationCost = 'Low',
     	MinimumLicense = ('AAD_PREMIUM'),
+    	CompatibleLicense = ('Entra_Premium_Private_Access','Entra_Premium_Internet_Access'),
     	Pillar = 'Network',
     	RiskLevel = 'High',
     	SfiPillar = 'Protect networks',

--- a/src/powershell/tests/Test-Assessment.25372.ps1
+++ b/src/powershell/tests/Test-Assessment.25372.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Validates that Global Secure Access client is deployed on all managed endpoints.
 
@@ -18,6 +18,7 @@ function Test-Assessment-25372 {
         Category = 'Global Secure Access',
         ImplementationCost = 'Medium',
         MinimumLicense = ('AAD_PREMIUM', 'Entra_Premium_Internet_Access', 'Entra_Premium_Private_Access'),
+        CompatibleLicense = ('Entra_Premium_Private_Access','Entra_Premium_Internet_Access'),
         Pillar = 'Network',
         RiskLevel = 'High',
         SfiPillar = 'Protect networks',

--- a/src/powershell/tests/Test-Assessment.25375.ps1
+++ b/src/powershell/tests/Test-Assessment.25375.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Validates that GSA licenses are available in the tenant and assigned to users.
 
@@ -25,6 +25,7 @@ function Test-Assessment-25375 {
     	Category = 'Global Secure Access',
     	ImplementationCost = 'Low',
     	MinimumLicense = ('Entra_Premium_Internet_Access','Entra_Premium_Private_Access'),
+    	CompatibleLicense = ('Entra_Premium_Internet_Access','Entra_Premium_Private_Access'),
     	Pillar = 'Network',
     	RiskLevel = 'High',
     	SfiPillar = 'Protect networks',

--- a/src/powershell/tests/Test-Assessment.25376.ps1
+++ b/src/powershell/tests/Test-Assessment.25376.ps1
@@ -17,6 +17,7 @@ function Test-Assessment-25376 {
         Category = 'Network security',
         ImplementationCost = 'Medium',
         MinimumLicense = 'Entra_Suite',
+        CompatibleLicense = ('Entra_Premium_Private_Access','Entra_Premium_Internet_Access'),
         Pillar = 'Network',
         RiskLevel = 'High',
         SfiPillar = 'Protect networks',

--- a/src/powershell/tests/Test-Assessment.25377.ps1
+++ b/src/powershell/tests/Test-Assessment.25377.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Validates that Universal Tenant Restrictions (UTR) are configured to block access to unauthorized external tenants.
 
@@ -18,6 +18,7 @@ function Test-Assessment-25377 {
     	Category = 'Global Secure Access',
     	ImplementationCost = 'Medium',
     	MinimumLicense = ('AAD_PREMIUM','Entra_Premium_Internet_Access'),
+    	CompatibleLicense = ('Entra_Premium_Internet_Access'),
     	Pillar = 'Network',
     	RiskLevel = 'High',
     	SfiPillar = 'Protect networks',

--- a/src/powershell/tests/Test-Assessment.25378.ps1
+++ b/src/powershell/tests/Test-Assessment.25378.ps1
@@ -17,6 +17,7 @@ function Test-Assessment-25378 {
         Category = 'External Identities',
         ImplementationCost = 'Medium',
         MinimumLicense = 'AAD_PREMIUM',
+        CompatibleLicense = ('AAD_PREMIUM','AAD_PREMIUM_P2'),
         Pillar = 'Network',
         RiskLevel = 'High',
         SfiPillar = 'Protect identities and secrets',

--- a/src/powershell/tests/Test-Assessment.25379.ps1
+++ b/src/powershell/tests/Test-Assessment.25379.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Checks that compliant network controls are configured in Conditional Access policies
 
@@ -17,6 +17,7 @@ function Test-Assessment-25379 {
     	Category = 'Global Secure Access',
     	ImplementationCost = 'Medium',
     	MinimumLicense = ('AAD_PREMIUM'),
+    	CompatibleLicense = ('AAD_PREMIUM','AAD_PREMIUM_P2'),
     	Pillar = 'Network',
     	RiskLevel = 'Medium',
     	SfiPillar = 'Protect networks',

--- a/src/powershell/tests/Test-Assessment.25381.ps1
+++ b/src/powershell/tests/Test-Assessment.25381.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Validates that traffic forwarding profiles are enabled in Global Secure Access.
 
@@ -18,6 +18,7 @@ function Test-Assessment-25381 {
     	Category = 'Global Secure Access',
     	ImplementationCost = 'Medium',
     	MinimumLicense = ('Entra_Suite','Entra_Premium_Private_Access','Entra_Premium_Internet_Access','P2'),
+    	CompatibleLicense = ('Entra_Premium_Private_Access','Entra_Premium_Internet_Access'),
     	Pillar = 'Network',
     	RiskLevel = 'High',
     	SfiPillar = 'Protect networks',

--- a/src/powershell/tests/Test-Assessment.25382.ps1
+++ b/src/powershell/tests/Test-Assessment.25382.ps1
@@ -18,6 +18,7 @@ function Test-Assessment-25382 {
         Category = 'Global Secure Access',
         ImplementationCost = 'Low',
         MinimumLicense = ('Entra_Premium_Private_Access', 'Entra_Premium_Internet_Access'),
+        CompatibleLicense = ('Entra_Premium_Internet_Access','Entra_Premium_Private_Access'),
         Pillar = 'Network',
         RiskLevel = 'High',
         SfiPillar = 'Protect networks',

--- a/src/powershell/tests/Test-Assessment.25383.ps1
+++ b/src/powershell/tests/Test-Assessment.25383.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Validates that Global Administrator and Global Secure Access Administrator roles are tightly limited.
 
@@ -18,6 +18,7 @@ function Test-Assessment-25383 {
     	Category = 'Global Secure Access',
     	ImplementationCost = 'Low',
     	MinimumLicense = ('AAD_PREMIUM'),
+    	CompatibleLicense = ('AAD_PREMIUM','AAD_PREMIUM_P2'),
     	Pillar = 'Network',
     	RiskLevel = 'High',
     	SfiPillar = 'Protect identities and secrets',

--- a/src/powershell/tests/Test-Assessment.25384.ps1
+++ b/src/powershell/tests/Test-Assessment.25384.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Checks if Application Administrator rights are constrained to specific Private Access apps.
 
@@ -17,6 +17,7 @@ function Test-Assessment-25384 {
     	Category = 'Role management',
     	ImplementationCost = 'Low',
     	MinimumLicense = ('P1'),
+    	CompatibleLicense = ('Entra_Premium_Private_Access','Entra_Premium_Internet_Access'),
     	Pillar = 'Network',
     	RiskLevel = 'High',
     	SfiPillar = 'Protect identities and secrets',

--- a/src/powershell/tests/Test-Assessment.25391.ps1
+++ b/src/powershell/tests/Test-Assessment.25391.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Validates that all Private Network Connectors are active and healthy.
 
@@ -17,6 +17,7 @@ function Test-Assessment-25391 {
     	Category = 'Global Secure Access',
     	ImplementationCost = 'Low',
     	MinimumLicense = ('Entra_Premium_Private_Access'),
+    	CompatibleLicense = ('Entra_Premium_Private_Access'),
     	Pillar = 'Network',
     	RiskLevel = 'Medium',
     	SfiPillar = 'Protect networks',

--- a/src/powershell/tests/Test-Assessment.25392.ps1
+++ b/src/powershell/tests/Test-Assessment.25392.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Validates that all Private Network Connectors are running the latest version.
 
@@ -18,6 +18,7 @@ function Test-Assessment-25392 {
     	Category = 'Private Access',
     	ImplementationCost = 'Low',
     	MinimumLicense = ('Entra_Premium_Private_Access'),
+    	CompatibleLicense = ('Entra_Premium_Private_Access'),
     	Pillar = 'Network',
     	RiskLevel = 'Medium',
     	SfiPillar = 'Protect networks',

--- a/src/powershell/tests/Test-Assessment.25394.ps1
+++ b/src/powershell/tests/Test-Assessment.25394.ps1
@@ -19,6 +19,7 @@ function Test-Assessment-25394 {
         Category = 'Global Secure Access',
         ImplementationCost = 'Low',
         MinimumLicense = ('Entra_Premium_Private_Access', 'AAD_PREMIUM'),
+        CompatibleLicense = ('Entra_Premium_Private_Access'),
         Pillar = 'Network',
         RiskLevel = 'High',
         SfiPillar = 'Protect networks',

--- a/src/powershell/tests/Test-Assessment.25395.ps1
+++ b/src/powershell/tests/Test-Assessment.25395.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Validates that Entra Private Access applications enforce least-privilege
     using granular network segments and Custom Security Attributes (CSA).
@@ -20,6 +20,7 @@ function Test-Assessment-25395 {
     	Category = 'Global Secure Access',
     	ImplementationCost = 'High',
     	MinimumLicense = ('Entra_Premium_Private_Access'),
+    	CompatibleLicense = ('Entra_Premium_Private_Access'),
     	Pillar = 'Network',
     	RiskLevel = 'High',
     	SfiPillar = 'Protect networks',

--- a/src/powershell/tests/Test-Assessment.25396.ps1
+++ b/src/powershell/tests/Test-Assessment.25396.ps1
@@ -17,6 +17,7 @@ function Test-Assessment-25396 {
         Category = 'Global Secure Access',
         ImplementationCost = 'Medium',
         MinimumLicense = ('Entra_Premium_Private_Access', 'AAD_PREMIUM'),
+        CompatibleLicense = ('Entra_Premium_Private_Access'),
         Pillar = 'Network',
         RiskLevel = 'High',
         SfiPillar = 'Protect identities and secrets',

--- a/src/powershell/tests/Test-Assessment.25398.ps1
+++ b/src/powershell/tests/Test-Assessment.25398.ps1
@@ -11,6 +11,7 @@ function Test-Assessment-25398 {
         Category = 'Global Secure Access',
         ImplementationCost = 'Medium',
         MinimumLicense = ('AAD_PREMIUM', 'Entra_Premium_Private_Access'),
+        CompatibleLicense = ('Entra_Premium_Private_Access'),
         Pillar = 'Network',
         RiskLevel = 'High',
         SfiPillar = 'Protect networks',

--- a/src/powershell/tests/Test-Assessment.25399.ps1
+++ b/src/powershell/tests/Test-Assessment.25399.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Checks that Private DNS is configured for internal name resolution in Entra Private Access (Quick Access)
 .DESCRIPTION
@@ -15,6 +15,7 @@ function Test-Assessment-25399 {
     	Category = 'Global Secure Access',
     	ImplementationCost = 'Medium',
     	MinimumLicense = ('Entra_Premium_Private_Access'),
+    	CompatibleLicense = ('Entra_Premium_Private_Access'),
     	Pillar = 'Network',
     	RiskLevel = 'Medium',
     	SfiPillar = 'Protect networks',

--- a/src/powershell/tests/Test-Assessment.25401.ps1
+++ b/src/powershell/tests/Test-Assessment.25401.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Validates that Application Proxy applications require pre-authentication to block anonymous access.
 
@@ -24,6 +24,7 @@ function Test-Assessment-25401 {
     	Category = 'Application Proxy',
     	ImplementationCost = 'Medium',
     	MinimumLicense = ('AAD_PREMIUM'),
+    	CompatibleLicense = ('AAD_PREMIUM','AAD_PREMIUM_P2'),
     	Pillar = 'Network',
     	RiskLevel = 'High',
     	SfiPillar = 'Protect identities and secrets',

--- a/src/powershell/tests/Test-Assessment.25403.ps1
+++ b/src/powershell/tests/Test-Assessment.25403.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Validates that Private Access Sensors are deployed on domain controllers and enforcing strong authentication policies.
 
@@ -17,6 +17,7 @@ function Test-Assessment-25403 {
     	Category = 'Global Secure Access',
     	ImplementationCost = 'Medium',
     	MinimumLicense = ('Entra_Suite','Entra_Premium_Private_Access'),
+    	CompatibleLicense = ('Entra_Premium_Private_Access'),
     	Pillar = 'Network',
     	RiskLevel = 'High',
     	SfiPillar = 'Protect networks',

--- a/src/powershell/tests/Test-Assessment.25406.ps1
+++ b/src/powershell/tests/Test-Assessment.25406.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Validates that the Internet Access forwarding profile is enabled with user assignments.
 #>
@@ -8,6 +8,7 @@ function Test-Assessment-25406 {
     	Category = 'Global Secure Access',
     	ImplementationCost = 'Low',
     	MinimumLicense = ('Entra_Premium_Global_Secure_Access'),
+    	CompatibleLicense = ('Entra_Premium_Internet_Access'),
     	Pillar = 'Network',
     	RiskLevel = 'High',
     	SfiPillar = 'Protect networks',

--- a/src/powershell/tests/Test-Assessment.25407.ps1
+++ b/src/powershell/tests/Test-Assessment.25407.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Internet Access security profiles are applied to users via Conditional Access policies.
 #>
@@ -8,6 +8,7 @@ function Test-Assessment-25407 {
     	Category = 'Global Secure Access',
     	ImplementationCost = 'Medium',
     	MinimumLicense = ('Entra_Premium_Internet_Access'),
+    	CompatibleLicense = ('Entra_Premium_Internet_Access'),
     	Pillar = 'Network',
     	RiskLevel = 'High',
     	SfiPillar = 'Protect networks',

--- a/src/powershell/tests/Test-Assessment.25408.ps1
+++ b/src/powershell/tests/Test-Assessment.25408.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Checks that Global Secure Access web content filtering is enabled and configured
 .DESCRIPTION
@@ -18,6 +18,7 @@ function Test-Assessment-25408 {
     	Category = 'Global Secure Access',
     	ImplementationCost = 'Medium',
     	MinimumLicense = ('Entra_Premium_Internet_Access'),
+    	CompatibleLicense = ('Entra_Premium_Internet_Access'),
     	Pillar = 'Network',
     	RiskLevel = 'Medium',
     	SfiPillar = 'Protect networks',

--- a/src/powershell/tests/Test-Assessment.25409.ps1
+++ b/src/powershell/tests/Test-Assessment.25409.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Validates that web content filtering policies based on website categories are configured in Global Secure Access.
 
@@ -17,6 +17,7 @@ function Test-Assessment-25409 {
     	Category = 'Global Secure Access',
     	ImplementationCost = 'Medium',
     	MinimumLicense = ('Entra_Premium_Internet_Access'),
+    	CompatibleLicense = ('Entra_Premium_Internet_Access'),
     	Pillar = 'Network',
     	RiskLevel = 'Medium',
     	SfiPillar = 'Protect networks',

--- a/src/powershell/tests/Test-Assessment.25410.ps1
+++ b/src/powershell/tests/Test-Assessment.25410.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Validates that web content filtering policies are configured and enforced in Global Secure Access.
 
@@ -20,6 +20,7 @@ function Test-Assessment-25410 {
     	Category = 'Global Secure Access',
     	ImplementationCost = 'Medium',
     	MinimumLicense = ('Entra_Premium_Internet_Access'),
+    	CompatibleLicense = ('Entra_Premium_Internet_Access'),
     	Pillar = 'Network',
     	RiskLevel = 'Medium',
     	SfiPillar = 'Protect networks',

--- a/src/powershell/tests/Test-Assessment.25411.ps1
+++ b/src/powershell/tests/Test-Assessment.25411.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     TLS inspection is enabled and correctly configured for outbound traffic in Global Secure Access.
 .DESCRIPTION
@@ -10,6 +10,7 @@ function Test-Assessment-25411 {
     	Category = 'Global Secure Access',
     	ImplementationCost = 'High',
     	MinimumLicense = ('Entra_Premium_Internet_Access'),
+    	CompatibleLicense = ('Entra_Premium_Internet_Access'),
     	Pillar = 'Network',
     	RiskLevel = 'High',
     	SfiPillar = 'Protect networks',

--- a/src/powershell/tests/Test-Assessment.25415.ps1
+++ b/src/powershell/tests/Test-Assessment.25415.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Enterprise generative AI applications are protected from prompt injection attacks through AI Gateway.
 .DESCRIPTION
@@ -12,6 +12,7 @@ function Test-Assessment-25415 {
     	Category = 'Global Secure Access',
     	ImplementationCost = 'Medium',
     	MinimumLicense = ('Entra_Premium_Internet_Access'),
+    	CompatibleLicense = ('Entra_Premium_Internet_Access'),
     	Pillar = 'Network',
     	RiskLevel = 'High',
     	SfiPillar = 'Protect networks',

--- a/src/powershell/tests/Test-Assessment.25416.ps1
+++ b/src/powershell/tests/Test-Assessment.25416.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Branch office internet traffic is protected by Cloud Firewall policies through Global Secure Access
 
@@ -20,6 +20,7 @@ function Test-Assessment-25416 {
     	Category = 'Global Secure Access',
     	ImplementationCost = 'Medium',
     	MinimumLicense = ('Entra_Premium_Internet_Access'),
+    	CompatibleLicense = ('Entra_Premium_Internet_Access'),
     	Pillar = 'Network',
     	RiskLevel = 'High',
     	SfiPillar = 'Protect networks',

--- a/src/powershell/tests/Test-Assessment.25419.ps1
+++ b/src/powershell/tests/Test-Assessment.25419.ps1
@@ -19,6 +19,7 @@ function Test-Assessment-25419 {
         Category = 'Global Secure Access',
         ImplementationCost = 'Low',
         MinimumLicense = ('AAD_PREMIUM', 'Entra_Premium_Internet_Access', 'Entra_Premium_Private_Access'),
+        CompatibleLicense = ('Entra_Premium_Private_Access','Entra_Premium_Internet_Access'),
         Pillar = 'Network',
         RiskLevel = 'Medium',
         SfiPillar = 'Monitor and detect cyberthreats',

--- a/src/powershell/tests/Test-Assessment.25420.ps1
+++ b/src/powershell/tests/Test-Assessment.25420.ps1
@@ -20,6 +20,7 @@ function Test-Assessment-25420 {
         Category = 'Global Secure Access',
         ImplementationCost = 'Low',
         MinimumLicense = ('AAD_PREMIUM', 'Entra_Premium_Internet_Access', 'Entra_Premium_Private_Access'),
+        CompatibleLicense = ('Entra_Premium_Private_Access','Entra_Premium_Internet_Access'),
         Pillar = 'Network',
         RiskLevel = 'High',
         SfiPillar = 'Monitor and detect cyberthreats',

--- a/src/powershell/tests/Test-Assessment.25422.ps1
+++ b/src/powershell/tests/Test-Assessment.25422.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     GSA Deployment logs are populated and reviewed
 
@@ -18,6 +18,7 @@ function Test-Assessment-25422 {
     	Category = 'Global Secure Access',
     	ImplementationCost = 'Low',
     	MinimumLicense = ('Entra_Premium_Internet_Access','Entra_Premium_Private_Access'),
+    	CompatibleLicense = ('Entra_Premium_Internet_Access','Entra_Premium_Private_Access'),
     	Pillar = 'Network',
     	RiskLevel = 'Medium',
     	SfiPillar = 'Monitor and detect cyberthreats',

--- a/src/powershell/tests/Test-Assessment.25480.ps1
+++ b/src/powershell/tests/Test-Assessment.25480.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Checks that Quick Access has assigned users or groups
 .DESCRIPTION
@@ -15,6 +15,7 @@ function Test-Assessment-25480 {
     	Category = 'Global Secure Access',
     	ImplementationCost = 'Low',
     	MinimumLicense = ('Entra_Private_Access'),
+    	CompatibleLicense = ('Entra_Premium_Private_Access'),
     	Pillar = 'Network',
     	RiskLevel = 'Medium',
     	SfiPillar = 'Protect networks',

--- a/src/powershell/tests/Test-Assessment.25481.ps1
+++ b/src/powershell/tests/Test-Assessment.25481.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Checks that all Private Access applications have assigned users or groups
 .DESCRIPTION
@@ -15,6 +15,7 @@ function Test-Assessment-25481 {
     	Category = 'Global Secure Access',
     	ImplementationCost = 'Low',
     	MinimumLicense = ('Entra_Private_Access'),
+    	CompatibleLicense = ('Entra_Premium_Private_Access'),
     	Pillar = 'Network',
     	RiskLevel = 'High',
     	SfiPillar = 'Protect networks',

--- a/src/powershell/tests/Test-Assessment.27001.ps1
+++ b/src/powershell/tests/Test-Assessment.27001.ps1
@@ -18,6 +18,7 @@ function Test-Assessment-27001 {
         Category = 'Global Secure Access',
         ImplementationCost = 'Medium',
         MinimumLicense = 'Entra_Premium_Internet_Access',
+        CompatibleLicense = ('Entra_Premium_Internet_Access'),
         Pillar = 'Network',
         RiskLevel = 'Medium',
         SfiPillar = 'Protect networks',

--- a/src/powershell/tests/Test-Assessment.27003.ps1
+++ b/src/powershell/tests/Test-Assessment.27003.ps1
@@ -20,6 +20,7 @@ function Test-Assessment-27003 {
         Category = 'Global Secure Access',
         ImplementationCost = 'Medium',
         MinimumLicense = ('Entra_Premium_Internet_Access'),
+        CompatibleLicense = ('Entra_Premium_Internet_Access'),
         Pillar = 'Network',
         RiskLevel = 'High',
         SfiPillar = 'Protect networks',

--- a/src/powershell/tests/Test-Assessment.27004.ps1
+++ b/src/powershell/tests/Test-Assessment.27004.ps1
@@ -24,6 +24,7 @@ function Test-Assessment-27004 {
         Category = 'Global Secure Access',
         ImplementationCost = 'Low',
         MinimumLicense = ('Entra_Premium_Internet_Access'),
+        CompatibleLicense = ('Entra_Premium_Internet_Access'),
         Pillar = 'Network',
         RiskLevel = 'Low',
         SfiPillar = 'Protect networks',


### PR DESCRIPTION
Added the Compatible License attribute to 36 GSA tests and kept the Azure tests unchanged.
Only `25405` is pending, as the spec file currently has an empty Minimum License field.