### PR TITLE
Added Compatible License attribute for Data tests

### DIFF
--- a/src/powershell/tests/Test-Assessment.35001.ps1
+++ b/src/powershell/tests/Test-Assessment.35001.ps1
@@ -9,6 +9,7 @@ function Test-Assessment-35001 {
         ImplementationCost = 'Low',
         Service = ('Graph'),
         MinimumLicense = ('Microsoft 365 E5'),
+        CompatibleLicense = ('RMS_S_PREMIUM2'),
         Pillar = 'Data',
         RiskLevel = 'High',
         SfiPillar = '',

--- a/src/powershell/tests/Test-Assessment.35002.ps1
+++ b/src/powershell/tests/Test-Assessment.35002.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Checks if Microsoft Rights Management Services (RMS) is allowed in Cross-Tenant Access Policies (XTAP).
 
@@ -22,6 +22,7 @@ function Test-Assessment-35002 {
     	Category = 'Identity',
     	ImplementationCost = 'Low',
     	MinimumLicense = ('Microsoft 365 E5'),
+    	CompatibleLicense = ('RMS_S_PREMIUM2'),
     	Service = ('Graph'),
     	Pillar = 'Data',
     	RiskLevel = 'High',

--- a/src/powershell/tests/Test-Assessment.35003.ps1
+++ b/src/powershell/tests/Test-Assessment.35003.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Sensitivity labels are configured
 
@@ -17,6 +17,7 @@ function Test-Assessment-35003 {
     	Category = 'sensitivity-labels',
     	ImplementationCost = 'Medium',
     	MinimumLicense = ('Microsoft 365 E3'),
+    	CompatibleLicense = ('RMS_S_PREMIUM'),
     	Service = ('SecurityCompliance'),
     	Pillar = 'Data',
     	RiskLevel = 'High',

--- a/src/powershell/tests/Test-Assessment.35004.ps1
+++ b/src/powershell/tests/Test-Assessment.35004.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Sensitivity label policies are published to users
 
@@ -19,6 +19,7 @@ function Test-Assessment-35004 {
     	Category = 'Sensitivity Labels',
     	ImplementationCost = 'Low',
     	MinimumLicense = ('Microsoft 365 E3'),
+    	CompatibleLicense = ('RMS_S_PREMIUM'),
     	Service = ('SecurityCompliance'),
     	Pillar = 'Data',
     	RiskLevel = 'Low',

--- a/src/powershell/tests/Test-Assessment.35005.ps1
+++ b/src/powershell/tests/Test-Assessment.35005.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Sensitivity labels are enabled in SharePoint Online
 
@@ -16,6 +16,7 @@ function Test-Assessment-35005 {
     	Category = 'SharePoint Online',
     	ImplementationCost = 'Low',
     	MinimumLicense = ('MIP_P1'),
+    	CompatibleLicense = ('RMS_S_PREMIUM'),
     	Service = ('SharePointOnline'),
     	Pillar = 'Data',
     	RiskLevel = 'High',

--- a/src/powershell/tests/Test-Assessment.35006.ps1
+++ b/src/powershell/tests/Test-Assessment.35006.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     PDF labeling is enabled in SharePoint Online
 
@@ -16,6 +16,7 @@ function Test-Assessment-35006 {
     	Category = 'SharePoint Online',
     	ImplementationCost = 'Low',
     	MinimumLicense = ('MIP_P1'),
+    	CompatibleLicense = ('RMS_S_PREMIUM'),
     	Service = ('SharePointOnline'),
     	Pillar = 'Data',
     	RiskLevel = 'Medium',

--- a/src/powershell/tests/Test-Assessment.35007.ps1
+++ b/src/powershell/tests/Test-Assessment.35007.ps1
@@ -17,6 +17,7 @@ function Test-Assessment-35007 {
         ImplementationCost = 'Low',
         Service = ('SharePointOnline'),
         MinimumLicense = ('Microsoft 365 E3'),
+        CompatibleLicense = ('RMS_S_PREMIUM'),
         Pillar = 'Data',
         RiskLevel = 'Low',
         SfiPillar = '',

--- a/src/powershell/tests/Test-Assessment.35008.ps1
+++ b/src/powershell/tests/Test-Assessment.35008.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     A default sensitivity label is configured for SharePoint document libraries
 
@@ -16,6 +16,7 @@ function Test-Assessment-35008 {
     	Category = 'SharePoint Online',
     	ImplementationCost = 'Low',
     	MinimumLicense = ('Microsoft 365 E5'),
+    	CompatibleLicense = ('RMS_S_PREMIUM2'),
     	Service = ('SharePointOnline'),
     	Pillar = 'Data',
     	RiskLevel = 'Medium',

--- a/src/powershell/tests/Test-Assessment.35009.ps1
+++ b/src/powershell/tests/Test-Assessment.35009.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Co-authoring is enabled for encrypted documents
 #>
@@ -8,6 +8,7 @@ function Test-Assessment-35009 {
     	Category = 'Sensitivity Labels',
     	ImplementationCost = 'Low',
     	MinimumLicense = ('Microsoft 365 E5'),
+    	CompatibleLicense = ('RMS_S_PREMIUM2'),
     	Service = ('SecurityCompliance'),
     	Pillar = 'Data',
     	RiskLevel = 'Low',

--- a/src/powershell/tests/Test-Assessment.35010.ps1
+++ b/src/powershell/tests/Test-Assessment.35010.ps1
@@ -27,6 +27,7 @@ function Test-Assessment-35010 {
     	ImplementationCost = 'Medium',
     	Service = ('SecurityCompliance'),
     	MinimumLicense = ('Microsoft 365 E5'),
+    	CompatibleLicense = ('RMS_S_PREMIUM2'),
     	Pillar = 'Data',
     	RiskLevel = 'Low',
     	SfiPillar = 'Protect tenants and production systems',

--- a/src/powershell/tests/Test-Assessment.35011.ps1
+++ b/src/powershell/tests/Test-Assessment.35011.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Super user membership is configured for Azure Information Protection
 
@@ -18,6 +18,7 @@ function Test-Assessment-35011 {
     	Category = 'Advanced Label Features',
     	ImplementationCost = 'Medium',
     	MinimumLicense = ('Microsoft 365 E5'),
+    	CompatibleLicense = ('RMS_S_PREMIUM2'),
     	Service = ('AipService','Graph'),
     	Pillar = 'Data',
     	RiskLevel = 'Medium',

--- a/src/powershell/tests/Test-Assessment.35012.ps1
+++ b/src/powershell/tests/Test-Assessment.35012.ps1
@@ -21,6 +21,7 @@ function Test-Assessment-35012 {
         ImplementationCost = 'Medium',
         Service = ('SecurityCompliance'),
         MinimumLicense = ('Microsoft 365 E5'),
+        CompatibleLicense = ('RMS_S_PREMIUM2'),
         Pillar = 'Data',
         RiskLevel = 'Medium',
         SfiPillar = 'Protect tenants and production systems',

--- a/src/powershell/tests/Test-Assessment.35013.ps1
+++ b/src/powershell/tests/Test-Assessment.35013.ps1
@@ -21,6 +21,7 @@ function Test-Assessment-35013 {
         ImplementationCost = 'Medium',
         Service = ('SecurityCompliance'),
         MinimumLicense = 'Microsoft 365 E3',
+        CompatibleLicense = ('RMS_S_PREMIUM'),
         Pillar = 'Data',
         RiskLevel = 'High',
         SfiPillar = 'Protect tenants and production systems',

--- a/src/powershell/tests/Test-Assessment.35014.ps1
+++ b/src/powershell/tests/Test-Assessment.35014.ps1
@@ -20,6 +20,7 @@ function Test-Assessment-35014 {
         ImplementationCost = 'Low',
         Service = ('SecurityCompliance'),
         MinimumLicense = ('Microsoft 365 E3'),
+        CompatibleLicense = ('RMS_S_PREMIUM'),
         Pillar = 'Data',
         RiskLevel = 'Medium',
         SfiPillar = 'Protect tenants and production systems',

--- a/src/powershell/tests/Test-Assessment.35015.ps1
+++ b/src/powershell/tests/Test-Assessment.35015.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Globally published sensitivity labels don't exceed the recommended maximum
 
@@ -16,6 +16,7 @@ function Test-Assessment-35015 {
     	Category = 'sensitivity-labels',
     	ImplementationCost = 'Medium',
     	MinimumLicense = ('Microsoft 365 E3'),
+    	CompatibleLicense = ('RMS_S_PREMIUM'),
     	Service = ('SecurityCompliance'),
     	Pillar = 'Data',
     	RiskLevel = 'Medium',

--- a/src/powershell/tests/Test-Assessment.35016.ps1
+++ b/src/powershell/tests/Test-Assessment.35016.ps1
@@ -9,6 +9,7 @@ function Test-Assessment-35016 {
         ImplementationCost = 'Medium',
         Service = ('SecurityCompliance'),
         MinimumLicense = ('Microsoft 365 E3'),
+        CompatibleLicense = ('RMS_S_PREMIUM'),
         Pillar = 'Data',
         RiskLevel = 'High',
         SfiPillar = 'Protect tenants and production systems',

--- a/src/powershell/tests/Test-Assessment.35017.ps1
+++ b/src/powershell/tests/Test-Assessment.35017.ps1
@@ -20,6 +20,7 @@ function Test-Assessment-35017 {
         ImplementationCost = 'Low',
         Service = ('SecurityCompliance'),
         MinimumLicense = ('Microsoft 365 E3'),
+        CompatibleLicense = ('RMS_S_PREMIUM'),
         Pillar = 'Data',
         RiskLevel = 'Medium',
         SfiPillar = 'Protect tenants and production systems',

--- a/src/powershell/tests/Test-Assessment.35018.ps1
+++ b/src/powershell/tests/Test-Assessment.35018.ps1
@@ -17,6 +17,7 @@ function Test-Assessment-35018 {
         ImplementationCost = 'Low',
         Service = ('SecurityCompliance'),
         MinimumLicense = ('Microsoft 365 E3'),
+        CompatibleLicense = ('RMS_S_PREMIUM'),
         Pillar = 'Data',
         RiskLevel = 'Medium',
         SfiPillar = 'Protect tenants and production systems',

--- a/src/powershell/tests/Test-Assessment.35024.ps1
+++ b/src/powershell/tests/Test-Assessment.35024.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Azure Rights Management licensing is enabled
 
@@ -20,6 +20,7 @@ function Test-Assessment-35024 {
     	Category = 'Rights Management Service',
     	ImplementationCost = 'Low',
     	MinimumLicense = ('Microsoft 365 E3'),
+    	CompatibleLicense = ('RMS_S_PREMIUM'),
     	Service = ('ExchangeOnline'),
     	Pillar = 'Data',
     	RiskLevel = 'High',

--- a/src/powershell/tests/Test-Assessment.35025.ps1
+++ b/src/powershell/tests/Test-Assessment.35025.ps1
@@ -21,6 +21,7 @@ function Test-Assessment-35025 {
         ImplementationCost = 'Low',
         Service = ('ExchangeOnline'),
         MinimumLicense = ('Microsoft 365 E3'),
+        CompatibleLicense = ('RMS_S_PREMIUM'),
         Pillar = 'Data',
         RiskLevel = 'High',
         SfiPillar = 'Protect tenants and production systems',

--- a/src/powershell/tests/Test-Assessment.35026.ps1
+++ b/src/powershell/tests/Test-Assessment.35026.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Office 365 Message Encryption is configured with simplified client access
 
@@ -21,6 +21,7 @@ function Test-Assessment-35026 {
     	Category = 'Microsoft Purview Message Encryption',
     	ImplementationCost = 'Low',
     	MinimumLicense = ('Microsoft 365 E3'),
+    	CompatibleLicense = ('RMS_S_PREMIUM'),
     	Service = ('ExchangeOnline'),
     	Pillar = 'Data',
     	RiskLevel = 'Medium',

--- a/src/powershell/tests/Test-Assessment.35028.ps1
+++ b/src/powershell/tests/Test-Assessment.35028.ps1
@@ -23,6 +23,7 @@ function Test-Assessment-35028 {
         ImplementationCost = 'Medium',
         Service = ('SecurityCompliance'),
         MinimumLicense = ('Microsoft 365 E3'),
+        CompatibleLicense = ('RMS_S_PREMIUM'),
         Pillar = 'Data',
         RiskLevel = 'Medium',
         SfiPillar = 'Protect tenants and production systems',

--- a/src/powershell/tests/Test-Assessment.35029.ps1
+++ b/src/powershell/tests/Test-Assessment.35029.ps1
@@ -17,6 +17,7 @@ function Test-Assessment-35029 {
         ImplementationCost = 'Medium',
         Service = ('ExchangeOnline'),
         MinimumLicense = ('Microsoft 365 E5'),
+        CompatibleLicense = ('RMS_S_PREMIUM2'),
         Pillar = 'Data',
         RiskLevel = 'Medium',
         SfiPillar = 'Protect tenants and production systems',

--- a/src/powershell/tests/Test-Assessment.35037.ps1
+++ b/src/powershell/tests/Test-Assessment.35037.ps1
@@ -9,6 +9,7 @@ function Test-Assessment-35037 {
         ImplementationCost = 'Low',
         Service = ('ExchangeOnline'),
         MinimumLicense = ('Microsoft 365 E3'),
+        CompatibleLicense = ('RMS_S_PREMIUM'),
         Pillar = 'Data',
         RiskLevel = 'High',
         SfiPillar = 'Protect tenants and production systems',


### PR DESCRIPTION
Added Compatible License attribute to following 24 Data tests:
35001, 35002, 35003, 35004, 35005, 35006, 35007, 35008, 35009, 35010, 35011, 35012, 35013, 35014, 35015, 35016, 35017, 35018, 35024, 35025, 35026, 35028, 35029, 35037 