### PR TITLE
Bugfix/issue-266: Exclude emergency access accounts

### DIFF
--- a/src/powershell/private/core/New-ZtInteractiveConfig.ps1
+++ b/src/powershell/private/core/New-ZtInteractiveConfig.ps1
@@ -202,9 +202,86 @@ function New-ZtInteractiveConfig {
             Write-SpectreHost "[green]✅ Will run all available tests[/]"
         }
 
+        # Emergency Access Accounts section
+        Write-Host
+        Write-SpectreRule "Step 4: Emergency Access Accounts (Optional)" -Color ([Spectre.Console.Color]::Cyan1)
+        Write-Host
+        Write-SpectreHost "[bold cyan1]🔐 Emergency Access Account Exclusions[/]"
+        Write-SpectreHost "[dim]Break glass / emergency access accounts are typically excluded from[/]"
+        Write-SpectreHost "[dim]just-in-time access requirements. You can specify accounts to exclude[/]"
+        Write-SpectreHost "[dim]from Test 21815 (JIT privileged role assignment check).[/]"
+        Write-Host
+
+        $configureEmergency = Read-SpectreConfirm -Prompt "[cyan1]Do you want to configure emergency access accounts?[/]" -DefaultAnswer "n"
+
+        if ($configureEmergency) {
+            $emergencyAccounts = @()
+            $addMore = $true
+
+            while ($addMore) {
+                Write-Host
+                $accountType = Read-SpectreSelection -Prompt "[cyan1]Account type[/]" -Choices @(
+                    "User (by UPN - e.g., breakglass@contoso.com)",
+                    "User (by Object ID)",
+                    "Group (by Object ID)"
+                )
+
+                $accountEntry = @{}
+
+                switch ($accountType) {
+                    "User (by UPN - e.g., breakglass@contoso.com)" {
+                        $upn = Read-SpectreText -Prompt "[cyan1]User Principal Name[/]"
+                        if (![string]::IsNullOrWhiteSpace($upn)) {
+                            $accountEntry = @{
+                                Type = "User"
+                                UserPrincipalName = $upn.Trim()
+                            }
+                            Write-SpectreHost "[green]✅ Added user: $($upn.Trim())[/]"
+                        }
+                    }
+                    "User (by Object ID)" {
+                        $userId = Read-SpectreText -Prompt "[cyan1]User Object ID (GUID)[/]"
+                        if (![string]::IsNullOrWhiteSpace($userId)) {
+                            $accountEntry = @{
+                                Type = "User"
+                                Id = $userId.Trim()
+                            }
+                            Write-SpectreHost "[green]✅ Added user ID: $($userId.Trim())[/]"
+                        }
+                    }
+                    "Group (by Object ID)" {
+                        $groupId = Read-SpectreText -Prompt "[cyan1]Group Object ID (GUID)[/]"
+                        if (![string]::IsNullOrWhiteSpace($groupId)) {
+                            $accountEntry = @{
+                                Type = "Group"
+                                Id = $groupId.Trim()
+                            }
+                            Write-SpectreHost "[green]✅ Added group ID: $($groupId.Trim())[/]"
+                        }
+                    }
+                }
+
+                if ($accountEntry.Count -gt 0) {
+                    $emergencyAccounts += $accountEntry
+                }
+
+                Write-Host
+                $addMore = Read-SpectreConfirm -Prompt "[cyan1]Add another emergency access account?[/]" -DefaultAnswer "n"
+            }
+
+            if ($emergencyAccounts.Count -gt 0) {
+                if (-not $configData.GlobalSettings) { $configData.GlobalSettings = @{} }
+                $configData.GlobalSettings.EmergencyAccessAccounts = $emergencyAccounts
+                Write-Host
+                Write-SpectreHost "[green]✅ Configured $($emergencyAccounts.Count) emergency access account(s)[/]"
+            }
+        } else {
+            Write-SpectreHost "[dim]No emergency access accounts configured. All accounts will be evaluated.[/]"
+        }
+
         # Enhanced preview section
         Write-Host
-        Write-SpectreRule "Step 4: Review & Save" -Color ([Spectre.Console.Color]::Cyan1)
+        Write-SpectreRule "Step 5: Review & Save" -Color ([Spectre.Console.Color]::Cyan1)
         Write-Host
 
         $showPreview = Read-SpectreConfirm -Prompt "[cyan1]Would you like to preview your configuration?[/]" -DefaultAnswer "y"
@@ -227,6 +304,12 @@ function New-ZtInteractiveConfig {
                 Write-SpectreHost "  [cyan1]Specific tests:[/] $($configData.Tests -join ', ')"
             } else {
                 Write-SpectreHost "  [cyan1]Test selection:[/] All tests"
+            }
+
+            if ($configData.GlobalSettings -and $configData.GlobalSettings.EmergencyAccessAccounts -and $configData.GlobalSettings.EmergencyAccessAccounts.Count -gt 0) {
+                Write-SpectreHost "  [cyan1]Emergency accounts:[/] $($configData.GlobalSettings.EmergencyAccessAccounts.Count) configured"
+            } else {
+                Write-SpectreHost "  [cyan1]Emergency accounts:[/] None configured"
             }
 
             Write-Host

