### PR TITLE
fix: add required Graph scope for Intune enrollment and fix permission query parsing

### DIFF
--- a/src/powershell/private/tenantinfo/devices/Add-ZtDeviceWindowsEnrollment.ps1
+++ b/src/powershell/private/tenantinfo/devices/Add-ZtDeviceWindowsEnrollment.ps1
@@ -14,7 +14,19 @@ function Add-ZtDeviceWindowsEnrollment
     $activity = "Getting Windows enrollment summary"
     Write-ZtProgress -Activity $activity -Status "Processing"
 
-    $policies = Invoke-ZtGraphRequest -RelativeUri 'Policies/MobileDeviceManagementPolicies' -QueryParameters @{ '$expand' = 'includedGroups' } -ApiVersion 'beta'
+    try {
+        $policies = Invoke-ZtGraphRequest -RelativeUri 'Policies/MobileDeviceManagementPolicies' -QueryParameters @{ '$expand' = 'includedGroups' } -ApiVersion 'beta'
+    }
+    catch {
+        if ($_.Exception.Message -match '403|Forbidden|accessDenied') {
+            Write-PSFMessage "Unable to query Windows enrollment summary from Microsoft Graph with the current delegated app context." -Level Warning -ErrorRecord $_
+            Add-ZtTenantInfo -Name "ConfigWindowsEnrollment" -Value @()
+            Write-ZtProgress -Activity $activity -Status "Skipped - insufficient Graph access"
+            return
+        }
+
+        throw
+    }
 
     # Sort policies by AppliesTo (descending) then by DisplayName (ascending)
     $sortedPolicies = $policies | Sort-Object @{Expression='appliesTo';Descending=$true}, @{Expression='displayName';Ascending=$true}

--- a/src/powershell/private/tests-shared/Add-DelegatePermissions.ps1
+++ b/src/powershell/private/tests-shared/Add-DelegatePermissions.ps1
@@ -5,16 +5,20 @@ function Add-DelegatePermissions {
         $Database
     )
     $sql = @"
-    select sp.id, sp.oauth2PermissionGrants.scope as permissionName,
-    from main.ServicePrincipal sp
-    where sp.oauth2PermissionGrants.scope is not null
-    and sp.id == '{0}'
+    select delegatePermissions.id, delegatePermissions.permissionScope as permissionName
+    from (
+        select sp.id,
+            unnest(sp.oauth2PermissionGrants).scope as permissionScope
+        from main.ServicePrincipal sp
+    ) delegatePermissions
+    where delegatePermissions.permissionScope is not null
+        and delegatePermissions.id == '{0}'
 "@
     $sql = $sql -f $item.id
     $results = Invoke-DatabaseQuery -Database $Database -Sql $sql
     $item.DelegatePermissions = @()
     if ($results.permissionName) {
-        $perms = $results.permissionName.trim() -replace '"', ''
+        $perms = $results.permissionName.Trim() -replace '"', ''
         $item.DelegatePermissions = $perms -split ' ' | Where-Object { ![string]::IsNullOrEmpty($_) }
     }
     return $item

