### PR TITLE
Feature: Add version display to report footer, fix tsconfig, and update devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "npm install",
+	"postCreateCommand": "npm install && cd src/report && npm install",
 
 	// Configure tool-specific properties.
 	"customizations": {}

--- a/src/report/src/components/layouts/Footer.tsx
+++ b/src/report/src/components/layouts/Footer.tsx
@@ -121,6 +121,8 @@ export function Footer() {
                         </a>
                         <span>•</span>
                         <span>{assessmentDate}</span>
+                        <span>•</span>
+                        <span>v{reportData.CurrentVersion}</span>
                     </div>
 
                     {/* Theme Toggle (Hidden but available for future use) */}

--- a/src/report/tsconfig.app.json
+++ b/src/report/tsconfig.app.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@/*": [
         "./src/*"


### PR DESCRIPTION
Add version display to report footer, fix tsconfig, and update devcontainer

Display module version (v{CurrentVersion}) in the report footer alongside the assessment date
Remove unnecessary baseUrl from tsconfig.app.json (paths config already handles resolution)
Update devcontainer postCreateCommand to also install report dependencies