### PR TITLE
Add GitHub Pre-Release step to preview workflow

### DIFF
--- a/.github/workflows/publish-psmodule-preview.yml
+++ b/.github/workflows/publish-psmodule-preview.yml
@@ -8,6 +8,9 @@ on:
       - 'src/powershell/**'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build-and-publish:
     runs-on: windows-latest
@@ -21,6 +24,7 @@ jobs:
         shell: pwsh
 
       - name: Build PowerShell Module (Preview)
+        id: build
         run: |
           .\build\powershell\Build-PSModule.ps1 -BaseDirectory $PWD
         shell: pwsh
@@ -32,3 +36,12 @@ jobs:
         shell: pwsh
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+
+      - name: Create GitHub Pre-Release
+        if: steps.build.outputs.tag != ''
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.build.outputs.tag }}
+          name: ${{ steps.build.outputs.tag }}
+          generate_release_notes: true
+          prerelease: true

--- a/.github/workflows/publish-psmodule-preview.yml
+++ b/.github/workflows/publish-psmodule-preview.yml
@@ -37,6 +37,15 @@ jobs:
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
 
+      - name: Commit version bump
+        if: steps.build.outputs.tag != ''
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add src/powershell/ZeroTrustAssessment.psd1
+          git commit -m "Bump version to ${{ steps.build.outputs.tag }}"
+          git push
+
       - name: Create GitHub Pre-Release
         if: steps.build.outputs.tag != ''
         uses: softprops/action-gh-release@v2

--- a/build/powershell/Set-Version.ps1
+++ b/build/powershell/Set-Version.ps1
@@ -52,5 +52,4 @@ if ( -not (Test-Path $ManifestPath )) {
 
 $NewVersion += $previewLabel
 Write-Host "New version: $NewVersion"
-#Add-Content -Path $env:GITHUB_OUTPUT -Value "newtag=$NewVersion"
-#Add-Content -Path $env:GITHUB_OUTPUT -Value "tag=$NewVersion"
+Add-Content -Path $env:GITHUB_OUTPUT -Value "tag=$NewVersion"

--- a/build/powershell/Set-Version.ps1
+++ b/build/powershell/Set-Version.ps1
@@ -52,4 +52,8 @@ if ( -not (Test-Path $ManifestPath )) {
 
 $NewVersion += $previewLabel
 Write-Host "New version: $NewVersion"
-Add-Content -Path $env:GITHUB_OUTPUT -Value "tag=$NewVersion"
+if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_OUTPUT)) {
+    Add-Content -Path $env:GITHUB_OUTPUT -Value "tag=$NewVersion"
+} else {
+    Write-Host "GITHUB_OUTPUT is not set; skipping GitHub Actions step output."
+}


### PR DESCRIPTION
Add permissions: contents: write to allow release creation
Add id: build to the build step for output referencing
Add "Create GitHub Pre-Release" step using softprops/action-gh-release@v2
Uncomment tag output in Set-Version.ps1 to emit version as a GitHub Actions step output

Allows for this to tag the repro with the GitHub Pre-Release during the pre-release workflow

Production workflow is not wired (To Do)