### PR TITLE
Fix for #860 to avoid infinite loop

### DIFF
--- a/code-tests/commands/Invoke-ZtRetry.Tests.ps1
+++ b/code-tests/commands/Invoke-ZtRetry.Tests.ps1
@@ -293,7 +293,7 @@ Describe "Invoke-ZtRetry" {
 			Should -Invoke Start-Sleep -Times 0 -Exactly
 		}
 
-		It "Should NOT retry on HTTP 400 Bad Request" {
+		It "Should retry on HTTP 400 Bad Request" {
 			$script:callCount = 0
 			{
 				Invoke-ZtRetry -RetryCount 3 -RetryDelay 1 -ScriptBlock {
@@ -302,8 +302,8 @@ Describe "Invoke-ZtRetry" {
 				}
 			} | Should -Throw "*400*"
 
-			$script:callCount | Should -Be 1
-			Should -Invoke Start-Sleep -Times 0 -Exactly
+			$script:callCount | Should -Be 4
+			Should -Invoke Start-Sleep -Times 3 -Exactly
 		}
 
 		It "Should log non-retryable warning before failing" {

--- a/code-tests/commands/Invoke-ZtRetry.Tests.ps1
+++ b/code-tests/commands/Invoke-ZtRetry.Tests.ps1
@@ -252,7 +252,7 @@ Describe "Invoke-ZtRetry" {
 		}
 	}
 
-	Context "Error Filtering - Non-Retryable Errors (4xx)" {
+	Context "Error Filtering - 4xx Status Codes (Retryable and Non-Retryable)" {
 		It "Should NOT retry on HTTP 401 Unauthorized" {
 			$script:callCount = 0
 			{

--- a/src/powershell/private/core/Get-ZtHttpStatusCode.ps1
+++ b/src/powershell/private/core/Get-ZtHttpStatusCode.ps1
@@ -51,6 +51,12 @@ function Get-ZtHttpStatusCode {
 		return [int]$Matches[1]
 	}
 
+	# Strategy 4: Match raw HTTP status line in error message
+	# e.g., "HTTP/2.0 400 Bad Request" or "HTTP/1.1 503 Service Unavailable"
+	if ($exception.Message -match 'HTTP/\S+\s+(4\d{2}|5\d{2})\s') {
+		return [int]$Matches[1]
+	}
+
 	# Could not determine the HTTP status code
 	return $null
 }

--- a/src/powershell/private/core/Test-ZtRetryableError.ps1
+++ b/src/powershell/private/core/Test-ZtRetryableError.ps1
@@ -28,6 +28,7 @@ function Test-ZtRetryableError {
 
 	# Well-known permanent 4xx errors that will never succeed on retry
 	$nonRetryableStatusCodes = @(
+		400  # Bad Request - malformed request
 		401  # Unauthorized - invalid/missing credentials
 		403  # Forbidden - insufficient permissions
 		404  # Not Found - resource doesn't exist

--- a/src/powershell/private/core/Test-ZtRetryableError.ps1
+++ b/src/powershell/private/core/Test-ZtRetryableError.ps1
@@ -26,7 +26,19 @@ function Test-ZtRetryableError {
 		$ErrorRecord
 	)
 
-	$nonRetryableStatusCodes = @(401, 403, 404)
+	# Well-known permanent 4xx errors that will never succeed on retry
+	$nonRetryableStatusCodes = @(
+		401  # Unauthorized - invalid/missing credentials
+		403  # Forbidden - insufficient permissions
+		404  # Not Found - resource doesn't exist
+		405  # Method Not Allowed - wrong HTTP verb
+		409  # Conflict - resource state conflict
+		410  # Gone - resource permanently removed
+		411  # Length Required - missing Content-Length
+		413  # Payload Too Large - request body too big
+		415  # Unsupported Media Type - wrong content type
+		422  # Unprocessable Entity - validation failure
+	)
 
 	$statusCode = Get-ZtHttpStatusCode -ErrorRecord $ErrorRecord
 
@@ -36,7 +48,7 @@ function Test-ZtRetryableError {
 		return $true
 	}
 
-	# Only authentication/authorization and not-found errors are permanent.
-	# All other errors (including 400, 429, 5xx) are retried up to the configured retry count.
+	# Permanent client errors fail immediately. All other errors (including 400, 429, 5xx)
+	# are retried up to the configured retry count, since they may be transient.
 	return $statusCode -notin $nonRetryableStatusCodes
 }

--- a/src/powershell/private/core/Test-ZtRetryableError.ps1
+++ b/src/powershell/private/core/Test-ZtRetryableError.ps1
@@ -26,7 +26,7 @@ function Test-ZtRetryableError {
 		$ErrorRecord
 	)
 
-	$retryableStatusCodes = @(408, 429, 500, 502, 503, 504, 507)
+	$nonRetryableStatusCodes = @(401, 403, 404)
 
 	$statusCode = Get-ZtHttpStatusCode -ErrorRecord $ErrorRecord
 
@@ -36,5 +36,7 @@ function Test-ZtRetryableError {
 		return $true
 	}
 
-	return $statusCode -in $retryableStatusCodes
+	# Only authentication/authorization and not-found errors are permanent.
+	# All other errors (including 400, 429, 5xx) are retried up to the configured retry count.
+	return $statusCode -notin $nonRetryableStatusCodes
 }

--- a/src/powershell/private/export/Export-ZtGraphEntity.ps1
+++ b/src/powershell/private/export/Export-ZtGraphEntity.ps1
@@ -228,7 +228,7 @@ function Export-ZtGraphEntity {
 		# Detect stuck paging - same nextLink returned consecutively
 		if ($actualUri -eq $previousNextLink) {
 			Write-PSFMessage -Level Warning "Stuck paging detected for '$Name': nextLink unchanged on page $pageIndex. Stopping export." -Tag Export, Error
-			break
+			throw "Stuck paging detected for '$Name': nextLink unchanged on page $pageIndex"
 		}
 		$previousNextLink = $actualUri
 

--- a/src/powershell/private/export/Export-ZtGraphEntity.ps1
+++ b/src/powershell/private/export/Export-ZtGraphEntity.ps1
@@ -190,7 +190,16 @@ function Export-ZtGraphEntity {
 			$errorCode = $results.error.code
 			$errorMessage = $results.error.message
 			Write-PSFMessage -Level Warning "API returned error response for '$Name' page ${pageIndex}: [$errorCode] $errorMessage" -Tag Export, Error
-			throw "API returned error for '$Name': [$errorCode] $errorMessage"
+			# Throw a structured error so callers can inspect error code/category
+			$exception = New-Object System.Exception("API returned error for '$Name': [$errorCode] $errorMessage")
+			$exception.Data['GraphErrorCode'] = $errorCode
+			$exception.Data['GraphErrorMessage'] = $errorMessage
+			$errorRecord = New-Object System.Management.Automation.ErrorRecord `
+				$exception, `
+				$errorCode, `
+				[System.Management.Automation.ErrorCategory]::InvalidOperation, `
+				$null
+			throw $errorRecord
 		}
 
 		Export-Page -PageIndex $pageIndex -Path $folderPath -Results $results -RelatedPropertyNames $RelatedPropertyNames -Name $Name -Uri $Uri

--- a/src/powershell/private/export/Export-ZtGraphEntity.ps1
+++ b/src/powershell/private/export/Export-ZtGraphEntity.ps1
@@ -165,6 +165,7 @@ function Export-ZtGraphEntity {
 	$startTime = Get-Date
 	$stopTime = $startTime.AddMinutes($MaximumQueryTime)
 	$hasTimeLimit = $MaximumQueryTime -gt 0
+	$previousNextLink = $null
 
 	do {
 		# Update progress detail with the Graph API endpoint and page number
@@ -175,7 +176,23 @@ function Export-ZtGraphEntity {
 			Update-ZtProgressState -WorkerId $Name -WorkerName $Name -WorkerStatus 'Running' -WorkerDetail "GET $Uri — page $($pageIndex + 1)"
 		}
 
-		$results = Invoke-ZtRetry -ScriptBlock { Invoke-MgGraphRequest -Method GET -Uri $actualUri -OutputType HashTable }
+		$results = $null
+		try {
+			$results = Invoke-ZtRetry -ScriptBlock { Invoke-MgGraphRequest -Method GET -Uri $actualUri -OutputType HashTable }
+		}
+		catch {
+			Write-PSFMessage -Level Warning "Export '$Name' failed on page $pageIndex. URI: $actualUri" -ErrorRecord $_ -Tag Export, Error
+			throw
+		}
+
+		# Validate response - API may return error JSON as a valid hashtable without throwing
+		if ($results -is [hashtable] -and $results.ContainsKey('error')) {
+			$errorCode = $results.error.code
+			$errorMessage = $results.error.message
+			Write-PSFMessage -Level Warning "API returned error response for '$Name' page ${pageIndex}: [$errorCode] $errorMessage" -Tag Export, Error
+			throw "API returned error for '$Name': [$errorCode] $errorMessage"
+		}
+
 		Export-Page -PageIndex $pageIndex -Path $folderPath -Results $results -RelatedPropertyNames $RelatedPropertyNames -Name $Name -Uri $Uri
 
 		# Track file size for SignIn logs
@@ -207,7 +224,15 @@ function Export-ZtGraphEntity {
 		if (-not $actualUri) {
 			break
 		}
-		elseif ($hasTimeLimit -and (Get-Date) -gt $stopTime) {
+
+		# Detect stuck paging - same nextLink returned consecutively
+		if ($actualUri -eq $previousNextLink) {
+			Write-PSFMessage -Level Warning "Stuck paging detected for '$Name': nextLink unchanged on page $pageIndex. Stopping export." -Tag Export, Error
+			break
+		}
+		$previousNextLink = $actualUri
+
+		if ($hasTimeLimit -and (Get-Date) -gt $stopTime) {
 			Write-PSFMessage "Maximum time limit reached for $Name"
 			break
 		}


### PR DESCRIPTION
## Fix infinite loop during Graph API paging (#860)

When paging through large Graph API result sets (e.g., `UserRegistrationDetails`), if the API returns an error response that still contains `@odata.nextLink`, the export loop runs indefinitely. This also applies when transient 400 errors (like expired skip tokens) are immediately classified as non-retryable, causing the export to fail without retry.

### Changes

**4 files changed across 3 areas:**

#### 1. Paging loop hardening — `Export-ZtGraphEntity.ps1`
- **Clear stale results**: Set `$results = $null` at the start of each iteration so a failed API call (that was already retried five times) can't silently reuse the previous page's `@odata.nextLink`
- **Try-catch around API call**: Catches errors from `Invoke-ZtRetry`, logs the entity name/page/URI, then re-throws so the export is marked as `Failed`
- **Error-response validation**: Detects when `Invoke-MgGraphRequest` returns error JSON as a valid hashtable (with an `error` key) without throwing, and terminates the loop
- **Stuck-paging detection**: Tracks `$previousNextLink` and breaks if the same `@odata.nextLink` is returned on consecutive pages

#### 2. Broader retry classification — `Test-ZtRetryableError.ps1`
- Changed from an **allowlist** (`408, 429, 500, 502, 503, 504, 507`) to a **denylist