### PR TITLE
Add CustomSecurityAttributes column to ServicePrincipal table

### DIFF
--- a/src/powershell/assets/export-tenant.config.psd1
+++ b/src/powershell/assets/export-tenant.config.psd1
@@ -87,7 +87,7 @@ Note: Avoid using the same names as used for the "General Parameters" section of
 @{
 	Name = 'ServicePrincipal'
 	Uri = 'beta/servicePrincipals'
-	QueryString = '$expand=appRoleAssignments&$top=999'
+	QueryString = '$expand=appRoleAssignments&$top=999&$select=id,deletedDateTime,accountEnabled,alternativeNames,createdByAppId,createdDateTime,deviceManagementAppType,appDescription,appDisplayName,appId,applicationTemplateId,appOwnerOrganizationId,appRoleAssignmentRequired,assignmentRequiredForPrincipalTypes,description,disabledByMicrosoftStatus,displayName,errorUrl,homepage,isAuthorizationServiceEnabled,isDisabled,isManagementRestricted,loginUrl,logoutUrl,notes,notificationEmailAddresses,preferredSingleSignOnMode,preferredTokenSigningKeyEndDateTime,preferredTokenSigningKeyThumbprint,publisherName,replyUrls,samlMetadataUrl,samlSLOBindingType,servicePrincipalNames,servicePrincipalType,signInAudience,tags,tokenEncryptionKeyId,certification,samlSingleSignOnSettings,addIns,api,appRoles,info,keyCredentials,publishedPermissionScopes,passwordCredentials,resourceSpecificApplicationPermissions,verifiedPublisher,customSecurityAttributes'
 	RelatedPropertyNames = @('oauth2PermissionGrants')
 	Type = 'Default' # PrivilegedGroup
 

--- a/src/powershell/doc/readme.md
+++ b/src/powershell/doc/readme.md
@@ -54,8 +54,11 @@ optionally to Azure. When connecting using Microsoft Graph PowerShell, the follo
 
 The consent prompt is only displayed if the Graph PowerShell app does not already have these permissions.
 
+> **Note:** To read Custom Security Attributes on service principals, the account running the assessment must also be assigned the **Attribute Assignment Reader** (or **Attribute Assignment Administrator**) Entra ID role. Without this role, Custom Security Attribute values will be returned as null.
+
 - AuditLog.Read.All
 - CrossTenantInformation.ReadBasic.All
+- CustomSecAttributeAssignment.Read.All
 - DeviceManagementApps.Read.All
 - DeviceManagementConfiguration.Read.All
 - DeviceManagementManagedDevices.Read.All

--- a/src/powershell/private/db/content/Get-TableSchemaConfig.ps1
+++ b/src/powershell/private/db/content/Get-TableSchemaConfig.ps1
@@ -23,6 +23,11 @@ function Get-TableSchemaConfig {
     )
 
     $configs = @{
+        'ServicePrincipal' = @{
+            'use_union_by_name' = $true
+            'sample_size' = 50
+            'reason' = 'customSecurityAttributes is an open complex type with varying nested keys across service principals'
+        }
         'ServicePrincipalSignIn' = @{
             'use_union_by_name' = $true
             'sample_size' = 50  # Sample more files to avoid schema inference issues

--- a/src/powershell/public/Get-ZtGraphScope.ps1
+++ b/src/powershell/public/Get-ZtGraphScope.ps1
@@ -34,6 +34,7 @@ Function Get-ZtGraphScope {
     $scopes = @( #IMPORTANT: Read note above before adding any new scopes.
         'AuditLog.Read.All'
         'CrossTenantInformation.ReadBasic.All'
+        'CustomSecAttributeAssignment.Read.All'
         'DeviceManagementApps.Read.All'
         'DeviceManagementConfiguration.Read.All'
         'DeviceManagementManagedDevices.Read.All',


### PR DESCRIPTION
This pull request updates the handling of Service Principal data and permissions to support reading Custom Security Attributes. The changes ensure that the necessary API fields and permissions are included, and update the schema inference logic to accommodate the complex structure of custom security attributes.

**Service Principal data and permissions:**

* Expanded the `$select` query in the `ServicePrincipal` config to include the `customSecurityAttributes` property and several other fields, enabling retrieval of custom security attributes from the Microsoft Graph API.
* Added `CustomSecAttributeAssignment.Read.All` to the required Graph API permissions in both the documentation and the `Get-ZtGraphScope` function, ensuring the tool requests the correct scope for reading custom security attributes. [[1]](diffhunk://#diff-44cc61dd6538251bc01c4d719051224ceb7013d809fce7205b1b1616a74f39edR57-R61) [[2]](diffhunk://#diff-b279417959fd174f5be896975b78ea3a4a213edea6a56b1992609fb45441149dR37)
* Updated documentation to clarify that the account running the assessment must have the **Attribute Assignment Reader** or **Attribute Assignment Administrator** Entra ID role to read custom security attributes on service principals.

**Schema inference improvements:**

* Modified the `Get-TableSchemaConfig` function to add a custom schema config for `ServicePrincipal`, setting `use_union_by_name` to true and increasing the sample size to 50, to better handle the open complex type structure of `customSecurityAttributes`.