### PR TITLE
Fix: Update Q3 notification query to use Admin assignment in test 21820

### DIFF
--- a/src/powershell/tests/Test-Assessment.21820.ps1
+++ b/src/powershell/tests/Test-Assessment.21820.ps1
@@ -98,11 +98,11 @@ function Test-Assessment-21820 {
         Write-PSFMessage "Role: $($role.displayName) - isDefaultRecipientsEnabled: $isDefaultRecipientsEnabled, Recipients: $($notificationRecipients -join ', ')" -Level Verbose
 
         # Check if alert is properly configured
-        # Fail if: (isDefaultRecipientsEnabled is true AND notificationRecipients is empty) OR (isDefaultRecipientsEnabled is false AND no custom recipients)
-        if (($isDefaultRecipientsEnabled -eq $true -and ([string]::IsNullOrEmpty($notificationRecipients) -or $notificationRecipients.Count -eq 0))) {
+        # Fail if: isDefaultRecipientsEnabled is false AND notificationRecipients is empty
+        if ($isDefaultRecipientsEnabled -eq $false -and ([string]::IsNullOrEmpty($notificationRecipients) -or $notificationRecipients.Count -eq 0)) {
 
             $passed = $false
-            Write-PSFMessage "Alert misconfigured for role: $($role.displayName) - Default recipients enabled but no recipients configured" -Level Verbose
+            Write-PSFMessage "Alert misconfigured for role: $($role.displayName) - Default recipients disabled and no custom recipients configured" -Level Verbose
 
             $rolesWithIssues += @{
                 Role                       = $role

--- a/src/powershell/tests/Test-Assessment.21820.ps1
+++ b/src/powershell/tests/Test-Assessment.21820.ps1
@@ -99,7 +99,7 @@ function Test-Assessment-21820 {
 
         # Check if alert is properly configured
         # Fail if: isDefaultRecipientsEnabled is false AND notificationRecipients is empty
-        if ($isDefaultRecipientsEnabled -eq $false -and ([string]::IsNullOrEmpty($notificationRecipients) -or $notificationRecipients.Count -eq 0)) {
+        if ($isDefaultRecipientsEnabled -eq $false -and ($null -eq $notificationRecipients -or $notificationRecipients.Count -eq 0)) {
 
             $passed = $false
             Write-PSFMessage "Alert misconfigured for role: $($role.displayName) - Default recipients disabled and no custom recipients configured" -Level Verbose

--- a/src/powershell/tests/Test-Assessment.21820.ps1
+++ b/src/powershell/tests/Test-Assessment.21820.ps1
@@ -88,7 +88,7 @@ function Test-Assessment-21820 {
         Write-PSFMessage "Found policy ID: $policyId for role: $($role.displayName)" -Level Verbose
 
         # Query 3: Get activation notification rules for this policy
-        $notificationRuleUri = "policies/roleManagementPolicies/$policyId/rules/Notification_Requestor_EndUser_Assignment"
+        $notificationRuleUri = "policies/roleManagementPolicies/$policyId/rules/Notification_Admin_EndUser_Assignment"
 
         $notificationRule = Invoke-ZtGraphRequest -RelativeUri $notificationRuleUri -ApiVersion beta
 


### PR DESCRIPTION
Updates the Query 3 in test 21820 to use Notification_Admin_EndUser_Assignment in place of Notification_Requestor_EndUser_Assignment and changes the fail scenario logic, as mentioned in issue #1039.
