### PR TITLE
Add logging for export tenant data and database creation processes

### DIFF
--- a/src/powershell/private/export/Export-Database.ps1
+++ b/src/powershell/private/export/Export-Database.ps1
@@ -30,7 +30,10 @@ function Export-Database {
 		# The Zero Trust pillar to assess. Defaults to All.
 		[ValidateSet('All', 'Identity', 'Devices', 'Network', 'Data')]
 		[string]
-		$Pillar = 'All'
+		$Pillar = 'All',
+
+		[string]
+		$LogsPath
 	)
 
 	#region Utility Function
@@ -116,6 +119,41 @@ as
 	}
 	#endregion Utility Function
 
+	#region Logged Import Helper
+	function Import-EntraTableLogged {
+		[CmdletBinding()]
+		param (
+			[Parameter(Mandatory = $true)]
+			[DuckDB.NET.Data.DuckDBConnection]
+			$Database,
+
+			[Parameter(Mandatory = $true)]
+			[string]
+			$ExportPath,
+
+			[Parameter(Mandatory = $true)]
+			[string]
+			$TableName,
+
+			[string]
+			$LogsPath
+		)
+
+		Write-ZtDatabaseLog -TableName $TableName -LogsPath $LogsPath -Action Started
+		$tableStart = Get-Date
+		try {
+			Import-EntraTable -Database $Database -ExportPath $ExportPath -TableName $TableName
+			$tableDuration = (Get-Date) - $tableStart
+			Write-ZtDatabaseLog -TableName $TableName -LogsPath $LogsPath -Action Completed -Duration $tableDuration
+		}
+		catch {
+			$tableDuration = (Get-Date) - $tableStart
+			Write-ZtDatabaseLog -TableName $TableName -LogsPath $LogsPath -Action Failed -Duration $tableDuration -ErrorMessage $_
+			throw
+		}
+	}
+	#endregion Logged Import Helper
+
 	$activity = "Creating database"
 	Write-ZtProgress -Activity $activity -Status "Starting"
 	Update-ZtProgressState -WorkerId 'database' -WorkerName 'Creating Database' -WorkerStatus 'Running' -WorkerDetail 'Initializing...'
