### PR TITLE
fix: updated sql query in test 21858 to prevent datediff errors

### DIFF
--- a/src/powershell/tests/Test-Assessment.21858.ps1
+++ b/src/powershell/tests/Test-Assessment.21858.ps1
@@ -32,10 +32,10 @@ function Test-Assessment-21858 {
 
     $sql = @"
     SELECT id, displayName, userPrincipalName, accountEnabled, externalUserState,
-    date_diff('day', TRY_CAST(signInActivity.lastSuccessfulSignInDateTime AS DATE), today()) daysSinceLastSignIn,
-    date_diff('day', TRY_CAST(createdDateTime AS DATE), today()) daysSinceCreated,
-    strftime(TRY_CAST(createdDateTime AS DATE), '%Y-%m-%d') fmtCreatedDateTime,
-    strftime(TRY_CAST(signInActivity.lastSuccessfulSignInDateTime AS DATE), '%Y-%m-%d') fmtLastSignInDateTime
+    date_diff('day', try_cast(signInActivity.lastSuccessfulSignInDateTime as date), today()) daysSinceLastSignIn,
+    date_diff('day', try_cast(createdDateTime as date), today()) daysSinceCreated,
+    strftime(try_cast(createdDateTime as date), '%Y-%m-%d') fmtCreatedDateTime,
+    strftime(try_cast(signInActivity.lastSuccessfulSignInDateTime as date), '%Y-%m-%d') fmtLastSignInDateTime
     FROM User
     WHERE UserType = 'Guest' AND AccountEnabled = true
 "@

--- a/src/powershell/tests/Test-Assessment.21858.ps1
+++ b/src/powershell/tests/Test-Assessment.21858.ps1
@@ -32,10 +32,10 @@ function Test-Assessment-21858 {
 
     $sql = @"
     SELECT id, displayName, userPrincipalName, accountEnabled, externalUserState,
-    date_diff('day', TRY_CAST(signInActivity.lastSuccessfulSignInDateTime AS TIMESTAMP), now()) daysSinceLastSignIn,
-    date_diff('day', TRY_CAST(createdDateTime AS TIMESTAMP), now()) daysSinceCreated,
-    strftime(TRY_CAST(createdDateTime AS TIMESTAMP), '%Y-%m-%d') fmtCreatedDateTime,
-    strftime(TRY_CAST(signInActivity.lastSuccessfulSignInDateTime AS TIMESTAMP), '%Y-%m-%d') fmtLastSignInDateTime
+    date_diff('day', TRY_CAST(signInActivity.lastSuccessfulSignInDateTime AS DATE), today()) daysSinceLastSignIn,
+    date_diff('day', TRY_CAST(createdDateTime AS DATE), today()) daysSinceCreated,
+    strftime(TRY_CAST(createdDateTime AS DATE), '%Y-%m-%d') fmtCreatedDateTime,
+    strftime(TRY_CAST(signInActivity.lastSuccessfulSignInDateTime AS DATE), '%Y-%m-%d') fmtLastSignInDateTime
     FROM User
     WHERE UserType = 'Guest' AND AccountEnabled = true
 "@

--- a/src/powershell/tests/Test-Assessment.21858.ps1
+++ b/src/powershell/tests/Test-Assessment.21858.ps1
@@ -32,10 +32,10 @@ function Test-Assessment-21858 {
 
     $sql = @"
     SELECT id, displayName, userPrincipalName, accountEnabled, externalUserState,
-    date_diff('day', signInActivity.lastSuccessfulSignInDateTime, today()) daysSinceLastSignIn,
-    date_diff('day', createdDateTime, today()) daysSinceCreated,
-    strftime(createdDateTime, '%Y-%m-%d') fmtCreatedDateTime,
-    strftime(signInActivity.lastSuccessfulSignInDateTime, '%Y-%m-%d') fmtLastSignInDateTime
+    date_diff('day', TRY_CAST(signInActivity.lastSuccessfulSignInDateTime AS TIMESTAMP), now()) daysSinceLastSignIn,
+    date_diff('day', TRY_CAST(createdDateTime AS TIMESTAMP), now()) daysSinceCreated,
+    strftime(TRY_CAST(createdDateTime AS TIMESTAMP), '%Y-%m-%d') fmtCreatedDateTime,
+    strftime(TRY_CAST(signInActivity.lastSuccessfulSignInDateTime AS TIMESTAMP), '%Y-%m-%d') fmtLastSignInDateTime
     FROM User
     WHERE UserType = 'Guest' AND AccountEnabled = true
 "@


### PR DESCRIPTION
Updated the SQL query in Test 21858 to explicitly cast `signInActivity.lastSuccessfulSignInDateTime` and `createdDateTime` to DATE using TRY_CAST. This prevents DuckDB Binder Errors at runtime (e.g. #1077) when these columns are inferred as VARCHAR or JSON instead of DATE/TIMESTAMP.