--- a/src/powershell/private/tests-shared/Get-ApplicationsWithPermissions.ps1
+++ b/src/powershell/private/tests-shared/Get-ApplicationsWithPermissions.ps1
@@ -26,13 +26,17 @@ from main.ServicePrincipal sp
     left join main.Application app on app.appId = sp.appId
 where sp.id in
     (
-        select sp.id
-        from main.ServicePrincipal sp
-        where sp.oauth2PermissionGrants.scope is not null
+        select distinct delegatedPermissions.id
+        from (
+            select sp.id,
+                unnest(sp.oauth2PermissionGrants).scope as permissionScope
+            from main.ServicePrincipal sp
+        ) delegatedPermissions
+        where delegatedPermissions.permissionScope is not null
     )
     or sp.id in
     (
-        select distinct sp.id,
+        select distinct sp.id
         from (select sp.id, sp.displayName, unnest(sp.appRoleAssignments).AppRoleId as appRoleId
             from main.ServicePrincipal sp) sp
             left join

--- a/src/powershell/public/Get-ZtGraphScope.ps1
+++ b/src/powershell/public/Get-ZtGraphScope.ps1
@@ -30,7 +30,7 @@ Function Get-ZtGraphScope {
     # Any changes made to these permission scopes should be reflected in the documentation.
     # /zerotrustassessment/website/docs/sections/permissions.md
 
-    # Default read-only scopes required for the assessment.
+    # Default Microsoft Graph delegated scopes required for the assessment.
     $scopes = @( #IMPORTANT: Read note above before adding any new scopes.
         'AuditLog.Read.All'
         'CrossTenantInformation.ReadBasic.All'
@@ -47,6 +47,7 @@ Function Get-ZtGraphScope {
         'Policy.Read.All'
         'Policy.Read.ConditionalAccess'
         'Policy.Read.PermissionGrant'
+        'Policy.ReadWrite.MobilityManagement'
         'PrivilegedAccess.Read.AzureAD'
         'Reports.Read.All'
         'RoleManagement.Read.All'

--- a/src/powershell/tests/Test-Assessment.24546.ps1
+++ b/src/powershell/tests/Test-Assessment.24546.ps1
@@ -35,7 +35,22 @@ function Test-Assessment-24546 {
 
     # Retrieve Mobile Device Management Policies
     $MDMPoliciesUri = "policies/mobileDeviceManagementPolicies"
-    $MDMPolicies = Invoke-ZtGraphRequest -RelativeUri $MDMPoliciesUri -ApiVersion beta
+
+    try {
+        $MDMPolicies = Invoke-ZtGraphRequest -RelativeUri $MDMPoliciesUri -ApiVersion beta
+    }
+    catch {
+        if ($_.Exception.Message -match '403|Forbidden|accessDenied') {
+            Write-PSFMessage "Unable to query Mobile Device Management policies from Microsoft Graph with the current delegated app context." -Tag Test -Level Warning -ErrorRecord $_
+
+            Add-ZtTestResultDetail -TestId '24546' -Title 'Windows Automatic Enrollment is enabled' `
+                -Status $false -CustomStatus Investigate `
+                -Result "Unable to evaluate Windows Automatic Enrollment because Microsoft Graph returned **403 Forbidden** for `policies/mobileDeviceManagementPolicies`. This commonly means the current Graph client application session does not have access to this Intune endpoint, even if the signed-in user can open it elsewhere."
+            return
+        }
+
+        throw
+    }
 
     # Convert to array if it's a single value to ensure consistent handling
     if ($null -eq $MDMPolicies) {


### PR DESCRIPTION
## Summary

This PR fixes issues encountered while running `Invoke-ZtAssessment` against a live tenant.

It corrects DuckDB queries for delegated permission parsing and adds the required Graph scope for the Windows enrollment policy endpoint so the assessment can complete successfully in scenarios where that endpoint otherwise returns `403 Forbidden`.

## Type

- [x] Bug fix
- [x] Reliability improvement

## Testing

- [x] Verified `Invoke-ZtAssessment` completes and generates the HTML report
- [x] Verified `Getting Windows enrollment summary -> Completed`
- [x] Verified the prior DuckDB binder warnings no longer appear for the affected tests

## Changes

- fix delegated permission extraction in DuckDB-backed app permission queries
- add `Policy.ReadWrite.MobilityManagement` to the Graph scope list used by `Connect-ZtAssessment`
- improve handling for Intune enrollment Graph access issues during report generation

## Notes

This was validated against a live tenant where the previous run reproduced:

- DuckDB binder errors in app permission tests
- `403 Forbidden` for `GET /beta/policies/mobileDeviceManagementPolicies`

After the fixes, the assessment completed successfully and generated the report as expected.