### PR TITLE
fix #1122 - UI progress page duplicate 

### DIFF
--- a/src/powershell/assets/progress.html
+++ b/src/powershell/assets/progress.html
@@ -335,8 +335,9 @@
 <script>
 (function() {
   const POLL_INTERVAL = 500;
-  // Read runId from URL hash (e.g. #run=abc123) so it survives page reloads
-  const MY_RUN_ID = (location.hash.match(/run=([a-f0-9]+)/i) || [])[1] || '';
+  // Read runId from URL hash (e.g. #run=abc123) so it survives page reloads.
+  // If the hash is missing, we populate it from the server's first response.
+  let MY_RUN_ID = (location.hash.match(/run=([a-f0-9]+)/i) || [])[1] || '';
   let lastData = null;
   let lastWorkerDetails = {};
   let pollTimer = null;
@@ -577,6 +578,13 @@
       lastData = data;
       errorCount = 0;
       $('errorBanner').style.display = 'none';
+
+      // Populate the hash with the server-provided runId on first successful poll
+      // so that tab-isolation works even if the page was opened without #run=...
+      if (!MY_RUN_ID && data.runId) {
+        MY_RUN_ID = data.runId;
+        history.replaceState(null, '', '#run=' + data.runId);
+      }
 
       // If the server is now serving a different run, stop polling this tab
       if (MY_RUN_ID && data.runId && data.runId !== MY_RUN_ID) {

--- a/src/powershell/assets/progress.html
+++ b/src/powershell/assets/progress.html
@@ -335,6 +335,8 @@
 <script>
 (function() {
   const POLL_INTERVAL = 500;
+  // Read runId from URL hash (e.g. #run=abc123) so it survives page reloads
+  const MY_RUN_ID = (location.hash.match(/run=([a-f0-9]+)/i) || [])[1] || '';
   let lastData = null;
   let lastWorkerDetails = {};
   let pollTimer = null;
@@ -575,6 +577,17 @@
       lastData = data;
       errorCount = 0;
       $('errorBanner').style.display = 'none';
+
+      // If the server is now serving a different run, stop polling this tab
+      if (MY_RUN_ID && data.runId && data.runId !== MY_RUN_ID) {
+        $('errorBanner').textContent = 'A new assessment run has started. This tab is no longer active.';
+        $('errorBanner').style.display = 'block';
+        $('pulseDot').className = 'pulse-dot done';
+        $('statusText').textContent = 'Superseded';
+        if (pollTimer) clearInterval(pollTimer);
+        return;
+      }
+
       render(data);
 
       if (assessmentDone) {

--- a/src/powershell/private/progress/Start-ZtProgressServer.ps1
+++ b/src/powershell/private/progress/Start-ZtProgressServer.ps1
@@ -60,7 +60,7 @@ function Start-ZtProgressServer {
 			return
 		}
 
-		$url = "http://localhost:$selectedPort"
+		$url = "http://localhost:$selectedPort#run=$runId"
 
 		# Create a dedicated runspace for the HTTP server
 		$runspace = [runspacefactory]::CreateRunspace()
@@ -266,7 +266,7 @@ function Start-ZtProgressServer {
 		Write-Host $url -ForegroundColor Cyan
 		Write-Host
 
-		# Auto-open the progress dashboard in the default browser with the run ID in the URL hash
-		Start-Process "$url#run=$runId"
+		# Auto-open the progress dashboard in the default browser
+		Start-Process $url
 	}
 }

--- a/src/powershell/private/progress/Start-ZtProgressServer.ps1
+++ b/src/powershell/private/progress/Start-ZtProgressServer.ps1
@@ -29,8 +29,14 @@ function Start-ZtProgressServer {
 		}
 		$htmlContent = [System.IO.File]::ReadAllText($htmlPath)
 
+		# Generate a unique run ID so each browser tab can identify its assessment run.
+		# The runId is passed via URL hash (e.g. #run=abc123) rather than injected into HTML,
+		# so that reloading a stale tab preserves the original runId and stops polling.
+		$runId = [guid]::NewGuid().ToString('N')
+
 		# Get the ConcurrentDictionary backing the ProgressState DCO
 		$progressDict = $script:__ZtSession.ProgressState.Value
+		$progressDict['_runId'] = $runId
 
 		# Try to find an available port
 		$selectedPort = $null
@@ -175,7 +181,10 @@ function Start-ZtProgressServer {
 									$percent = [math]::Min(100, [math]::Floor(($completedItems + $failedItems) / $totalItems * 100))
 								}
 
+								$runIdVal = $null; $null = $ProgressDict.TryGetValue('_runId', [ref]$runIdVal)
+
 								$snapshot = @{
+									runId       = $runIdVal
 									stage       = $stage
 									stageNumber = $stageNumber
 									totalStages = $totalStages
@@ -257,7 +266,7 @@ function Start-ZtProgressServer {
 		Write-Host $url -ForegroundColor Cyan
 		Write-Host
 
-		# Auto-open the progress dashboard in the default browser
-		Start-Process $url
+		# Auto-open the progress dashboard in the default browser with the run ID in the URL hash
+		Start-Process "$url#run=$runId"
 	}
 }


### PR DESCRIPTION
## Fix progress dashboard tab isolation

### Problem

**Progress dashboard:** When running the assessment multiple times in a session, the progress page from run 1 would start displaying run 2's data. Reloading the old tab also re-activated it, causing duplicate live dashboards tracking the same run.


### Changes

#### Progress dashboard - unique run isolation

**Files:** `Start-ZtProgressServer.ps1`, `progress.html`

- Generate a unique `runId` (GUID) each time the progress server starts
- Store the `runId` in the shared `ProgressState` dictionary and include it in the `/api/progress` JSON response
- Pass the `runId` to the browser via URL hash fragment (`http://localhost:8924#run=<guid>`) instead of injecting into HTML
- The browser reads `runId` from `location.hash`, which **survives page reloads**
- On each poll, the dashboard compares its `runId` against the server's - if they differ, it stops polling and shows "A new assessment run has started. This tab is no longer active."
