### PR TITLE
Network 25411: TLS inspection is enabled and correctly configured for outbound traffic - Spec Update

### DIFF
--- a/src/powershell/tests/Test-Assessment.25411.ps1
+++ b/src/powershell/tests/Test-Assessment.25411.ps1
@@ -131,7 +131,7 @@ function Test-Assessment-25411 {
     if ($baselineProfileResults.Count -gt 0) {
 
         $mdInfo += "`n## TLS Inspection Policies Linked to Baseline Profiles`n`n"
-        $mdInfo += "| Linked Profile Name | Linked Profile Priority | Linked Policy Name | Policy Link State | Profile State |`n"
+        $mdInfo += "| Linked profile name | Linked profile priority | Linked policy name | Policy link state | Profile state |`n"
         $mdInfo += "| :--- | :--- | :--- | :--- | :--- |`n"
         foreach ($policy in $baselineProfileResults) {
             $baselineProfilePortalLink = "https://entra.microsoft.com/#view/Microsoft_Azure_Network_Access/EditProfileMenuBlade.MenuView/~/basics/profileId/$(($policy.ProfileId))"
@@ -147,7 +147,7 @@ function Test-Assessment-25411 {
 
     if ($securityProfileResults.Count -gt 0) {
         $mdInfo += "`n## TLS Inspection Policies Linked to Security Profiles`n`n"
-        $mdInfo += "| Linked Profile Name | Linked Profile Priority | Linked Policy Name | Policy Link State | Profile State | CA Policy Name | CA Policy State |`n"
+        $mdInfo += "| Linked profile name | Linked profile priority | Linked policy name | Policy link state | Profile state | CA policy name | CA policy state |`n"
         $mdInfo += "| :--- | :--- | :--- | :--- | :--- | :--- | :--- |`n"
         foreach ($profile in $securityProfileResults) {
             $securityProfilePortalLink = "https://entra.microsoft.com/#view/Microsoft_Azure_Network_Access/EditProfileMenuBlade.MenuView/~/basics/profileId/$(($profile.ProfileId))"

--- a/src/powershell/tests/Test-Assessment.25411.ps1
+++ b/src/powershell/tests/Test-Assessment.25411.ps1
@@ -2,7 +2,7 @@
 .SYNOPSIS
     TLS inspection is enabled and correctly configured for outbound traffic in Global Secure Access.
 .DESCRIPTION
-    Verifies that a TLS Inspection policy is properly configured. It will fail if no TLS Inspection policy exists, if the policy is not linked to a Security Profile, or if no Conditional Access policy assigning that Security Profile can be identified.
+    Verifies that a TLS Inspection policy is properly configured. It will fail if no TLS Inspection policy exists, if the policy is not linked to a Baseline or Security Profile with an enabled policy link, or (for Security Profiles) if no enabled Conditional Access policy assigning that profile can be identified.
 #>
 
 function Test-Assessment-25411 {
@@ -49,8 +49,8 @@ function Test-Assessment-25411 {
 
     #region Data Processing
     # Graph responses are automatically unwrapped by Invoke-ZtGraphRequest
-    $baselineProfileResults = @()
-    $securityProfileResults = @()
+    $baselineProfileResults = [System.Collections.Generic.List[object]]::new()
+    $securityProfileResults = [System.Collections.Generic.List[object]]::new()
 
     # Iterate each TLS inspection policy and find linked profiles using the helper function
     foreach ($tlsPolicy in $tlsInspectionPolicies) {
@@ -67,7 +67,7 @@ function Test-Assessment-25411 {
 
         foreach ($policyProfile in $linkedProfiles) {
             if ($policyProfile.ProfileType -eq 'Baseline Profile') {
-                $baselineProfileResults += [PSCustomObject]@{
+                $baselineProfileResults.Add([PSCustomObject]@{
                     ProfileId          = $policyProfile.ProfileId
                     ProfileName        = $policyProfile.ProfileName
                     ProfileState       = $policyProfile.ProfileState
@@ -75,7 +75,7 @@ function Test-Assessment-25411 {
                     TLSPolicyId        = $tlsPolicy.id
                     TLSPolicyName      = $tlsPolicy.name
                     TLSPolicyLinkState = $policyProfile.PolicyLinkState
-                }
+                })
             }
             elseif ($policyProfile.ProfileType -eq 'Security Profile') {
                 $matchedCAPolicies = @()
@@ -84,7 +84,7 @@ function Test-Assessment-25411 {
                 }
 
                 # Collect all linked security profiles for table display (regardless of state or CA policy linkage)
-                $securityProfileResults += [PSCustomObject]@{
+                $securityProfileResults.Add([PSCustomObject]@{
                     ProfileId          = $policyProfile.ProfileId
                     ProfileName        = $policyProfile.ProfileName
                     ProfileState       = $policyProfile.ProfileState
@@ -94,13 +94,13 @@ function Test-Assessment-25411 {
                     TLSPolicyLinkState = $policyProfile.PolicyLinkState
                     MatchedCAPolicies  = $matchedCAPolicies
                     PassesCriteria     = $policyProfile.PassesCriteria
-                }
+                })
             }
         }
     }
 
     # Baseline profiles that pass: both policy link state and profile state must be enabled
-    $enabledBaseLineProfiles = @($baselineProfileResults | Where-Object { $_.ProfileState -eq 'enabled' -and $_.TLSPolicyLinkState -eq 'enabled' })
+    $enabledBaselineProfiles = @($baselineProfileResults | Where-Object { $_.ProfileState -eq 'enabled' -and $_.TLSPolicyLinkState -eq 'enabled' })
 
     # Security profiles that pass: profile enabled, policy link enabled, and at least one enabled CA policy linked
     $enabledSecurityProfiles = @($securityProfileResults | Where-Object { $_.ProfileState -eq 'enabled' -and $_.TLSPolicyLinkState -eq 'enabled' -and $_.PassesCriteria })
@@ -114,13 +114,8 @@ function Test-Assessment-25411 {
 
     if ($null -eq $tlsInspectionPolicies -or $tlsInspectionPolicies.Count -eq 0) {
         $testResultMarkdown = "❌ TLS Inspection Policy has not been properly configured. `n`n%TestResult%"
-        $passed = $false
     }
-    elseif ($enabledBaseLineProfiles.Count -gt 0) {
-        $testResultMarkdown = "✅ TLS Inspection Policy is enabled and properly configured to inspect encrypted outbound traffic.`n`n%TestResult%"
-        $passed = $true
-    }
-    elseif ($enabledSecurityProfiles.Count -gt 0) {
+    elseif ($enabledBaselineProfiles.Count -gt 0 -or $enabledSecurityProfiles.Count -gt 0) {
         $testResultMarkdown = "✅ TLS Inspection Policy is enabled and properly configured to inspect encrypted outbound traffic.`n`n%TestResult%"
         $passed = $true
     }
@@ -139,14 +134,14 @@ function Test-Assessment-25411 {
         $mdInfo += "| Linked Profile Name | Linked Profile Priority | Linked Policy Name | Policy Link State | Profile State |`n"
         $mdInfo += "| :--- | :--- | :--- | :--- | :--- |`n"
         foreach ($policy in $baselineProfileResults) {
-            $baseLineProfilePortalLink = "https://entra.microsoft.com/#view/Microsoft_Azure_Network_Access/EditProfileMenuBlade.MenuView/~/basics/profileId/$(($policy.ProfileId))"
+            $baselineProfilePortalLink = "https://entra.microsoft.com/#view/Microsoft_Azure_Network_Access/EditProfileMenuBlade.MenuView/~/basics/profileId/$(($policy.ProfileId))"
             $tlsPolicyPortalLink = "https://entra.microsoft.com/#view/Microsoft_Azure_Network_Access/EditTlsInspectionPolicyMenuBlade.MenuView/~/basics/policyId/$(($policy.TLSPolicyId))"
             $profileName = Get-SafeMarkdown -Text $policy.ProfileName
             $profilePriority = $policy.ProfilePriority
             $tlsPolicyName = Get-SafeMarkdown -Text $policy.TLSPolicyName
             $tlsPolicyLinkState = if ($policy.TLSPolicyLinkState -eq 'enabled') { '✅ Enabled' } else { '❌ Disabled' }
             $profileState = if ($policy.ProfileState -eq 'enabled') { '✅ Enabled' } else { '❌ Disabled' }
-            $mdInfo += "| [$profileName]($baseLineProfilePortalLink) | $profilePriority | [$tlsPolicyName]($tlsPolicyPortalLink) | $tlsPolicyLinkState | $profileState |`n"
+            $mdInfo += "| [$profileName]($baselineProfilePortalLink) | $profilePriority | [$tlsPolicyName]($tlsPolicyPortalLink) | $tlsPolicyLinkState | $profileState |`n"
         }
     }
 
@@ -163,13 +158,13 @@ function Test-Assessment-25411 {
             $tlsPolicyLinkState = if ($profile.TLSPolicyLinkState -eq 'enabled') { '✅ Enabled' } else { '❌ Disabled' }
             $profileState = if ($profile.ProfileState -eq 'enabled') { '✅ Enabled' } else { '❌ Disabled' }
             if ($profile.MatchedCAPolicies.Count -gt 0) {
-                $caPolicyLinksMarkdown = @()
-                $caPolicyStatesList = @()
+                $caPolicyLinksMarkdown = [System.Collections.Generic.List[string]]::new()
+                $caPolicyStatesList = [System.Collections.Generic.List[string]]::new()
                 foreach ($caPolicy in $profile.MatchedCAPolicies) {
                     $caPolicyPortalLink = "https://entra.microsoft.com/#view/Microsoft_AAD_ConditionalAccess/PolicyBlade/policyId/$($caPolicy.Id)"
                     $safeName = Get-SafeMarkdown -Text $caPolicy.DisplayName
-                    $caPolicyLinksMarkdown += "[$safeName]($caPolicyPortalLink)"
-                    $caPolicyStatesList += if ($caPolicy.State -eq 'enabled') { '✅ Enabled' } elseif ($caPolicy.State -eq 'enabledForReportingButNotEnforced') { '⚠️ Report Only' } else { '❌ Disabled' }
+                    $caPolicyLinksMarkdown.Add("[$safeName]($caPolicyPortalLink)")
+                    $caPolicyStatesList.Add($(if ($caPolicy.State -eq 'enabled') { '✅ Enabled' } elseif ($caPolicy.State -eq 'enabledForReportingButNotEnforced') { '⚠️ Report Only' } else { '❌ Disabled' }))
                 }
                 $caPolicyNamesLinked = $caPolicyLinksMarkdown -join ', '
                 $caPolicyStates = $caPolicyStatesList -join ', '

--- a/src/powershell/tests/Test-Assessment.25411.ps1
+++ b/src/powershell/tests/Test-Assessment.25411.ps1
@@ -49,8 +49,8 @@ function Test-Assessment-25411 {
 
     #region Data Processing
     # Graph responses are automatically unwrapped by Invoke-ZtGraphRequest
-    $enabledSecurityProfiles = @()
-    $enabledBaseLineProfiles = @()
+    $baselineProfileResults = @()
+    $securityProfileResults = @()
 
     # Iterate each TLS inspection policy and find linked profiles using the helper function
     foreach ($tlsPolicy in $tlsInspectionPolicies) {
@@ -66,8 +66,8 @@ function Test-Assessment-25411 {
         $linkedProfiles = Find-ZtProfilesLinkedToPolicy @findParams
 
         foreach ($policyProfile in $linkedProfiles) {
-            if ($policyProfile.ProfileType -eq 'Baseline Profile' -and $policyProfile.PassesCriteria -and $policyProfile.ProfileState -eq 'enabled') {
-                $enabledBaseLineProfiles += [PSCustomObject]@{
+            if ($policyProfile.ProfileType -eq 'Baseline Profile') {
+                $baselineProfileResults += [PSCustomObject]@{
                     ProfileId          = $policyProfile.ProfileId
                     ProfileName        = $policyProfile.ProfileName
                     ProfileState       = $policyProfile.ProfileState
@@ -77,13 +77,14 @@ function Test-Assessment-25411 {
                     TLSPolicyLinkState = $policyProfile.PolicyLinkState
                 }
             }
-            elseif ($policyProfile.ProfileType -eq 'Security Profile' -and $policyProfile.PassesCriteria -and $policyProfile.ProfileState -eq 'enabled') {
+            elseif ($policyProfile.ProfileType -eq 'Security Profile') {
                 $matchedCAPolicies = @()
                 if ($null -ne $policyProfile.CAPolicy) {
                     $matchedCAPolicies = @($policyProfile.CAPolicy)
                 }
 
-                $enabledSecurityProfiles += [PSCustomObject]@{
+                # Collect all linked security profiles for table display (regardless of state or CA policy linkage)
+                $securityProfileResults += [PSCustomObject]@{
                     ProfileId          = $policyProfile.ProfileId
                     ProfileName        = $policyProfile.ProfileName
                     ProfileState       = $policyProfile.ProfileState
@@ -92,17 +93,17 @@ function Test-Assessment-25411 {
                     TLSPolicyName      = $tlsPolicy.name
                     TLSPolicyLinkState = $policyProfile.PolicyLinkState
                     MatchedCAPolicies  = $matchedCAPolicies
-                    CAPolicyCount      = $matchedCAPolicies.Count
-                    DefaultAction      = if ($null -ne $tlsPolicy.settings) {
-                        $tlsPolicy.settings.defaultAction
-                    }
-                    else {
-                        'unknown'
-                    }
+                    PassesCriteria     = $policyProfile.PassesCriteria
                 }
             }
         }
     }
+
+    # Baseline profiles that pass: both policy link state and profile state must be enabled
+    $enabledBaseLineProfiles = @($baselineProfileResults | Where-Object { $_.ProfileState -eq 'enabled' -and $_.TLSPolicyLinkState -eq 'enabled' })
+
+    # Security profiles that pass: profile enabled, policy link enabled, and at least one enabled CA policy linked
+    $enabledSecurityProfiles = @($securityProfileResults | Where-Object { $_.ProfileState -eq 'enabled' -and $_.TLSPolicyLinkState -eq 'enabled' -and $_.PassesCriteria })
 
     #endregion Data Processing
     #region Assessment logic
@@ -132,47 +133,52 @@ function Test-Assessment-25411 {
 
     #region Report Generation
 
-    if ($enabledBaseLineProfiles.Count -gt 0) {
+    if ($baselineProfileResults.Count -gt 0) {
 
         $mdInfo += "`n## TLS Inspection Policies Linked to Baseline Profiles`n`n"
         $mdInfo += "| Linked Profile Name | Linked Profile Priority | Linked Policy Name | Policy Link State | Profile State |`n"
         $mdInfo += "| :--- | :--- | :--- | :--- | :--- |`n"
-        foreach ($policy in $enabledBaseLineProfiles) {
+        foreach ($policy in $baselineProfileResults) {
             $baseLineProfilePortalLink = "https://entra.microsoft.com/#view/Microsoft_Azure_Network_Access/EditProfileMenuBlade.MenuView/~/basics/profileId/$(($policy.ProfileId))"
             $tlsPolicyPortalLink = "https://entra.microsoft.com/#view/Microsoft_Azure_Network_Access/EditTlsInspectionPolicyMenuBlade.MenuView/~/basics/policyId/$(($policy.TLSPolicyId))"
             $profileName = Get-SafeMarkdown -Text $policy.ProfileName
             $profilePriority = $policy.ProfilePriority
             $tlsPolicyName = Get-SafeMarkdown -Text $policy.TLSPolicyName
-            $tlsPolicyLinkState = $policy.TLSPolicyLinkState
-            $profileState = $policy.ProfileState
+            $tlsPolicyLinkState = if ($policy.TLSPolicyLinkState -eq 'enabled') { '✅ Enabled' } else { '❌ Disabled' }
+            $profileState = if ($policy.ProfileState -eq 'enabled') { '✅ Enabled' } else { '❌ Disabled' }
             $mdInfo += "| [$profileName]($baseLineProfilePortalLink) | $profilePriority | [$tlsPolicyName]($tlsPolicyPortalLink) | $tlsPolicyLinkState | $profileState |`n"
         }
     }
 
-    if ($enabledSecurityProfiles.Count -gt 0) {
-        $mdInfo += "`n## Security Profiles Linked to Conditional Access Policies`n`n"
-        $mdInfo += "| Linked Profile Name | Linked Profile Priority | CA Policy Names | CA Policy State | Profile State | TLS Inspection Policy Name | Default Action |`n"
+    if ($securityProfileResults.Count -gt 0) {
+        $mdInfo += "`n## TLS Inspection Policies Linked to Security Profiles`n`n"
+        $mdInfo += "| Linked Profile Name | Linked Profile Priority | Linked Policy Name | Policy Link State | Profile State | CA Policy Name | CA Policy State |`n"
         $mdInfo += "| :--- | :--- | :--- | :--- | :--- | :--- | :--- |`n"
-        foreach ($enabledProfile in $enabledSecurityProfiles) {
-            $securityProfilePortalLink = "https://entra.microsoft.com/#view/Microsoft_Azure_Network_Access/EditProfileMenuBlade.MenuView/~/basics/profileId/$(($enabledProfile.ProfileId))"
-            $tlsPolicyPortalLink = "https://entra.microsoft.com/#view/Microsoft_Azure_Network_Access/EditTlsInspectionPolicyMenuBlade.MenuView/~/basics/policyId/$(($enabledProfile.TLSPolicyId))"
-            $profileName = Get-SafeMarkdown -Text $enabledProfile.ProfileName
-            $profilePriority = $enabledProfile.ProfilePriority
-            # Build CA policy links
-            $caPolicyLinksMarkdown = @()
-            $caPolicyStatesList = @()
-            foreach ($caPolicy in $enabledProfile.MatchedCAPolicies) {
-                $caPolicyPortalLink = "https://entra.microsoft.com/#view/Microsoft_AAD_ConditionalAccess/PolicyBlade/policyId/$($caPolicy.Id)"
-                $safeName = Get-SafeMarkdown -Text $caPolicy.DisplayName
-                $caPolicyLinksMarkdown += "[$safeName]($caPolicyPortalLink)"
-                $caPolicyStatesList += $caPolicy.State
+        foreach ($profile in $securityProfileResults) {
+            $securityProfilePortalLink = "https://entra.microsoft.com/#view/Microsoft_Azure_Network_Access/EditProfileMenuBlade.MenuView/~/basics/profileId/$(($profile.ProfileId))"
+            $tlsPolicyPortalLink = "https://entra.microsoft.com/#view/Microsoft_Azure_Network_Access/EditTlsInspectionPolicyMenuBlade.MenuView/~/basics/policyId/$(($profile.TLSPolicyId))"
+            $profileName = Get-SafeMarkdown -Text $profile.ProfileName
+            $profilePriority = $profile.ProfilePriority
+            $tlsPolicyName = Get-SafeMarkdown -Text $profile.TLSPolicyName
+            $tlsPolicyLinkState = if ($profile.TLSPolicyLinkState -eq 'enabled') { '✅ Enabled' } else { '❌ Disabled' }
+            $profileState = if ($profile.ProfileState -eq 'enabled') { '✅ Enabled' } else { '❌ Disabled' }
+            if ($profile.MatchedCAPolicies.Count -gt 0) {
+                $caPolicyLinksMarkdown = @()
+                $caPolicyStatesList = @()
+                foreach ($caPolicy in $profile.MatchedCAPolicies) {
+                    $caPolicyPortalLink = "https://entra.microsoft.com/#view/Microsoft_AAD_ConditionalAccess/PolicyBlade/policyId/$($caPolicy.Id)"
+                    $safeName = Get-SafeMarkdown -Text $caPolicy.DisplayName
+                    $caPolicyLinksMarkdown += "[$safeName]($caPolicyPortalLink)"
+                    $caPolicyStatesList += if ($caPolicy.State -eq 'enabled') { '✅ Enabled' } elseif ($caPolicy.State -eq 'enabledForReportingButNotEnforced') { '⚠️ Report Only' } else { '❌ Disabled' }
+                }
+                $caPolicyNamesLinked = $caPolicyLinksMarkdown -join ', '
+                $caPolicyStates = $caPolicyStatesList -join ', '
             }
-            $caPolicyNamesLinked = $caPolicyLinksMarkdown -join ', '
-            $caPolicyStates = $caPolicyStatesList -join ', '
-            $profileState = $enabledProfile.ProfileState
-            $tlsPolicyName = Get-SafeMarkdown -Text $enabledProfile.TLSPolicyName
-            $defaultAction = $enabledProfile.DefaultAction
-            $mdInfo += "| [$profileName]($securityProfilePortalLink) | $profilePriority | $caPolicyNamesLinked | $caPolicyStates | $profileState | [$tlsPolicyName]($tlsPolicyPortalLink) | $defaultAction |`n"
+            else {
+                $caPolicyNamesLinked = 'Missing'
+                $caPolicyStates = 'Missing'
+            }
+            $mdInfo += "| [$profileName]($securityProfilePortalLink) | $profilePriority | [$tlsPolicyName]($tlsPolicyPortalLink) | $tlsPolicyLinkState | $profileState | $caPolicyNamesLinked | $caPolicyStates |`n"
         }
     }
 

--- a/src/powershell/tests/Test-Assessment.25411.ps1
+++ b/src/powershell/tests/Test-Assessment.25411.ps1
@@ -37,8 +37,8 @@ function Test-Assessment-25411 {
     # Step 2: List all policies in the Baseline Profile and in each Security Profile
     Write-ZtProgress -Activity $activity -Status 'Querying filtering profiles and policies'
     $filteringProfiles = Invoke-ZtGraphRequest -RelativeUri 'networkAccess/filteringProfiles' -QueryParameters @{
-        '$select' = 'id,name,description,state,version,priority'
-        '$expand' = 'policies($select=id,state;$expand=policy($select=id,name,version)),conditionalAccessPolicies($select=id,displayName)'
+        '$select' = 'id,name,description,state,priority'
+        '$expand' = 'policies($select=id,state;$expand=policy($select=id,name,version))'
     } -ApiVersion beta
 
     # Query all Conditional Access policies with details


### PR DESCRIPTION
PR Contains below changes:

1. Collect all linked profiles for table display regardless of state (previously only enabled profiles were collected, causing disabled entries to silently disappear from tables)
2. Tables now show profiles with `❌ Disabled` state so users can see misconfigured entries
3. Added `TLSPolicyLinkState -eq 'enabled'` check to Baseline Profile pass/fail logic (previously a disabled policy link would incorrectly count as a pass)
4. Added `TLSPolicyLinkState -eq 'enabled'` check to Security Profile pass/fail logic for consistency
5. Renamed `$enabledBaseLineProfiles` collection variable to `$baselineProfileResults` to reflect it now holds all linked baseline profiles, not only passing ones
6. Pass/fail filtering now derived post-collection via `Where-Object` on `$baselineProfileResults` and `$securityProfileResults`