### PR TITLE
fix: category with naming mismatches to reduce duplicate categories in diffrent naming variants

### DIFF
--- a/src/powershell/tests/Test-Assessment.21784.ps1
+++ b/src/powershell/tests/Test-Assessment.21784.ps1
@@ -11,7 +11,7 @@ Pass/Fail Hook:
 
 function Test-Assessment-21784 {
     [ZtTest(
-    	Category = 'Access control; Credential management',
+    	Category = 'Access control, Credential management',
     	ImplementationCost = 'Medium',
     	MinimumLicense = ('P1'),
     	Pillar = 'Identity',

--- a/src/powershell/tests/Test-Assessment.21837.ps1
+++ b/src/powershell/tests/Test-Assessment.21837.ps1
@@ -5,7 +5,7 @@
 
 function Test-Assessment-21837{
     [ZtTest(
-    	Category = 'Devices',
+    	Category = 'Device',
     	ImplementationCost = 'Low',
     	MinimumLicense = ('Free'),
     	Pillar = 'Identity',

--- a/src/powershell/tests/Test-Assessment.21886.ps1
+++ b/src/powershell/tests/Test-Assessment.21886.ps1
@@ -5,7 +5,7 @@
 
 function Test-Assessment-21886 {
     [ZtTest(
-    	Category = 'Applications management',
+    	Category = 'Application management',
     	ImplementationCost = 'Medium',
     	MinimumLicense = ('P1'),
     	Pillar = 'Identity',

--- a/src/powershell/tests/Test-Assessment.21953.ps1
+++ b/src/powershell/tests/Test-Assessment.21953.ps1
@@ -5,7 +5,7 @@
 
 function Test-Assessment-21953{
     [ZtTest(
-    	Category = 'Devices',
+    	Category = 'Device',
     	ImplementationCost = 'Medium',
     	MinimumLicense = ('P1'),
     	Pillar = 'Identity',

--- a/src/powershell/tests/Test-Assessment.21954.ps1
+++ b/src/powershell/tests/Test-Assessment.21954.ps1
@@ -5,7 +5,7 @@
 
 function Test-Assessment-21954{
     [ZtTest(
-    	Category = 'Devices',
+    	Category = 'Device',
     	ImplementationCost = 'Low',
     	MinimumLicense = ('Free'),
     	Pillar = 'Identity',

--- a/src/powershell/tests/Test-Assessment.21955.ps1
+++ b/src/powershell/tests/Test-Assessment.21955.ps1
@@ -5,7 +5,7 @@
 
 function Test-Assessment-21955 {
     [ZtTest(
-    	Category = 'Devices',
+    	Category = 'Device',
     	ImplementationCost = 'Low',
     	MinimumLicense = ('P1'),
     	Pillar = 'Identity',

--- a/src/powershell/tests/Test-Assessment.35003.ps1
+++ b/src/powershell/tests/Test-Assessment.35003.ps1
@@ -14,7 +14,7 @@
 
 function Test-Assessment-35003 {
     [ZtTest(
-    	Category = 'sensitivity-labels',
+    	Category = 'Sensitivity Labels',
     	ImplementationCost = 'Medium',
     	MinimumLicense = ('Microsoft 365 E3'),
     	Service = ('SecurityCompliance'),

--- a/src/powershell/tests/Test-Assessment.35012.ps1
+++ b/src/powershell/tests/Test-Assessment.35012.ps1
@@ -10,7 +10,7 @@
 
 .NOTES
     Test ID: 35012
-    Category: Sensitivity Labels Configuration
+    Category: Sensitivity Labels
     Required APIs: Get-Label (Exchange PowerShell)
 #>
 

--- a/src/powershell/tests/Test-Assessment.35012.ps1
+++ b/src/powershell/tests/Test-Assessment.35012.ps1
@@ -17,7 +17,7 @@
 function Test-Assessment-35012 {
 
     [ZtTest(
-        Category = 'Sensitivity Labels Configuration',
+        Category = 'Sensitivity Labels',
         ImplementationCost = 'Medium',
         Service = ('SecurityCompliance'),
         MinimumLicense = ('Microsoft 365 E5'),

--- a/src/powershell/tests/Test-Assessment.35013.ps1
+++ b/src/powershell/tests/Test-Assessment.35013.ps1
@@ -10,7 +10,7 @@
 
 .NOTES
     Test ID: 35013
-    Category: Sensitivity Labels Configuration
+    Category: Sensitivity Labels
     Required Module: ExchangeOnlineManagement v3.5.1+
     Required Connection: Connect-IPPSSession
 #>

--- a/src/powershell/tests/Test-Assessment.35013.ps1
+++ b/src/powershell/tests/Test-Assessment.35013.ps1
@@ -17,7 +17,7 @@
 
 function Test-Assessment-35013 {
     [ZtTest(
-        Category = 'Sensitivity Labels Configuration',
+        Category = 'Sensitivity Labels',
         ImplementationCost = 'Medium',
         Service = ('SecurityCompliance'),
         MinimumLicense = 'Microsoft 365 E3',

--- a/src/powershell/tests/Test-Assessment.35015.ps1
+++ b/src/powershell/tests/Test-Assessment.35015.ps1
@@ -13,7 +13,7 @@
 
 function Test-Assessment-35015 {
     [ZtTest(
-    	Category = 'sensitivity-labels',
+    	Category = 'Sensitivity Labels',
     	ImplementationCost = 'Medium',
     	MinimumLicense = ('Microsoft 365 E3'),
     	Service = ('SecurityCompliance'),

--- a/src/powershell/tests/Test-Assessment.35024.ps1
+++ b/src/powershell/tests/Test-Assessment.35024.ps1
@@ -17,7 +17,7 @@
 
 function Test-Assessment-35024 {
     [ZtTest(
-    	Category = 'Rights Management Service',
+    	Category = 'Rights Management Service (RMS)',
     	ImplementationCost = 'Low',
     	MinimumLicense = ('Microsoft 365 E3'),
     	Service = ('ExchangeOnline'),


### PR DESCRIPTION
Currently after running the assessment if you wnt to parse the json file "ZeroTrustAssessmentReport.json" and want to look at categories a hinderance i see is the diffrent naming schemes for the same topic example:
Sensitivity Labels
Sensitivity Labels Configuration
sensitivity-labels

3 different naming schemes for Sensitivity Labels.

I am adding an output of the diffrent categories below to show how it looks before this pr:

$t.Tests.TestCategory | select -Unique | sort 
Access control
Access control; Credential management
Advanced Classification
Advanced Label Features
Application management
Application Proxy
Applications management
Azure Network Security
Credential management
Credential management, Privileged access
Data
Data Loss Prevention (DLP)
Data Security Posture Management
Device
Devices
Encryption
Entra
External collaboration
External Identities
Global Secure Access
Hybrid infrastructure
Identity
Identity governance
Information Protection
Label Policy Configuration
Microsoft Purview Message Encryption
Monitoring
Network
Network security
Private Access
Privileged access
Rights Management Service
Rights Management Service (RMS)
Role management
Sensitivity Labels
Sensitivity Labels Configuration
sensitivity-labels
SharePoint Online
Tenant