### PR TITLE
Identity - 21824 - fixed case when no filteredCApolicies exist ( Bugfix/issue 779)

### DIFF
--- a/src/powershell/tests/Test-Assessment.21824.ps1
+++ b/src/powershell/tests/Test-Assessment.21824.ps1
@@ -53,7 +53,7 @@ function Test-Assessment-21824 {
     $passed = $false
     $testResultMarkdown = ""
 
-    if ($filteredCAPolicies.Count -eq $matchedPolicies.Count) {
+    if ($filteredCAPolicies.Count -gt 0 -and $filteredCAPolicies.Count -eq $matchedPolicies.Count) {
         $passed = $true
         $testResultMarkdown = "Guests don't have long lived sign-in sessions.`n`n%TestResult%"
     }
@@ -76,7 +76,7 @@ function Test-Assessment-21824 {
 
 ## {0}
 
-| Policy Name | Sign-in Frequency | Status |
+| Policy name | Sign-in frequency | Status |
 | :---------- | :---------------- | :----- |
 {1}
 

--- a/src/powershell/tests/Test-Assessment.21824.ps1
+++ b/src/powershell/tests/Test-Assessment.21824.ps1
@@ -53,7 +53,11 @@ function Test-Assessment-21824 {
     $passed = $false
     $testResultMarkdown = ""
 
-    if ($filteredCAPolicies.Count -gt 0 -and $filteredCAPolicies.Count -eq $matchedPolicies.Count) {
+    if ($filteredCAPolicies.Count -eq 0) {
+        $passed = $false
+        $testResultMarkdown = "No Conditional Access policies are targeting guests or external users. Sign-in frequency for guests is not enforced.`n`n%TestResult%"
+    }
+    elseif ($filteredCAPolicies.Count -eq $matchedPolicies.Count) {
         $passed = $true
         $testResultMarkdown = "Guests don't have long lived sign-in sessions.`n`n%TestResult%"
     }


### PR DESCRIPTION
Fixes #779 