--- a/src/powershell/private/core/New-ZtInteractiveConfig.ps1
+++ b/src/powershell/private/core/New-ZtInteractiveConfig.ps1
@@ -202,86 +202,9 @@ function New-ZtInteractiveConfig {
             Write-SpectreHost "[green]✅ Will run all available tests[/]"
         }
 
-        # Emergency Access Accounts section
-        Write-Host
-        Write-SpectreRule "Step 4: Emergency Access Accounts (Optional)" -Color ([Spectre.Console.Color]::Cyan1)
-        Write-Host
-        Write-SpectreHost "[bold cyan1]🔐 Emergency Access Account Exclusions[/]"
-        Write-SpectreHost "[dim]Break glass / emergency access accounts are typically excluded from[/]"
-        Write-SpectreHost "[dim]just-in-time access requirements. You can specify accounts to exclude[/]"
-        Write-SpectreHost "[dim]from Test 21815 (JIT privileged role assignment check).[/]"
-        Write-Host
-
-        $configureEmergency = Read-SpectreConfirm -Prompt "[cyan1]Do you want to configure emergency access accounts?[/]" -DefaultAnswer "n"
-
-        if ($configureEmergency) {
-            $emergencyAccounts = @()
-            $addMore = $true
-
-            while ($addMore) {
-                Write-Host
-                $accountType = Read-SpectreSelection -Prompt "[cyan1]Account type[/]" -Choices @(
-                    "User (by UPN - e.g., breakglass@contoso.com)",
-                    "User (by Object ID)",
-                    "Group (by Object ID)"
-                )
-
-                $accountEntry = @{}
-
-                switch ($accountType) {
-                    "User (by UPN - e.g., breakglass@contoso.com)" {
-                        $upn = Read-SpectreText -Prompt "[cyan1]User Principal Name[/]"
-                        if (![string]::IsNullOrWhiteSpace($upn)) {
-                            $accountEntry = @{
-                                Type = "User"
-                                UserPrincipalName = $upn.Trim()
-                            }
-                            Write-SpectreHost "[green]✅ Added user: $($upn.Trim())[/]"
-                        }
-                    }
-                    "User (by Object ID)" {
-                        $userId = Read-SpectreText -Prompt "[cyan1]User Object ID (GUID)[/]"
-                        if (![string]::IsNullOrWhiteSpace($userId)) {
-                            $accountEntry = @{
-                                Type = "User"
-                                Id = $userId.Trim()
-                            }
-                            Write-SpectreHost "[green]✅ Added user ID: $($userId.Trim())[/]"
-                        }
-                    }
-                    "Group (by Object ID)" {
-                        $groupId = Read-SpectreText -Prompt "[cyan1]Group Object ID (GUID)[/]"
-                        if (![string]::IsNullOrWhiteSpace($groupId)) {
-                            $accountEntry = @{
-                                Type = "Group"
-                                Id = $groupId.Trim()
-                            }
-                            Write-SpectreHost "[green]✅ Added group ID: $($groupId.Trim())[/]"
-                        }
-                    }
-                }
-
-                if ($accountEntry.Count -gt 0) {
-                    $emergencyAccounts += $accountEntry
-                }
-
-                Write-Host
-                $addMore = Read-SpectreConfirm -Prompt "[cyan1]Add another emergency access account?[/]" -DefaultAnswer "n"
-            }
-
-            if ($emergencyAccounts.Count -gt 0) {
-                if (-not $configData.GlobalSettings) { $configData.GlobalSettings = @{} }
-                $configData.GlobalSettings.EmergencyAccessAccounts = $emergencyAccounts
-                Write-Host
-                Write-SpectreHost "[green]✅ Configured $($emergencyAccounts.Count) emergency access account(s)[/]"
-            }
-        } else {
-            Write-SpectreHost "[dim]No emergency access accounts configured. All accounts will be evaluated.[/]"
-        }
-
         # Enhanced preview section
         Write-Host
-        Write-SpectreRule "Step 5: Review & Save" -Color ([Spectre.Console.Color]::Cyan1)
+        Write-SpectreRule "Step 4: Review & Save" -Color ([Spectre.Console.Color]::Cyan1)
         Write-Host
 
         $showPreview = Read-SpectreConfirm -Prompt "[cyan1]Would you like to preview your configuration?[/]" -DefaultAnswer "y"
@@ -304,12 +227,6 @@ function New-ZtInteractiveConfig {
                 Write-SpectreHost "  [cyan1]Specific tests:[/] $($configData.Tests -join ', ')"
             } else {
                 Write-SpectreHost "  [cyan1]Test selection:[/] All tests"
-            }
-
-            if ($configData.GlobalSettings -and $configData.GlobalSettings.EmergencyAccessAccounts -and $configData.GlobalSettings.EmergencyAccessAccounts.Count -gt 0) {
-                Write-SpectreHost "  [cyan1]Emergency accounts:[/] $($configData.GlobalSettings.EmergencyAccessAccounts.Count) configured"
-            } else {
-                Write-SpectreHost "  [cyan1]Emergency accounts:[/] None configured"
             }
 
             Write-Host

--- a/src/powershell/private/tests-shared/Get-ZtEmergencyAccessAccounts.ps1
+++ b/src/powershell/private/tests-shared/Get-ZtEmergencyAccessAccounts.ps1
@@ -21,7 +21,7 @@
     Note: Group-based emergency accounts are resolved at runtime via Microsoft Graph API.
 
 .PARAMETER Database
