### PR TITLE
uniform minimumLicense requirements naming

### DIFF
--- a/src/powershell/tests/Test-Assessment.26884.ps1
+++ b/src/powershell/tests/Test-Assessment.26884.ps1
@@ -17,7 +17,7 @@ function Test-Assessment-26884 {
     [ZtTest(
         Category = 'Azure Network Security',
         ImplementationCost = 'Low',
-        MinimumLicense = ('Azure_Front_Door_Premium'),
+        MinimumLicense = ('Azure_FrontDoor_Premium'),
         Pillar = 'Network',
         RiskLevel = 'High',
         SfiPillar = 'Protect networks',


### PR DESCRIPTION
Currently after running the assessment if you want to parse the json file "ZeroTrustAssessmentReport.json" and want to look at minimum licenses requirements a hinderance i see is the diffrent naming schemes for the same topic example:
Azure_Front_Door_Premium
Azure_FrontDoor_Premium

2 different naming schemes for Azure FrontDoor Premium license.

I am adding an output of the diffrent categories below to show how it looks before this pr:

$t.Tests.TestMinimumLicense | select -Unique | sort
Advanced Message Encryption add-on
Azure Application Gateway Standard SKU
Azure Standard SKU
Azure WAF
Azure WAF on Azure Front Door Premium SKU
Azure_Application_Gateway_WAF
Azure_Firewall_Basic
Azure_Firewall_Premium
Azure_Firewall_Standard
Azure_Front_Door_Premium
Azure_FrontDoor_Premium
Azure_FrontDoor_Standard
Azure_WAF
DDoS_IP_Protection
DDoS_Network_Protection
Entra_Premium_Internet_Access
Entra_Premium_Private_Access
EXCHANGE_S_ENTERPRISE
Free
Governance
Intune
Microsoft 365 E3
Microsoft 365 E5
MIP_P1
P1
P2
Workload
AAD_PREMIUM
AAD_PREMIUM_P2