@@ -142,40 +180,40 @@ as
 	}
 
 	if ($Pillar -in ('All', 'Identity')) {
-		Import-EntraTable -Database $database -ExportPath $ExportPath -TableName 'User'
-		Import-EntraTable -Database $database -ExportPath $ExportPath -TableName 'Application'
-		Import-EntraTable -Database $database -ExportPath $ExportPath -TableName 'ServicePrincipal'
-		Import-EntraTable -Database $database -ExportPath $ExportPath -TableName 'ServicePrincipalSignIn'
-		Import-EntraTable -Database $database -ExportPath $ExportPath -TableName 'SignIn'
-		Import-EntraTable -Database $database -ExportPath $ExportPath -TableName 'RoleDefinition'
-		Import-EntraTable -Database $database -ExportPath $ExportPath -TableName 'RoleAssignment'
-		Import-EntraTable -Database $database -ExportPath $ExportPath -TableName 'RoleAssignmentGroup'
-		Import-EntraTable -Database $database -ExportPath $ExportPath -TableName 'RoleAssignmentScheduleInstance'
-		Import-EntraTable -Database $database -ExportPath $ExportPath -TableName 'RoleAssignmentScheduleInstanceGroup'
-		Import-EntraTable -Database $database -ExportPath $ExportPath -TableName 'RoleEligibilityScheduleInstance'
-		Import-EntraTable -Database $database -ExportPath $ExportPath -TableName 'RoleEligibilityScheduleInstanceGroup'
-		Import-EntraTable -Database $database -ExportPath $ExportPath -TableName 'RoleManagementPolicyAssignment'
-		Import-EntraTable -Database $database -ExportPath $ExportPath -TableName 'UserRegistrationDetails'
+		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'User' -LogsPath $LogsPath
+		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'Application' -LogsPath $LogsPath
+		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'ServicePrincipal' -LogsPath $LogsPath
+		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'ServicePrincipalSignIn' -LogsPath $LogsPath
+		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'SignIn' -LogsPath $LogsPath
+		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleDefinition' -LogsPath $LogsPath
+		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleAssignment' -LogsPath $LogsPath
+		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleAssignmentGroup' -LogsPath $LogsPath
+		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleAssignmentScheduleInstance' -LogsPath $LogsPath
+		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleAssignmentScheduleInstanceGroup' -LogsPath $LogsPath
+		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleEligibilityScheduleInstance' -LogsPath $LogsPath
+		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleEligibilityScheduleInstanceGroup' -LogsPath $LogsPath
+		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleManagementPolicyAssignment' -LogsPath $LogsPath
+		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'UserRegistrationDetails' -LogsPath $LogsPath
 
 		New-ViewRole -Database $database
 	}
 
 	if ($Pillar -in ('All', 'Devices')) {
-		Import-EntraTable -Database $database -ExportPath $ExportPath -TableName 'Device'
-		Import-EntraTable -Database $database -ExportPath $ExportPath -TableName 'ConfigurationPolicy'
+		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'Device' -LogsPath $LogsPath
+		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'ConfigurationPolicy' -LogsPath $LogsPath
 	}
 
 	if ($Pillar -in ('All', 'Network')) {
-		Import-EntraTable -Database $database -ExportPath $ExportPath -TableName 'User'
-		Import-EntraTable -Database $database -ExportPath $ExportPath -TableName 'Application'
-		Import-EntraTable -Database $database -ExportPath $ExportPath -TableName 'ServicePrincipal'
-		Import-EntraTable -Database $database -ExportPath $ExportPath -TableName 'RoleDefinition'
-		Import-EntraTable -Database $database -ExportPath $ExportPath -TableName 'RoleAssignment'
-		Import-EntraTable -Database $database -ExportPath $ExportPath -TableName 'RoleAssignmentGroup'
-		Import-EntraTable -Database $database -ExportPath $ExportPath -TableName 'RoleAssignmentScheduleInstance'
-		Import-EntraTable -Database $database -ExportPath $ExportPath -TableName 'RoleAssignmentScheduleInstanceGroup'
-		Import-EntraTable -Database $database -ExportPath $ExportPath -TableName 'RoleEligibilityScheduleInstance'
-		Import-EntraTable -Database $database -ExportPath $ExportPath -TableName 'RoleEligibilityScheduleInstanceGroup'
+		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'User' -LogsPath $LogsPath
+		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'Application' -LogsPath $LogsPath
+		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'ServicePrincipal' -LogsPath $LogsPath
+		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleDefinition' -LogsPath $LogsPath
+		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleAssignment' -LogsPath $LogsPath
+		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleAssignmentGroup' -LogsPath $LogsPath
+		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleAssignmentScheduleInstance' -LogsPath $LogsPath
+		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleAssignmentScheduleInstanceGroup' -LogsPath $LogsPath
+		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleEligibilityScheduleInstance' -LogsPath $LogsPath
+		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleEligibilityScheduleInstanceGroup' -LogsPath $LogsPath
 
 		New-ViewRole -Database $database
 	}

--- a/src/powershell/private/export/Export-ZtTenantData.ps1
+++ b/src/powershell/private/export/Export-ZtTenantData.ps1
@@ -51,7 +51,10 @@ function Export-ZtTenantData {
 		$Pillar = 'All',
 
 		[int]
-		$ThrottleLimit = (Get-PSFConfigValue -FullName 'ZeroTrustAssessment.ThrottleLimit.Export' -Fallback 5)
+		$ThrottleLimit = (Get-PSFConfigValue -FullName 'ZeroTrustAssessment.ThrottleLimit.Export' -Fallback 5),
+
+		[string]
+		$LogsPath
 	)
 
 	#region Helper Functions
@@ -146,8 +149,8 @@ https://github.com/microsoft/zerotrustassessment/issues
 		# Show $applicableExports
 		Write-PSFMessage "Applicable exports: $($applicableExports | ForEach-Object { $_.Name } | Sort-Object | Out-String)"
 
