### PR TITLE
bugfix-1147 - Export ServicePrincipal owners to fix 0 owner count in tests 21867 and 24518

### DIFF
--- a/src/powershell/assets/export-tenant.config.psd1
+++ b/src/powershell/assets/export-tenant.config.psd1
@@ -88,7 +88,7 @@ Note: Avoid using the same names as used for the "General Parameters" section of
 	Name = 'ServicePrincipal'
 	Uri = 'beta/servicePrincipals'
 	QueryString = '$expand=appRoleAssignments&$top=999&$select=id,deletedDateTime,accountEnabled,alternativeNames,createdByAppId,createdDateTime,deviceManagementAppType,appDescription,appDisplayName,appId,applicationTemplateId,appOwnerOrganizationId,appRoleAssignmentRequired,assignmentRequiredForPrincipalTypes,description,disabledByMicrosoftStatus,displayName,errorUrl,homepage,isAuthorizationServiceEnabled,isDisabled,isManagementRestricted,loginUrl,logoutUrl,notes,notificationEmailAddresses,preferredSingleSignOnMode,preferredTokenSigningKeyEndDateTime,preferredTokenSigningKeyThumbprint,publisherName,replyUrls,samlMetadataUrl,samlSLOBindingType,servicePrincipalNames,servicePrincipalType,signInAudience,tags,tokenEncryptionKeyId,certification,samlSingleSignOnSettings,addIns,api,appRoles,info,keyCredentials,publishedPermissionScopes,passwordCredentials,resourceSpecificApplicationPermissions,verifiedPublisher,customSecurityAttributes'
-	RelatedPropertyNames = @('oauth2PermissionGrants')
+	RelatedPropertyNames = @('oauth2PermissionGrants', 'owners')
 	Type = 'Default' # PrivilegedGroup
 
 	Pillar = @('Identity', 'Network')

--- a/src/powershell/private/export/Export-TenantData.ps1
+++ b/src/powershell/private/export/Export-TenantData.ps1
@@ -70,11 +70,10 @@ function Export-TenantData {
 
 		Export-GraphEntity -ExportPath $ExportPath -EntityName 'Application' `
 			-EntityUri 'beta/applications' -ProgressActivity 'Applications' `
-			-QueryString '$expand=owners&$top=999' -ShowCount
 
 		Export-GraphEntity -ExportPath $ExportPath -EntityName 'ServicePrincipal' `
 			-EntityUri 'beta/servicePrincipals' -ProgressActivity 'Service Principals' `
-			-QueryString '$expand=appRoleAssignments&$top=999' -RelatedPropertyNames @('oauth2PermissionGrants') `
+			-QueryString '$expand=appRoleAssignments&$top=999' -RelatedPropertyNames @('oauth2PermissionGrants', 'owners') `
 			-ShowCount
 
 		if ((Get-MgContext).Environment -eq 'Global') {

--- a/src/powershell/private/export/Export-TenantData.ps1
+++ b/src/powershell/private/export/Export-TenantData.ps1
@@ -69,7 +69,8 @@ function Export-TenantData {
 			-QueryString $userQueryString -ShowCount
 
 		Export-GraphEntity -ExportPath $ExportPath -EntityName 'Application' `
-			-EntityUri 'beta/applications' -ProgressActivity 'Applications' -ShowCount
+			-EntityUri 'beta/applications' -ProgressActivity 'Applications' `
+			-QueryString '$top=999' -ShowCount
 
 		Export-GraphEntity -ExportPath $ExportPath -EntityName 'ServicePrincipal' `
 			-EntityUri 'beta/servicePrincipals' -ProgressActivity 'Service Principals' `

--- a/src/powershell/private/export/Export-TenantData.ps1
+++ b/src/powershell/private/export/Export-TenantData.ps1
@@ -69,7 +69,7 @@ function Export-TenantData {
 			-QueryString $userQueryString -ShowCount
 
 		Export-GraphEntity -ExportPath $ExportPath -EntityName 'Application' `
-			-EntityUri 'beta/applications' -ProgressActivity 'Applications' `
+			-EntityUri 'beta/applications' -ProgressActivity 'Applications' -ShowCount
 
 		Export-GraphEntity -ExportPath $ExportPath -EntityName 'ServicePrincipal' `
 			-EntityUri 'beta/servicePrincipals' -ProgressActivity 'Service Principals' `

--- a/src/powershell/private/tests-shared/Get-ApplicationsWithPermissions.ps1
+++ b/src/powershell/private/tests-shared/Get-ApplicationsWithPermissions.ps1
@@ -3,7 +3,7 @@
     Get all applications with permissions, classified by risk level.
 
 .DESCRIPTION
-    This function queries ServicePrincipal objects with their associated Application data,
+    This function queries ServicePrincipal objects with their sign-in activity,
     enriches them with permission details, risk classifications and owner counts.
     Used by tests 21770, 24518, and 21867.
 #>
@@ -15,15 +15,14 @@ function Get-ApplicationsWithPermissions {
         $Database
     )
 
-    # Query ServicePrincipal objects with permissions (same SQL as Test-21770)
-    # LEFT JOIN with Application to get owners and other app properties
+    # Query ServicePrincipal objects with permissions
+    # Used by tests 21770, 24518, and 21867
     $sql = @"
 select sp.id, sp.appId, sp.displayName, sp.appOwnerOrganizationId, sp.publisherName,
 spsi.lastSignInActivity.lastSignInDateTime,
-app.owners, app.signInAudience, app.publisherDomain
+sp.owners, sp.signInAudience
 from main.ServicePrincipal sp
     left join main.ServicePrincipalSignIn spsi on spsi.appId = sp.appId
-    left join main.Application app on app.appId = sp.appId
 where sp.id in
     (
         select sp.id
@@ -66,7 +65,7 @@ order by spsi.lastSignInActivity.lastSignInDateTime
             # Add risk classification
             $item = Add-GraphRisk $item
 
-            # Add owner count from Application.owners field
+            # Add owner count from ServicePrincipal.owners field
             $ownerCount = 0
             if ($item.owners) {
                 if ($item.owners -is [System.Collections.ICollection]) {


### PR DESCRIPTION
fix: Export and use ServicePrincipal owners for tests 21867/24518 (#1147)

Tests 21867 and 24518 were showing 0 owners for all applications because:
- ServicePrincipal owners were not being exported from Graph API
- SQL was incorrectly using Application.owners instead of ServicePrincipal.owners

Changes:
- Add 'owners' to ServicePrincipal RelatedPropertyNames in export-tenant.config.psd1
- Add 'owners' to ServicePrincipal export in Export-TenantData.ps1 (legacy path)
- Update Get-ApplicationsWithPermissions to use sp.owners instead of app.owners
- Remove redundant Application table LEFT JOIN (use sp.signInAudience instead)

Fixes #1147