-    The SQLite database connection used to resolve user information.
+    The DuckDB database connection used to resolve user information.
 
 .OUTPUTS
     Array of PSCustomObject with properties:
@@ -105,20 +105,23 @@ function Get-ZtEmergencyAccessAccounts {
             # Resolve group members via Microsoft Graph API (GroupMember table not available in DB)
             try {
                 Write-PSFMessage "Resolving emergency access group members via Graph API: Id=$id" -Level Verbose
-                $members = @(Get-MgGroupMember -GroupId $id -All -ErrorAction Stop | Where-Object { $_.'@odata.type' -eq '#microsoft.graph.user' })
+                $membersResponse = Get-ZtGroupMember -GroupId $id
+                $members = @($membersResponse | Where-Object { $_.'@odata.type' -eq '#microsoft.graph.user' })
 
                 if ($members.Count -gt 0) {
                     foreach ($member in $members) {
-                        # Get additional user properties
-                        $userDetails = Get-MgUser -UserId $member.Id -Property Id, UserPrincipalName, DisplayName -ErrorAction SilentlyContinue
+                        # Get additional user properties from the User table
+                        $escapedMemberId = $member.id -replace "'", "''"
+                        $memberSql = "SELECT id, userPrincipalName, displayName FROM User WHERE id = '$escapedMemberId'"
+                        $userDetails = Invoke-DatabaseQuery -Database $Database -Sql $memberSql | Select-Object -First 1
                         if ($userDetails) {
                             $emergencyAccessAccounts += [PSCustomObject]@{
-                                Id                = $userDetails.Id
-                                UserPrincipalName = $userDetails.UserPrincipalName
-                                DisplayName       = $userDetails.DisplayName
+                                Id                = $userDetails.id
+                                UserPrincipalName = $userDetails.userPrincipalName
+                                DisplayName       = $userDetails.displayName
                                 Type              = 'GroupMember'
                             }
-                            Write-PSFMessage "Emergency access group member found: $($userDetails.UserPrincipalName)" -Level Verbose
+                            Write-PSFMessage "Emergency access group member found: $($userDetails.userPrincipalName)" -Level Verbose
                         }
                     }
                 }

--- a/src/powershell/private/tests-shared/Get-ZtEmergencyAccessAccounts.ps1
+++ b/src/powershell/private/tests-shared/Get-ZtEmergencyAccessAccounts.ps1
@@ -1,0 +1,141 @@
+<#
+.SYNOPSIS
+    Gets emergency access accounts from the configuration.
+
+.DESCRIPTION
+    Returns emergency access accounts defined in the ZeroTrustAssessment configuration file.
+    Uses Maester-style configuration format where customers explicitly define their
+    emergency/breakglass accounts.
+
+    Configuration format (in zt-config.json) - follows Maester format:
+    {
+        "GlobalSettings": {
+            "EmergencyAccessAccounts": [
+                { "Type": "User", "UserPrincipalName": "breakglass1@contoso.com" },
+                { "Type": "User", "Id": "00000000-0000-0000-0000-000000000001" },
+                { "Type": "Group", "Id": "00000000-0000-0000-0000-000000000002" }
+            ]
+        }
+    }
+
+    Note: Group-based emergency accounts are resolved at runtime via Microsoft Graph API.
+
+.PARAMETER Database
+    The SQLite database connection used to resolve user information.
+
+.OUTPUTS
+    Array of PSCustomObject with properties:
+    - Id: User's object ID
+    - UserPrincipalName: User's UPN
+    - DisplayName: User's display name
+    - Type: 'User' or 'GroupMember' (indicates user resolved from a configured group)
+
+.EXAMPLE
+    $emergencyAccounts = Get-ZtEmergencyAccessAccounts -Database $Database
+
+.NOTES
+    Created to fix Issue #266 - Test 21815 incorrectly flags emergency access accounts
+    as failures for having permanent privileged role assignments.
+
+    Updated to use config-based approach per PM feedback (FIDO2 requirement too strict).
+#>
+
+function Get-ZtEmergencyAccessAccounts {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        $Database
+    )
+
+    Write-PSFMessage 'Getting emergency access accounts from configuration' -Level Verbose
+
+    # Get emergency accounts from PSFConfig (set by Invoke-ZtAssessment)
+    $configuredAccounts = Get-PSFConfigValue -FullName 'ZeroTrustAssessment.EmergencyAccessAccounts'
+
+    if (-not $configuredAccounts -or $configuredAccounts.Count -eq 0) {
+        Write-PSFMessage 'No emergency access accounts configured' -Level Verbose
+        return @()
+    }
+
+    Write-PSFMessage "Found $($configuredAccounts.Count) configured emergency access accounts" -Level Verbose
+
+    $emergencyAccessAccounts = @()
+
+    foreach ($account in $configuredAccounts) {
+        $type = $account.Type
+        $id = $account.Id
+        $upn = $account.UserPrincipalName
+
+        if ($type -eq 'User') {
+            # Resolve user by UPN or ID
+            if ($upn) {
+                $escapedUpn = $upn -replace "'", "''"
+                $sql = "SELECT id, userPrincipalName, displayName FROM User WHERE userPrincipalName = '$escapedUpn' COLLATE NOCASE"
+            }
+            elseif ($id) {
+                $escapedId = $id -replace "'", "''"
+                $sql = "SELECT id, userPrincipalName, displayName FROM User WHERE id = '$escapedId'"
+            }
+            else {
+                Write-PSFMessage "Skipping invalid user entry: no Id or UserPrincipalName provided" -Level Warning
+                continue
+            }
+
+            $user = Invoke-DatabaseQuery -Database $Database -Sql $sql | Select-Object -First 1
+
+            if ($user) {
+                $emergencyAccessAccounts += [PSCustomObject]@{
+                    Id                = $user.id
+                    UserPrincipalName = $user.userPrincipalName
+                    DisplayName       = $user.displayName
+                    Type              = 'User'
+                }
+                Write-PSFMessage "Emergency access user found: $($user.userPrincipalName)" -Level Verbose
+            }
+            else {
+                Write-PSFMessage "Emergency access user not found in tenant: UPN=$upn, Id=$id" -Level Warning
+            }
+        }
+        elseif ($type -eq 'Group') {
+            if (-not $id) {
+                Write-PSFMessage "Skipping invalid group entry: no Id provided" -Level Warning
+                continue
+            }
+
+            # Resolve group members via Microsoft Graph API (GroupMember table not available in DB)
+            try {
+                Write-PSFMessage "Resolving emergency access group members via Graph API: Id=$id" -Level Verbose
+                $members = @(Get-MgGroupMember -GroupId $id -All -ErrorAction Stop | Where-Object { $_.'@odata.type' -eq '#microsoft.graph.user' })
+
+                if ($members.Count -gt 0) {
+                    foreach ($member in $members) {
+                        # Get additional user properties
+                        $userDetails = Get-MgUser -UserId $member.Id -Property Id, UserPrincipalName, DisplayName -ErrorAction SilentlyContinue
+                        if ($userDetails) {
+                            $emergencyAccessAccounts += [PSCustomObject]@{
+                                Id                = $userDetails.Id
+                                UserPrincipalName = $userDetails.UserPrincipalName
+                                DisplayName       = $userDetails.DisplayName
+                                Type              = 'GroupMember'
+                            }
+                            Write-PSFMessage "Emergency access group member found: $($userDetails.UserPrincipalName)" -Level Verbose
+                        }
+                    }
+                }
+                else {
+                    Write-PSFMessage "Emergency access group has no user members: Id=$id" -Level Warning
+                }
+            }
+            catch {
+                Write-PSFMessage "Failed to resolve emergency access group members: Id=$id. Error: $($_.Exception.Message)" -Level Warning
+            }
+        }
+        else {
+            Write-PSFMessage "Skipping unknown account type: $type" -Level Warning
+        }
+    }
+
+    Write-PSFMessage "Total emergency access accounts resolved: $($emergencyAccessAccounts.Count)" -Level Verbose
+
+    return $emergencyAccessAccounts
+}

--- a/src/powershell/private/tests-shared/Get-ZtEmergencyAccessAccounts.ps1
+++ b/src/powershell/private/tests-shared/Get-ZtEmergencyAccessAccounts.ps1
@@ -70,8 +70,9 @@ function Get-ZtEmergencyAccessAccounts {
         if ($type -eq 'User') {
             # Resolve user by UPN or ID
             if ($upn) {
-                $escapedUpn = $upn -replace "'", "''"
-                $sql = "SELECT id, userPrincipalName, displayName FROM User WHERE userPrincipalName = '$escapedUpn' COLLATE NOCASE"
+                # Lower-case both sides for case-insensitive UPN match (portable; avoids DB-specific COLLATE syntax)
+                $escapedUpn = ($upn.ToLowerInvariant()) -replace "'", "''"
+                $sql = "SELECT id, userPrincipalName, displayName FROM User WHERE LOWER(userPrincipalName) = '$escapedUpn'"
             }
             elseif ($id) {
                 $escapedId = $id -replace "'", "''"

--- a/src/powershell/private/tests-shared/Get-ZtEmergencyAccessAccounts.ps1
+++ b/src/powershell/private/tests-shared/Get-ZtEmergencyAccessAccounts.ps1
@@ -75,7 +75,12 @@ function Get-ZtEmergencyAccessAccounts {
                 $sql = "SELECT id, userPrincipalName, displayName FROM User WHERE LOWER(userPrincipalName) = '$escapedUpn'"
             }
             elseif ($id) {
-                $escapedId = $id -replace "'", "''"
+                $guidRef = [System.Guid]::Empty
+                if (-not [System.Guid]::TryParse($id, [ref]$guidRef)) {
+                    Write-PSFMessage "Skipping invalid user entry: Id '$id' is not a valid GUID" -Level Warning
+                    continue
+                }
+                $escapedId = $guidRef.ToString()
                 $sql = "SELECT id, userPrincipalName, displayName FROM User WHERE id = '$escapedId'"
             }
             else {
@@ -104,27 +109,45 @@ function Get-ZtEmergencyAccessAccounts {
                 continue
             }
 
+            $guidRef = [System.Guid]::Empty
+            if (-not [System.Guid]::TryParse($id, [ref]$guidRef)) {
+                Write-PSFMessage "Skipping invalid group entry: Id '$id' is not a valid GUID" -Level Warning
+                continue
+            }
+
             # Resolve group members via Microsoft Graph API (GroupMember table not available in DB)
             try {
                 Write-PSFMessage "Resolving emergency access group members via Graph API: Id=$id" -Level Verbose
-                $membersResponse = Get-ZtGroupMember -GroupId $id -ErrorAction Stop
+                $membersResponse = Get-ZtGroupMember -GroupId $id -Recurse -ErrorAction Stop
                 $members = @($membersResponse | Where-Object { $_.'@odata.type' -eq '#microsoft.graph.user' })
 
                 if ($members.Count -gt 0) {
-                    # Batch all member ids into a single SQL lookup to avoid N+1 queries
-                    $escapedIds = $members | ForEach-Object { "'" + (($_.id) -replace "'", "''") + "'" }
-                    $idList = $escapedIds -join ','
-                    $memberSql = "SELECT id, userPrincipalName, displayName FROM User WHERE id IN ($idList)"
-                    $userDetailsList = @(Invoke-DatabaseQuery -Database $Database -Sql $memberSql)
-
-                    foreach ($userDetails in $userDetailsList) {
-                        $emergencyAccessAccounts += [PSCustomObject]@{
-                            Id                = $userDetails.id
-                            UserPrincipalName = $userDetails.userPrincipalName
-                            DisplayName       = $userDetails.displayName
-                            Type              = 'GroupMember'
+                    # Batch all member IDs into a single SQL lookup to avoid N+1 queries;
+                    # member IDs come from Graph API responses which are always valid GUIDs.
+                    $escapedIds = $members | ForEach-Object {
+                        $memberGuid = [System.Guid]::Empty
+                        if ([System.Guid]::TryParse($_.id, [ref]$memberGuid)) {
+                            "'" + $memberGuid.ToString() + "'"
                         }
-                        Write-PSFMessage "Emergency access group member found: $($userDetails.userPrincipalName)" -Level Verbose
+                    } | Where-Object { $_ }
+
+                    if (-not $escapedIds) {
+                        Write-PSFMessage "Emergency access group members had no valid GUIDs: Id=$id" -Level Warning
+                    }
+                    else {
+                        $idList = $escapedIds -join ','
+                        $memberSql = "SELECT id, userPrincipalName, displayName FROM User WHERE id IN ($idList)"
+                        $userDetailsList = @(Invoke-DatabaseQuery -Database $Database -Sql $memberSql)
+
+                        foreach ($userDetails in $userDetailsList) {
+                            $emergencyAccessAccounts += [PSCustomObject]@{
+                                Id                = $userDetails.id
+                                UserPrincipalName = $userDetails.userPrincipalName
+                                DisplayName       = $userDetails.displayName
+                                Type              = 'GroupMember'
+                            }
+                            Write-PSFMessage "Emergency access group member found: $($userDetails.userPrincipalName)" -Level Verbose
+                        }
                     }
                 }
                 else {

--- a/src/powershell/private/tests-shared/Get-ZtEmergencyAccessAccounts.ps1
+++ b/src/powershell/private/tests-shared/Get-ZtEmergencyAccessAccounts.ps1
@@ -47,6 +47,7 @@ function Get-ZtEmergencyAccessAccounts {
         $Database
     )
 
+    Write-PSFMessage '🟦 Start' -Tag Test -Level VeryVerbose
     Write-PSFMessage 'Getting emergency access accounts from configuration' -Level Verbose
 
     # Get emergency accounts from PSFConfig (set by Invoke-ZtAssessment)
@@ -105,24 +106,24 @@ function Get-ZtEmergencyAccessAccounts {
             # Resolve group members via Microsoft Graph API (GroupMember table not available in DB)
             try {
                 Write-PSFMessage "Resolving emergency access group members via Graph API: Id=$id" -Level Verbose
-                $membersResponse = Get-ZtGroupMember -GroupId $id
+                $membersResponse = Get-ZtGroupMember -GroupId $id -ErrorAction Stop
                 $members = @($membersResponse | Where-Object { $_.'@odata.type' -eq '#microsoft.graph.user' })
 
                 if ($members.Count -gt 0) {
-                    foreach ($member in $members) {
-                        # Get additional user properties from the User table
-                        $escapedMemberId = $member.id -replace "'", "''"
-                        $memberSql = "SELECT id, userPrincipalName, displayName FROM User WHERE id = '$escapedMemberId'"
-                        $userDetails = Invoke-DatabaseQuery -Database $Database -Sql $memberSql | Select-Object -First 1
-                        if ($userDetails) {
-                            $emergencyAccessAccounts += [PSCustomObject]@{
-                                Id                = $userDetails.id
-                                UserPrincipalName = $userDetails.userPrincipalName
-                                DisplayName       = $userDetails.displayName
-                                Type              = 'GroupMember'
-                            }
-                            Write-PSFMessage "Emergency access group member found: $($userDetails.userPrincipalName)" -Level Verbose
+                    # Batch all member ids into a single SQL lookup to avoid N+1 queries
+                    $escapedIds = $members | ForEach-Object { "'" + (($_.id) -replace "'", "''") + "'" }
+                    $idList = $escapedIds -join ','
+                    $memberSql = "SELECT id, userPrincipalName, displayName FROM User WHERE id IN ($idList)"
+                    $userDetailsList = @(Invoke-DatabaseQuery -Database $Database -Sql $memberSql)
+
+                    foreach ($userDetails in $userDetailsList) {
+                        $emergencyAccessAccounts += [PSCustomObject]@{
+                            Id                = $userDetails.id
+                            UserPrincipalName = $userDetails.userPrincipalName
+                            DisplayName       = $userDetails.displayName
+                            Type              = 'GroupMember'
                         }
+                        Write-PSFMessage "Emergency access group member found: $($userDetails.userPrincipalName)" -Level Verbose
                     }
                 }
                 else {

--- a/src/powershell/public/Invoke-ZtAssessment.ps1
+++ b/src/powershell/public/Invoke-ZtAssessment.ps1
@@ -301,6 +301,24 @@ $titleLine
 				}
 			}
 
+			# Parse EmergencyAccessAccounts if present (Maester-style config with GlobalSettings)
+			$emergencyAccounts = $null
+			if ($configContent.PSObject.Properties.Name -contains 'GlobalSettings' -and
+				$configContent.GlobalSettings.PSObject.Properties.Name -contains 'EmergencyAccessAccounts' -and
+				$configContent.GlobalSettings.EmergencyAccessAccounts -and
+				$configContent.GlobalSettings.EmergencyAccessAccounts.Count -gt 0) {
+				$emergencyAccounts = $configContent.GlobalSettings.EmergencyAccessAccounts
+			}
+			if ($emergencyAccounts -and $emergencyAccounts.Count -gt 0) {
+				Set-PSFConfig -FullName 'ZeroTrustAssessment.EmergencyAccessAccounts' -Value $emergencyAccounts
+				Write-Host "🔐 " -NoNewline -ForegroundColor Cyan
+				Write-Host "Loaded $($emergencyAccounts.Count) emergency access account(s) from configuration." -ForegroundColor White
+			}
+			else {
+				# Clear any previously loaded emergency accounts to prevent stale config in multi-run sessions
+				Set-PSFConfig -FullName 'ZeroTrustAssessment.EmergencyAccessAccounts' -Value $null
+			}
+
 			Write-Host "✅ " -NoNewline -ForegroundColor Green
 			Write-Host "Configuration loaded successfully. Command line parameters will override configuration file values." -ForegroundColor White
 			Write-Host

--- a/src/powershell/public/Invoke-ZtAssessment.ps1
+++ b/src/powershell/public/Invoke-ZtAssessment.ps1
@@ -249,6 +249,10 @@ $titleLine
 	#region Preparation
 	Show-ZtiBanner
 
+	# Always reset emergency access accounts at the start of each run to prevent stale
+	# config from a previous Invoke-ZtAssessment call carrying over (Issue #266 follow-up).
+	Set-PSFConfig -FullName 'ZeroTrustAssessment.EmergencyAccessAccounts' -Value $null
+
 	$effectiveIgnore = $IgnoreLanguageMode -or $script:IgnoreLanguageMode
 	if (-not (Test-ZtLanguageMode -IgnoreLanguageMode:$effectiveIgnore)) {
 		Stop-PSFFunction -Message "PowerShell is running in Constrained Language Mode, which is not supported." -EnableException $true -Cmdlet $PSCmdlet
@@ -314,10 +318,7 @@ $titleLine
 				Write-Host "🔐 " -NoNewline -ForegroundColor Cyan
 				Write-Host "Loaded $($emergencyAccounts.Count) emergency access account(s) from configuration." -ForegroundColor White
 			}
-			else {
-				# Clear any previously loaded emergency accounts to prevent stale config in multi-run sessions
-				Set-PSFConfig -FullName 'ZeroTrustAssessment.EmergencyAccessAccounts' -Value $null
-			}
+			# Note: stale-clear is now performed unconditionally at the start of Invoke-ZtAssessment.
 
 			Write-Host "✅ " -NoNewline -ForegroundColor Green
 			Write-Host "Configuration loaded successfully. Command line parameters will override configuration file values." -ForegroundColor White

--- a/src/powershell/tests/Test-Assessment.21815.ps1
+++ b/src/powershell/tests/Test-Assessment.21815.ps1
@@ -31,19 +31,34 @@ function Test-Assessment-21815 {
     Write-ZtProgress -Activity $activity -Status "Getting privileged role assignments"
 
     $sql = @"
-select distinct  principalDisplayName, userPrincipalName, roleDisplayName, privilegeType, isPrivileged
+select distinct  principalId, principalDisplayName, userPrincipalName, roleDisplayName, privilegeType, isPrivileged
 from vwRole
 "@
     $roleAssignments = Invoke-DatabaseQuery -Database $Database -Sql $sql
 
     # Check if any privileged role assignment in the results has privilegeType set to Permanent
-    $results = $roleAssignments | Where-Object { $_.isPrivileged -eq $true -and $_.privilegeType -eq 'Permanent' }
+    $permanentPrivileged = $roleAssignments | Where-Object { $_.isPrivileged -eq $true -and $_.privilegeType -eq 'Permanent' }
+
+    # Issue #266: Exclude emergency access accounts from failures
+    # Emergency accounts are expected to have permanent privileged role assignments per Microsoft best practices
+    Write-ZtProgress -Activity $activity -Status "Identifying emergency access accounts"
+    $emergencyAccounts = Get-ZtEmergencyAccessAccounts -Database $Database
+    $emergencyAccountIds = @($emergencyAccounts | Select-Object -ExpandProperty Id)
+
+    # Filter out emergency access accounts from the results
+    $results = @($permanentPrivileged | Where-Object { $emergencyAccountIds -notcontains $_.principalId })
+    $excludedEmergencyAccounts = @($permanentPrivileged | Where-Object { $emergencyAccountIds -contains $_.principalId })
 
     $testResultMarkdown = ""
 
     if ($results.Count -eq 0) {
         $passed = $true
-        $testResultMarkdown += "No privileged users have permanent role assignments."
+        if ($excludedEmergencyAccounts.Count -gt 0) {
+            $testResultMarkdown += "No privileged users have permanent role assignments (excluding $($excludedEmergencyAccounts.Count) emergency access account(s) which are expected to have permanent assignments)."
+        }
+        else {
+            $testResultMarkdown += "No privileged users have permanent role assignments."
+        }
     }
     else {
         $passed = $false
@@ -80,8 +95,38 @@ from vwRole
         $mdInfo = $formatTemplate -f $reportTitle, $tableRows
     }
 
-    # Replace the placeholder with the detailed information
+    # Add section for excluded emergency access accounts (Issue #266)
+    if ($excludedEmergencyAccounts.Count -gt 0) {
+        $emergencySection = @'
+
+## Excluded emergency access accounts
+
+The following emergency access accounts were excluded from this check as they are expected to have permanent privileged role assignments per [Microsoft best practices](https://learn.microsoft.com/entra/identity/role-based-access-control/security-emergency-access).
+
+| User | UPN | Role Name |
+| :--- | :-- | :-------- |
+
+'@
+        foreach ($emergency in $excludedEmergencyAccounts) {
+            $portalLink = 'https://entra.microsoft.com/#view/Microsoft_AAD_UsersAndTenants/UserProfileMenuBlade/~/AdministrativeRole/userId/{0}/hidePreviewBanner~/true' -f $emergency.principalId
+            $emergencySection += "| [$(Get-SafeMarkdown($emergency.principalDisplayName))]($portalLink) | $($emergency.userPrincipalName) | $($emergency.roleDisplayName) |`n"
+        }
+
+        if (-not $passed) {
+            $mdInfo += $emergencySection
+        }
+        else {
+            $mdInfo = $emergencySection
+        }
+    }
+
+    # Replace the placeholder with the detailed information (for failed tests)
     $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $mdInfo
+
+    # Append excluded section directly when test passes (no placeholder in pass message)
+    if ($passed -and $excludedEmergencyAccounts.Count -gt 0) {
+        $testResultMarkdown += "`n`n" + $mdInfo
+    }
 
     $params = @{
         TestId             = '21815'

--- a/src/powershell/tests/Test-Assessment.21815.ps1
+++ b/src/powershell/tests/Test-Assessment.21815.ps1
@@ -109,7 +109,7 @@ The following emergency access accounts were excluded from this check as they ar
 '@
         foreach ($emergency in $excludedEmergencyAccounts) {
             $portalLink = 'https://entra.microsoft.com/#view/Microsoft_AAD_UsersAndTenants/UserProfileMenuBlade/~/AdministrativeRole/userId/{0}/hidePreviewBanner~/true' -f $emergency.principalId
-            $emergencySection += "| [$(Get-SafeMarkdown($emergency.principalDisplayName))]($portalLink) | $($emergency.userPrincipalName) | $($emergency.roleDisplayName) |`n"
+            $emergencySection += "| [$(Get-SafeMarkdown($emergency.principalDisplayName))]($portalLink) | $(Get-SafeMarkdown($emergency.userPrincipalName)) | $(Get-SafeMarkdown($emergency.roleDisplayName)) |`n"
         }
 
         if (-not $passed) {

--- a/src/powershell/tests/Test-Assessment.21815.ps1
+++ b/src/powershell/tests/Test-Assessment.21815.ps1
@@ -46,8 +46,8 @@ from vwRole
     $emergencyAccountIds = @($emergencyAccounts | Select-Object -ExpandProperty Id)
 
     # Filter out emergency access accounts from the results
-    $results = @($permanentPrivileged | Where-Object { $emergencyAccountIds -notcontains $_.principalId })
-    $excludedEmergencyAccounts = @($permanentPrivileged | Where-Object { $emergencyAccountIds -contains $_.principalId })
+    $results = @($permanentPrivileged | Where-Object { $_.principalId -notin $emergencyAccountIds })
+    $excludedEmergencyAccounts = @($permanentPrivileged | Where-Object { $_.principalId -in $emergencyAccountIds })
 
     # Count of *distinct* excluded emergency accounts (one user can have multiple permanent role assignments)
     $excludedAccountCount = @($excludedEmergencyAccounts | Select-Object -ExpandProperty principalId -Unique).Count
@@ -113,7 +113,7 @@ The following emergency access accounts were excluded from this check as they ar
 '@
         foreach ($emergency in $excludedEmergencyAccounts) {
             $portalLink = 'https://entra.microsoft.com/#view/Microsoft_AAD_UsersAndTenants/UserProfileMenuBlade/~/AdministrativeRole/userId/{0}/hidePreviewBanner~/true' -f $emergency.principalId
-            $emergencySection += "| [$(Get-SafeMarkdown($emergency.principalDisplayName))]($portalLink) | $(Get-SafeMarkdown($emergency.userPrincipalName)) | $(Get-SafeMarkdown($emergency.roleDisplayName)) |`n"
+            $emergencySection += "| [$(Get-SafeMarkdown($emergency.principalDisplayName))]($portalLink) | $($emergency.userPrincipalName) | $($emergency.roleDisplayName) |`n"
         }
     }
 

--- a/src/powershell/tests/Test-Assessment.21815.ps1
+++ b/src/powershell/tests/Test-Assessment.21815.ps1
@@ -109,7 +109,6 @@ The following emergency access accounts were excluded from this check as they ar
 
 | User | UPN | Role Name |
 | :--- | :-- | :-------- |
-
 '@
         foreach ($emergency in $excludedEmergencyAccounts) {
             $portalLink = 'https://entra.microsoft.com/#view/Microsoft_AAD_UsersAndTenants/UserProfileMenuBlade/~/AdministrativeRole/userId/{0}/hidePreviewBanner~/true' -f $emergency.principalId

--- a/src/powershell/tests/Test-Assessment.21815.ps1
+++ b/src/powershell/tests/Test-Assessment.21815.ps1
@@ -95,7 +95,8 @@ from vwRole
         $mdInfo = $formatTemplate -f $reportTitle, $tableRows
     }
 
-    # Add section for excluded emergency access accounts (Issue #266)
+    # Build section for excluded emergency access accounts (Issue #266)
+    $emergencySection = ''
     if ($excludedEmergencyAccounts.Count -gt 0) {
         $emergencySection = @'
 
@@ -111,21 +112,15 @@ The following emergency access accounts were excluded from this check as they ar
             $portalLink = 'https://entra.microsoft.com/#view/Microsoft_AAD_UsersAndTenants/UserProfileMenuBlade/~/AdministrativeRole/userId/{0}/hidePreviewBanner~/true' -f $emergency.principalId
             $emergencySection += "| [$(Get-SafeMarkdown($emergency.principalDisplayName))]($portalLink) | $(Get-SafeMarkdown($emergency.userPrincipalName)) | $(Get-SafeMarkdown($emergency.roleDisplayName)) |`n"
         }
-
-        if (-not $passed) {
-            $mdInfo += $emergencySection
-        }
-        else {
-            $mdInfo = $emergencySection
-        }
     }
 
-    # Replace the placeholder with the detailed information (for failed tests)
-    $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", $mdInfo
-
-    # Append excluded section directly when test passes (no placeholder in pass message)
-    if ($passed -and $excludedEmergencyAccounts.Count -gt 0) {
-        $testResultMarkdown += "`n`n" + $mdInfo
+    if ($passed) {
+        # Pass message has no %TestResult% placeholder; append excluded section if any
+        $testResultMarkdown += $emergencySection
+    }
+    else {
+        # Replace the placeholder with the detailed failure table plus excluded section
+        $testResultMarkdown = $testResultMarkdown -replace "%TestResult%", ($mdInfo + $emergencySection)
     }
 
     $params = @{

--- a/src/powershell/tests/Test-Assessment.21815.ps1
+++ b/src/powershell/tests/Test-Assessment.21815.ps1
@@ -49,12 +49,15 @@ from vwRole
     $results = @($permanentPrivileged | Where-Object { $emergencyAccountIds -notcontains $_.principalId })
     $excludedEmergencyAccounts = @($permanentPrivileged | Where-Object { $emergencyAccountIds -contains $_.principalId })
 
+    # Count of *distinct* excluded emergency accounts (one user can have multiple permanent role assignments)
+    $excludedAccountCount = @($excludedEmergencyAccounts | Select-Object -ExpandProperty principalId -Unique).Count
+
     $testResultMarkdown = ""
 
     if ($results.Count -eq 0) {
         $passed = $true
-        if ($excludedEmergencyAccounts.Count -gt 0) {
-            $testResultMarkdown += "No privileged users have permanent role assignments (excluding $($excludedEmergencyAccounts.Count) emergency access account(s) which are expected to have permanent assignments)."
+        if ($excludedAccountCount -gt 0) {
+            $testResultMarkdown += "No privileged users have permanent role assignments (excluding $excludedAccountCount emergency access account(s) which are expected to have permanent assignments)."
         }
         else {
             $testResultMarkdown += "No privileged users have permanent role assignments."


### PR DESCRIPTION
## Summary
Fixes #266 - Test 21815 now excludes emergency access accounts from permanent role assignment failures.

## Changes
- **Get-ZtEmergencyAccessAccounts.ps1** - New helper to resolve emergency accounts from config (supports User/Group types)
- **Invoke-ZtAssessment.ps1** - Parses `GlobalSettings.EmergencyAccessAccounts` from config file
- **Test-Assessment.21815.ps1** - Filters out emergency accounts and shows them in a separate "Excluded" section