### PR TITLE
Fix: Update Q3 notification query to use Admin assignment in test 21819

### DIFF
--- a/src/powershell/tests/Test-Assessment.21819.ps1
+++ b/src/powershell/tests/Test-Assessment.21819.ps1
@@ -68,7 +68,7 @@ function Test-Assessment-21819 {
         Write-PSFMessage "Found policy ID: $policyId" -Level Verbose
 
         # Query 3: Get activation notification rules
-        $notificationRuleUri = "policies/roleManagementPolicies/$policyId/rules/Notification_Requestor_EndUser_Assignment"
+        $notificationRuleUri = "policies/roleManagementPolicies/$policyId/rules/Notification_Admin_EndUser_Assignment"
         $notificationRule = Invoke-ZtGraphRequest -RelativeUri $notificationRuleUri -ApiVersion beta -DisableCache
 
         $isDefaultRecipientsEnabled = $notificationRule.isDefaultRecipientsEnabled


### PR DESCRIPTION
Similar to PR #1084 , 21819 also has same issue. This PR updates the Query 3 to use Notification_Admin_EndUser_Assignment in place of Notification_Requestor_EndUser_Assignment.