-		$workflow = Start-ZtTenantDataExport -ExportConfig $applicableExports -ThrottleLimit $ThrottleLimit -ExportPath $ExportPath
-		Wait-ZtTenantDataExport -Workflow $workflow
+		$workflow = Start-ZtTenantDataExport -ExportConfig $applicableExports -ThrottleLimit $ThrottleLimit -ExportPath $ExportPath -LogsPath $LogsPath
+		Wait-ZtTenantDataExport -Workflow $workflow -LogsPath $LogsPath
 	}
 	finally {
 		if ($workflow) {

--- a/src/powershell/private/export/Invoke-ZtTenantDataExport.ps1
+++ b/src/powershell/private/export/Invoke-ZtTenantDataExport.ps1
@@ -34,7 +34,10 @@
 		$ExportPath,
 
 		[Psftimespan]
-		$DependencyTimeout
+		$DependencyTimeout,
+
+		[string]
+		$LogsPath
 	)
 	begin {
 		$previousMessages = Get-PSFMessage -Runspace ([runspace]::DefaultRunspace.InstanceId)
@@ -71,6 +74,7 @@
 	}
 	process {
 		Write-PSFMessage -Message "Processing export '{0}'" -StringValues $Export.Name -Target $Export -Tag start
+		Write-ZtExportProgress -ExportName $Export.Name -LogsPath $LogsPath -Action Started
 
 		# Update progress dashboard: map this runspace to this export and mark as starting
 		$runspaceId = [runspace]::DefaultRunspace.InstanceId.ToString()
@@ -86,6 +90,7 @@
 			$workflow.Data[$Export.Name].Status = 'Waiting'
 			$workflow.Data[$Export.Name].Updated = Get-Date
 			Update-ZtProgressState -WorkerId $Export.Name -WorkerName $Export.Name -WorkerStatus 'Waiting' -WorkerDetail "Waiting for dependency: $($Export.DependsOn)"
+			Write-ZtExportProgress -ExportName $Export.Name -LogsPath $LogsPath -Action Waiting -StatusMessage "dependency:$($Export.DependsOn)"
 
 			while (-not $exportState -and $workflow.Data[$Export.DependsOn].Status -ne 'Done') {
 				Write-PSFMessage -Message "Export '{0}' depends on '{1}', which is not yet completed" -StringValues $Export.Name, $Export.DependsOn -Once "ZeroTrust-$($Export.Name)-$($identity)" -Target $Export
@@ -135,6 +140,7 @@
 			$result.Start = Get-Date
 			$workflow.Data[$Export.Name].Status = 'InProgress'
 			Update-ZtProgressState -WorkerId $Export.Name -WorkerName $Export.Name -WorkerStatus 'Running' -WorkerDetail 'Initializing...'
+			Write-ZtExportProgress -ExportName $Export.Name -LogsPath $LogsPath -Action InProgress
 			switch ($Export.Type) {
 				PrivilegedGroup {
 					$exportParam = $Export | ConvertTo-PSFHashtable -ReferenceCommand Export-ZtGraphEntityPrivilegedGroup
@@ -161,6 +167,7 @@
 				$result.Success = $false
 				$result.Error = $_
 			}
+			Write-ZtExportProgress -ExportName $Export.Name -LogsPath $LogsPath -Action Failed -ErrorMessage $_
 		}
 		finally {
 			$result.End = Get-Date
@@ -169,12 +176,14 @@
 				$workflow.Data[$Export.Name].Status = 'Done'
 				$workflow.Data[$Export.Name].Updated = Get-Date
 				Update-ZtProgressState -WorkerId $Export.Name -WorkerName $Export.Name -WorkerStatus 'Done' -WorkerDetail ''
+				Write-ZtExportProgress -ExportName $Export.Name -LogsPath $LogsPath -Action Completed -Duration $result.Duration
 			}
 		}
 		Write-PSFMessage -Message "Processing test '{0}' - Concluded" -StringValues $Export.Name -Target $Export -Tag end
 	}
 	end {
 		$result.Messages = Get-PSFMessage -Runspace ([runspace]::DefaultRunspace.InstanceId) | Where-Object { $_ -notin $previousMessages }
+		Write-ZtExportLog -Result $result -LogsPath $LogsPath
 		$result
 	}
 }

--- a/src/powershell/private/export/Start-ZtTenantDataExport.ps1
+++ b/src/powershell/private/export/Start-ZtTenantDataExport.ps1
@@ -39,7 +39,10 @@
 		$ExportPath,
 
 		[int]
-		$ThrottleLimit = 5
+		$ThrottleLimit = 5,
+
+		[string]
+		$LogsPath
 	)
 	begin {
 		#region Calculate Resources to Import
@@ -47,6 +50,7 @@
 			exportPath        = $ExportPath
 			dependencyTimeout = Get-PSFConfigValue -FullName 'ZeroTrustAssessment.Export.DependencyWaitLimit'
 			moduleRoot        = $script:ModuleRoot
+			logsPath          = $LogsPath
 		}
 
 		# Explicitly including all modules required, as we later import the psm1, not the psd1 file
@@ -90,7 +94,7 @@
 		$null = $workflow | Add-PSFRunspaceWorker -Name Exporter @param -Begin {
 			$script:ModuleRoot = $moduleRoot
 		} -ScriptBlock {
-			Invoke-ZtTenantDataExport -Export $_ -DependencyTimeout $dependencyTimeout -ExportPath $exportPath
+			Invoke-ZtTenantDataExport -Export $_ -DependencyTimeout $dependencyTimeout -ExportPath $exportPath -LogsPath $logsPath
 		}
 		$workflow | Write-PSFRunspaceQueue -Name Input -BulkValues @($ExportConfig) -Close
 		foreach ($export in $ExportConfig) {

--- a/src/powershell/private/export/Wait-ZtTenantDataExport.ps1
+++ b/src/powershell/private/export/Wait-ZtTenantDataExport.ps1
@@ -17,7 +17,10 @@
 	[CmdletBinding()]
 	param (
 		[PSFramework.Runspace.RSWorkflow]
-		$Workflow
+		$Workflow,
+
+		[string]
+		$LogsPath
 	)
 	begin {
 		$failedExports = @{}
@@ -25,6 +28,7 @@
 		$progressID = Get-Random -Minimum 1 -Maximum 999
 		$taskProgID = @{ }
 		$lastMessageScan = [datetime]::MinValue
+		$lastStatusSnapshot = [datetime]::MinValue
 
 		# Initialize progress dashboard summary for the export stage
 		Update-ZtProgressState -TotalItems $totalCount -CompletedItems 0 -FailedItems 0 -InProgressItems 0
@@ -87,6 +91,13 @@
 			}
 			catch {
 				# Non-critical: don't let message scanning break the wait loop
+			}
+
+			# Write periodic status snapshot to export progress log (~every 10 seconds)
+			if ($LogsPath -and ([datetime]::Now - $lastStatusSnapshot).TotalSeconds -ge 10) {
+				$statusMsg = "Pending:$countPending Waiting:$countWaiting InProgress:$countInProgress Done:$countDone Failed:$countFailed"
+				Write-ZtExportProgress -ExportName '_overall_' -LogsPath $LogsPath -Action Status -StatusMessage $statusMsg
+				$lastStatusSnapshot = [datetime]::Now
 			}
 
 			foreach ($task in $Workflow.Data.Values) {

--- a/src/powershell/private/export/Write-ZtDatabaseLog.ps1
+++ b/src/powershell/private/export/Write-ZtDatabaseLog.ps1
@@ -1,0 +1,125 @@
+function Write-ZtDatabaseLog {
+	<#
+	.SYNOPSIS
+		Appends a progress entry to the database import progress log.
+
+	.DESCRIPTION
+		Appends a single line to _database_progress.log in the logs folder, recording when
+		each table import starts, completes, or fails. This append-only log provides an
+		at-a-glance timeline of all database table imports and makes it easy to identify
+		which table import caused an issue.
+
+		Uses a per-file named mutex plus [System.IO.File]::AppendAllText for
+		consistency with the export and test progress log patterns.
+
+	.PARAMETER TableName
+		The name of the database table being imported.
+
+	.PARAMETER LogsPath
+		Path to the logs folder. If empty or null, the function is a no-op.
+
+	.PARAMETER Action
+		The progress action: Started, Completed, or Failed.
+
+	.PARAMETER Duration
+		The table import duration (for Completed/Failed actions).
+
+	.PARAMETER ErrorMessage
+		The error message (for Failed actions).
+
+	.EXAMPLE
+		PS C:\> Write-ZtDatabaseLog -TableName 'User' -LogsPath $logsPath -Action Started
+
+		Appends a STARTED line for the User table import to the database progress log.
+
+	.EXAMPLE
+		PS C:\> Write-ZtDatabaseLog -TableName 'User' -LogsPath $logsPath -Action Completed -Duration $elapsed
+
+		Appends a COMPLETED line for the User table import to the database progress log.
+	#>
+	[CmdletBinding()]
+	param (
+		[Parameter(Mandatory = $true)]
+		[string]
+		$TableName,
+
+		[string]
+		$LogsPath,
+
+		[Parameter(Mandatory = $true)]
+		[ValidateSet('Started', 'Completed', 'Failed')]
+		[string]
+		$Action,
+
+		[timespan]
+		$Duration,
+
+		$ErrorMessage
+	)
+	process {
+		if (-not $LogsPath) { return }
+
+		try {
+			[void][System.IO.Directory]::CreateDirectory($LogsPath)
+
+			$timestamp = (Get-Date).ToString('yyyy-MM-dd HH:mm:ss.fff')
+			$actionPadded = $Action.ToUpper().PadRight(10)
+
+			$line = "$timestamp  $actionPadded  $TableName"
+			if ($null -ne $Duration) {
+				$line += "  $($Duration.ToString('hh\:mm\:ss\.fff'))"
+			}
+			if ($Action -eq 'Failed' -and $ErrorMessage) {
+				$errorText = "$ErrorMessage"
+				$errorText = $errorText -replace '[\r\n\t]+', ' '
+				if ($errorText.Length -gt 1000) {
+					$errorText = $errorText.Substring(0, 1000) + '...'
+				}
+				$line += "  $errorText"
+			}
+			$line += [System.Environment]::NewLine
+
+			$progressFilePath = Join-Path $LogsPath '_database_progress.log'
+			$fullPath = [System.IO.Path]::GetFullPath($progressFilePath)
+			$normalizedPath = if ($IsWindows) { $fullPath.ToLowerInvariant() } else { $fullPath }
+
+			# Cache the mutex name per resolved path to avoid repeated SHA256 hashing
+			if (-not $script:ZtDatabaseProgressMutexCache) {
+				$script:ZtDatabaseProgressMutexCache = @{}
+			}
+			if ($script:ZtDatabaseProgressMutexCache.ContainsKey($normalizedPath)) {
+				$mutexName = $script:ZtDatabaseProgressMutexCache[$normalizedPath]
+			}
+			else {
+				$pathBytes = [System.Text.Encoding]::UTF8.GetBytes($normalizedPath)
+				$pathHashBytes = [System.Security.Cryptography.SHA256]::HashData($pathBytes)
+				$pathHash = [System.BitConverter]::ToString($pathHashBytes).Replace('-', '')
+				$mutexName = "Local\ZtDatabaseProgress_$pathHash"
+				$script:ZtDatabaseProgressMutexCache[$normalizedPath] = $mutexName
+			}
+
+			$mutex = $null
+			$lockAcquired = $false
+			try {
+				$mutex = [System.Threading.Mutex]::new($false, $mutexName)
+				$lockAcquired = $mutex.WaitOne([TimeSpan]::FromSeconds(5))
+				if (-not $lockAcquired) {
+					throw "Timed out waiting for database progress log mutex '$mutexName'."
+				}
+
+				[System.IO.File]::AppendAllText($fullPath, $line)
+			}
+			finally {
+				if ($lockAcquired -and $null -ne $mutex) {
+					$null = $mutex.ReleaseMutex()
+				}
+				if ($null -ne $mutex) {
+					$mutex.Dispose()
+				}
+			}
+		}
+		catch {
+			Write-PSFMessage -Level Warning -Message "Failed to write database progress log for '{0}': {1}" -StringValues $TableName, $_.Exception.Message -Tag log
+		}
+	}
+}

--- a/src/powershell/private/export/Write-ZtExportLog.ps1
+++ b/src/powershell/private/export/Write-ZtExportLog.ps1
@@ -1,0 +1,99 @@
+function Write-ZtExportLog {
+	<#
+	.SYNOPSIS
+		Writes a per-export log file with execution summary and PSFramework messages.
+
+	.DESCRIPTION
+		Writes a per-export log file with execution summary and PSFramework messages.
+		Each export gets its own export_<Name>.md file under the logs folder, making it
+		easy to debug individual export executions in parallel runs.
+
+		The log file contains a header block with export metadata (name, status,
+		duration, timing, Graph URI, errors) followed by timestamped message lines.
+
+	.PARAMETER Result
+		The export execution statistics object (ZeroTrustAssessment.ExportStatistics).
+
+	.PARAMETER LogsPath
+		Path to the logs folder. If empty or null, the function is a no-op.
+
+	.EXAMPLE
+		PS C:\> Write-ZtExportLog -Result $result -LogsPath $logsPath
+
+		Writes the full export log for the completed export to <LogsPath>/export_<Name>.md.
+	#>
+	[CmdletBinding()]
+	param (
+		[Parameter(Mandatory = $true)]
+		$Result,
+
+		[string]
+		$LogsPath
+	)
+	process {
+		if (-not $LogsPath) { return }
+
+		try {
+			[void][System.IO.Directory]::CreateDirectory($LogsPath)
+
+			$name = $Result.Name
+			$status = if ($Result.Success) { 'Done' } else { 'Failed' }
+			$duration = if ($null -ne $Result.Duration) { $Result.Duration.ToString('hh\:mm\:ss\.fff') } else { 'N/A' }
+			$startTime = if ($Result.Start) { $Result.Start.ToString('yyyy-MM-dd HH:mm:ss.fff') } else { 'N/A' }
+			$endTime = if ($Result.End) { $Result.End.ToString('yyyy-MM-dd HH:mm:ss.fff') } else { 'N/A' }
+
+			$lines = [System.Collections.Generic.List[string]]::new()
+			$lines.Add("# Export: $name")
+			$lines.Add("# Status: $status")
+			$lines.Add("# Duration: $duration")
+			$lines.Add("# Start: $startTime")
+			$lines.Add("# End: $endTime")
+			if ($Result.Export) {
+				$uri = $Result.Export.Uri
+				if ($uri) {
+					$lines.Add("# URI: $uri")
+				}
+				$type = $Result.Export.Type
+				if ($type) {
+					$lines.Add("# Type: $type")
+				}
+				$dependsOn = $Result.Export.DependsOn
+				if ($dependsOn) {
+					$lines.Add("# DependsOn: $dependsOn")
+				}
+			}
+			$moduleVersion = if ($script:__ZtSession.ModuleVersion) { $script:__ZtSession.ModuleVersion } else { 'Unknown' }
+			$lines.Add("# Version: $moduleVersion")
+			if (-not $Result.Success -and $Result.Error) {
+				$errorText = "$($Result.Error)"
+				$lines.Add("# Error: $errorText")
+			}
+			$lines.Add('# ---')
+
+			if ($Result.Messages) {
+				foreach ($msg in $Result.Messages) {
+					$timestamp = 'N/A'
+					if ($null -ne $msg.Timestamp) {
+						try {
+							$timestamp = ([datetime]$msg.Timestamp).ToString('yyyy-MM-dd HH:mm:ss.fff')
+						}
+						catch {
+							$timestamp = "$($msg.Timestamp)"
+						}
+					}
+
+					$level = if ($null -ne $msg.Level) { "$($msg.Level)" } else { 'Info' }
+					$text = if ($null -ne $msg.LogMessage) { "$($msg.LogMessage)" } else { '' }
+					$lines.Add("$timestamp [$level] $text")
+				}
+			}
+
+			$logMarkdownPath = Join-Path $LogsPath "export_$name.md"
+			[System.IO.File]::WriteAllLines($logMarkdownPath, $lines)
+		}
+		catch {
+			$errorMessage = if ($null -ne $_.Exception -and $null -ne $_.Exception.Message) { $_.Exception.Message } else { 'Unknown error while writing export log.' }
+			Write-PSFMessage -Level Warning -Message "Failed to write export log for '{0}': {1}" -StringValues $Result.Name, $errorMessage -Tag log
+		}
+	}
+}

--- a/src/powershell/private/export/Write-ZtExportProgress.ps1
+++ b/src/powershell/private/export/Write-ZtExportProgress.ps1
@@ -1,0 +1,143 @@
+function Write-ZtExportProgress {
+	<#
+	.SYNOPSIS
+		Appends a progress entry to the overall export execution progress log.
+
+	.DESCRIPTION
+		Appends a single line to _export_progress.log in the logs folder, recording when
+		each export starts, waits for dependencies, completes, or fails. This append-only
+		log provides an at-a-glance timeline of all export executions and makes it easy to
+		identify hanging exports (STARTED without a matching COMPLETED/FAILED line).
+
+		Uses a per-file named mutex plus [System.IO.File]::AppendAllText to
+		serialize writes from parallel runspaces/processes and keep each entry
+		on a single line.
+
+	.PARAMETER ExportName
+		The name of the export to log progress for.
+
+	.PARAMETER LogsPath
+		Path to the logs folder. If empty or null, the function is a no-op.
+
+	.PARAMETER Action
+		The progress action: Started, Waiting, InProgress, Completed, Failed, or Status.
+
+	.PARAMETER Duration
+		The export duration (for Completed/Failed actions).
+
+	.PARAMETER ErrorMessage
+		The error message (for Failed actions).
+
+	.PARAMETER StatusMessage
+		Additional status information (for Waiting/Status actions).
+
+	.EXAMPLE
+		PS C:\> Write-ZtExportProgress -ExportName 'User' -LogsPath $logsPath -Action Started
+
+		Appends a STARTED line for the User export to the export progress log.
+
+	.EXAMPLE
+		PS C:\> Write-ZtExportProgress -ExportName 'User' -LogsPath $logsPath -Action Completed -Duration $result.Duration
+
+		Appends a COMPLETED line for the User export to the export progress log.
+
+	.EXAMPLE
+		PS C:\> Write-ZtExportProgress -ExportName 'RoleAssignmentGroup' -LogsPath $logsPath -Action Waiting -StatusMessage 'dependency:RoleAssignment'
+
+		Appends a WAITING line indicating a dependency wait.
+	#>
+	[CmdletBinding()]
+	param (
+		[Parameter(Mandatory = $true)]
+		[string]
+		$ExportName,
+
+		[string]
+		$LogsPath,
+
+		[Parameter(Mandatory = $true)]
+		[ValidateSet('Started', 'Waiting', 'InProgress', 'Completed', 'Failed', 'Status')]
+		[string]
+		$Action,
+
+		[timespan]
+		$Duration,
+
+		$ErrorMessage,
+
+		[string]
+		$StatusMessage
+	)
+	process {
+		if (-not $LogsPath) { return }
+
+		try {
+			[void][System.IO.Directory]::CreateDirectory($LogsPath)
+
+			$timestamp = (Get-Date).ToString('yyyy-MM-dd HH:mm:ss.fff')
+			$actionPadded = $Action.ToUpper().PadRight(10)
+
+			$line = "$timestamp  $actionPadded  $ExportName"
+			if ($null -ne $Duration) {
+				$line += "  $($Duration.ToString('hh\:mm\:ss\.fff'))"
+			}
+			if ($Action -eq 'Waiting' -and $StatusMessage) {
+				$line += "  $StatusMessage"
+			}
+			if ($Action -eq 'Status' -and $StatusMessage) {
+				$line += "  $StatusMessage"
+			}
+			if ($Action -eq 'Failed' -and $ErrorMessage) {
+				$errorText = "$ErrorMessage"
+				$errorText = $errorText -replace '[\r\n\t]+', ' '
+				if ($errorText.Length -gt 1000) {
+					$errorText = $errorText.Substring(0, 1000) + '...'
+				}
+				$line += "  $errorText"
+			}
+			$line += [System.Environment]::NewLine
+
+			$progressFilePath = Join-Path $LogsPath '_export_progress.log'
+			$fullPath = [System.IO.Path]::GetFullPath($progressFilePath)
+			$normalizedPath = if ($IsWindows) { $fullPath.ToLowerInvariant() } else { $fullPath }
+
+			# Cache the mutex name per resolved path to avoid repeated SHA256 hashing
+			if (-not $script:ZtExportProgressMutexCache) {
+				$script:ZtExportProgressMutexCache = @{}
+			}
+			if ($script:ZtExportProgressMutexCache.ContainsKey($normalizedPath)) {
+				$mutexName = $script:ZtExportProgressMutexCache[$normalizedPath]
+			}
+			else {
+				$pathBytes = [System.Text.Encoding]::UTF8.GetBytes($normalizedPath)
+				$pathHashBytes = [System.Security.Cryptography.SHA256]::HashData($pathBytes)
+				$pathHash = [System.BitConverter]::ToString($pathHashBytes).Replace('-', '')
+				$mutexName = "Local\ZtExportProgress_$pathHash"
+				$script:ZtExportProgressMutexCache[$normalizedPath] = $mutexName
+			}
+
+			$mutex = $null
+			$lockAcquired = $false
+			try {
+				$mutex = [System.Threading.Mutex]::new($false, $mutexName)
+				$lockAcquired = $mutex.WaitOne([TimeSpan]::FromSeconds(5))
+				if (-not $lockAcquired) {
+					throw "Timed out waiting for export progress log mutex '$mutexName'."
+				}
+
+				[System.IO.File]::AppendAllText($fullPath, $line)
+			}
+			finally {
+				if ($lockAcquired -and $null -ne $mutex) {
+					$null = $mutex.ReleaseMutex()
+				}
+				if ($null -ne $mutex) {
+					$mutex.Dispose()
+				}
+			}
+		}
+		catch {
+			Write-PSFMessage -Level Warning -Message "Failed to write export progress log for '{0}': {1}" -StringValues $ExportName, $_.Exception.Message -Tag log
+		}
+	}
+}

--- a/src/powershell/public/Invoke-ZtAssessment.ps1
+++ b/src/powershell/public/Invoke-ZtAssessment.ps1
@@ -465,10 +465,10 @@ function Invoke-ZtAssessment {
 
 	Write-PSFMessage -Message "Stage 1: Exporting Tenant Data" -Tag stage
 	Update-ZtProgressState -Stage 'export' -StageNumber 1 -StageName 'Exporting Tenant Data'
-	Export-ZtTenantData -ExportPath $exportPath -Days $Days -MaximumSignInLogQueryTime $MaximumSignInLogQueryTime -Pillar $Pillar -ThrottleLimit $ExportThrottleLimit
+	Export-ZtTenantData -ExportPath $exportPath -Days $Days -MaximumSignInLogQueryTime $MaximumSignInLogQueryTime -Pillar $Pillar -ThrottleLimit $ExportThrottleLimit -LogsPath $logsPath
 
 	Update-ZtProgressState -Stage 'database' -StageNumber 1 -StageName 'Importing Data into Database' -ClearWorkers
-	$database = Export-Database -ExportPath $exportPath -Pillar $Pillar
+	$database = Export-Database -ExportPath $exportPath -Pillar $Pillar -LogsPath $logsPath
 
 	try {
 		# Run the tests


### PR DESCRIPTION
This pull request adds robust logging capabilities to the export and database import processes, enabling detailed tracking of progress and errors. The changes introduce new parameters for specifying log paths and implement logging functions that record key actions and statuses for both database imports and export workflows.

**Logging enhancements for database import and export operations:**

* Added a new `LogsPath` parameter to `Export-Database`, `Export-ZtTenantData`, `Invoke-ZtTenantDataExport`, `Start-ZtTenantDataExport`, and `Wait-ZtTenantDataExport` to allow specifying a log directory for progress tracking.
* Introduced the `Write-ZtDatabaseLog` function, which appends progress entries to a database import log file, recording when each table import starts, completes, or fails, including duration and error messages.
* Replaced direct calls to `Import-EntraTable` with a new helper function `Import-EntraTableLogged` in `Export-Database`, which wraps imports with logging for start, completion, and failure events.

**Export workflow progress logging:**

* Enhanced `Invoke-ZtTenantDataExport` to log export actions (Started, Waiting, InProgress, Failed, Completed) and errors using `Write-ZtExportProgress`, and to write a summary log at the end of each export.
* Updated `Wait-ZtTenantDataExport` to periodically log overall export status snapshots (every ~10 seconds) for improved visibility into workflow progress.

**Parameter propagation and workflow integration:**

* Propagated the `LogsPath` parameter through all relevant export workflow functions to ensure logging is consistently applied throughout the process.

These changes collectively improve traceability and troubleshooting for export and database import operations by providing clear, timestamped logs for all major actions and errors.