### PR TITLE
Bugfix 1152

### DIFF
--- a/code-tests/commands/Export-ZtGraphEntity.Tests.ps1
+++ b/code-tests/commands/Export-ZtGraphEntity.Tests.ps1
@@ -1,0 +1,117 @@
+Describe "Export-ZtGraphEntity" {
+    # Regression tests for customer bug v2.2.0:
+    #
+    #   Error 1 (WARNING): Export 'ServicePrincipal' failed:
+    #     Cannot bind argument to parameter 'ArgumentList' because it is an empty array.
+    #
+    #   Root cause: When a Graph API page returned { "value": [] }, Add-GraphProperty
+    #   passed the empty $Results.Value directly to Invoke-ZtGraphBatchRequest -ArgumentList.
+    #   PowerShell cannot bind @() to a mandatory [object[]] parameter.
+    #
+    #   Fix: Guard in Add-GraphProperty:
+    #     if (-not $Results -or @($Results).Count -eq 0) { return }
+    #
+    #   Error 2 (Exception): Export-Database.ps1:115
+    #     Binder Error: Could not find key "userprincipalname" in struct
+    #
+    #   Root cause: When all role principals are Service Principals, DuckDB inferred the
+    #   principal struct without userPrincipalName, causing the vwRole SQL to fail.
+    #
+    #   Fix: Model JSON files pre-declare all principal fields as null.
+    #   See Export-Database.Tests.ps1 for Error 2 regression tests.
+
+    BeforeAll {
+        $srcRoot = Join-Path $PSScriptRoot "../../src/powershell"
+        if (-not (Get-Module ZeroTrustAssessment -ErrorAction SilentlyContinue)) {
+            Import-Module (Join-Path $srcRoot "ZeroTrustAssessment.psd1") -Global 3>$null
+            Import-Module (Join-Path $srcRoot "ZeroTrustAssessment.psm1") -Global -Force 3>$null
+        }
+        if (-not (Get-Command Get-MgContext -ErrorAction SilentlyContinue)) {
+            function global:Get-MgContext {}
+        }
+        if (-not (Get-Command Invoke-MgGraphRequest -ErrorAction SilentlyContinue)) {
+            function global:Invoke-MgGraphRequest { param($Method, $Uri, $OutputType) }
+        }
+    }
+
+    Context "Error 1 reproduction — empty page triggers ArgumentList error (old behaviour)" {
+        # Invoke-ZtGraphBatchRequest declares ArgumentList as mandatory [object[]].
+        # Before the fix, Add-GraphProperty passed $Results.Value directly with no guard,
+        # so an empty page caused the customer error.
+
+        It "Invoke-ZtGraphBatchRequest throws when ArgumentList is empty" {
+            { Invoke-ZtGraphBatchRequest -Path 'servicePrincipals/{0}/oauth2PermissionGrants' -ArgumentList @() } |
+                Should -Throw
+        }
+
+        It "The error message matches the customer warning ('ArgumentList')" {
+            $msg = $null
+            try {
+                Invoke-ZtGraphBatchRequest -Path 'servicePrincipals/{0}/oauth2PermissionGrants' -ArgumentList @()
+            }
+            catch { $msg = $_.Exception.Message }
+            $msg | Should -Match 'ArgumentList'
+        }
+    }
+
+    Context "Error 1 fix — guard in Add-GraphProperty skips batch when page is empty" {
+        BeforeAll {
+            $script:exportPath = Join-Path $env:TEMP "zt-test-graphentity-$(Get-Random)"
+            New-Item -ItemType Directory -Path $script:exportPath -Force | Out-Null
+        }
+
+        AfterAll {
+            Remove-Item $script:exportPath -Recurse -Force -ErrorAction SilentlyContinue
+        }
+
+        BeforeEach {
+            Mock -ModuleName ZeroTrustAssessment Get-ZtConfig            { return $false }
+            Mock -ModuleName ZeroTrustAssessment Set-ZtConfig            {}
+            Mock -ModuleName ZeroTrustAssessment Update-ZtProgressState  {}
+            Mock -ModuleName ZeroTrustAssessment Get-PSFConfigValue      { return 1073741824 }
+        }
+
+        It "Does not throw when Graph API returns an empty page" {
+            # Invoke-ZtRetry returns { "value": [] } — same as the customer tenant.
+            # The guard must return early without calling Invoke-ZtGraphBatchRequest.
+            Mock -ModuleName ZeroTrustAssessment Invoke-ZtRetry { return @{ value = @() } }
+            Mock -ModuleName ZeroTrustAssessment Invoke-ZtGraphBatchRequest {
+                throw "Guard missing — called with empty ArgumentList"
+            }
+
+            {
+                Export-ZtGraphEntity -Name 'ServicePrincipal' -Uri 'beta/servicePrincipals' `
+                    -QueryString '$top=999' -RelatedPropertyNames @('oauth2PermissionGrants') `
+                    -ExportPath $script:exportPath
+            } | Should -Not -Throw
+        }
+
+        It "Invoke-ZtGraphBatchRequest is not called when the page is empty" {
+            Mock -ModuleName ZeroTrustAssessment Invoke-ZtRetry { return @{ value = @() } }
+            Mock -ModuleName ZeroTrustAssessment Invoke-ZtGraphBatchRequest {}
+
+            Export-ZtGraphEntity -Name 'ServicePrincipal' -Uri 'beta/servicePrincipals' `
+                -QueryString '$top=999' -RelatedPropertyNames @('oauth2PermissionGrants') `
+                -ExportPath $script:exportPath
+
+            Should -Invoke -ModuleName ZeroTrustAssessment -CommandName Invoke-ZtGraphBatchRequest -Times 0 -Exactly
+        }
+
+        It "Invoke-ZtGraphBatchRequest is called once when the page has items" {
+            # Verifies the guard does not suppress normal (non-empty) pages.
+            $script:call = 0
+            Mock -ModuleName ZeroTrustAssessment Invoke-ZtRetry {
+                $script:call++
+                if ($script:call -eq 1) { return @{ value = @(@{ id = 'sp-1'; displayName = 'TestSP' }) } }
+                return @{ value = @() }
+            }
+            Mock -ModuleName ZeroTrustAssessment Invoke-ZtGraphBatchRequest { return @() }
+
+            Export-ZtGraphEntity -Name 'ServicePrincipal' -Uri 'beta/servicePrincipals' `
+                -QueryString '$top=999' -RelatedPropertyNames @('oauth2PermissionGrants') `
+                -ExportPath $script:exportPath
+
+            Should -Invoke -ModuleName ZeroTrustAssessment -CommandName Invoke-ZtGraphBatchRequest -Times 1 -Exactly
+        }
+    }
+}

--- a/code-tests/commands/Export-ZtGraphEntity.Tests.ps1
+++ b/code-tests/commands/Export-ZtGraphEntity.Tests.ps1
@@ -16,9 +16,6 @@ Describe "Export-ZtGraphEntity" {
         if (-not (Get-Command Get-MgContext -ErrorAction SilentlyContinue)) {
             function global:Get-MgContext {}
         }
-        if (-not (Get-Command Invoke-MgGraphRequest -ErrorAction SilentlyContinue)) {
-            function global:Invoke-MgGraphRequest { param($Method, $Uri, $OutputType) }
-        }
     }
 
     Context "Add-GraphProperty — guard skips batch when page is empty" {
@@ -64,12 +61,46 @@ Describe "Export-ZtGraphEntity" {
             Should -Invoke -ModuleName ZeroTrustAssessment -CommandName Invoke-ZtGraphBatchRequest -Times 0 -Exactly
         }
 
+        It "Does not throw when Invoke-ZtRetry returns null" {
+            # $null is distinct from @() — guard must handle both without calling Invoke-ZtGraphBatchRequest.
+            Mock -ModuleName ZeroTrustAssessment Invoke-ZtRetry { return $null }
+            Mock -ModuleName ZeroTrustAssessment Invoke-ZtGraphBatchRequest {
+                throw "Guard missing — called with null Results"
+            }
+
+            {
+                Export-ZtGraphEntity -Name 'ServicePrincipal' -Uri 'beta/servicePrincipals' `
+                    -QueryString '$top=999' -RelatedPropertyNames @('oauth2PermissionGrants') `
+                    -ExportPath $script:exportPath
+            } | Should -Not -Throw
+        }
+
+        It "Invoke-ZtGraphBatchRequest is not called when Invoke-ZtRetry returns null" {
+            Mock -ModuleName ZeroTrustAssessment Invoke-ZtRetry { return $null }
+            Mock -ModuleName ZeroTrustAssessment Invoke-ZtGraphBatchRequest {}
+
+            Export-ZtGraphEntity -Name 'ServicePrincipal' -Uri 'beta/servicePrincipals' `
+                -QueryString '$top=999' -RelatedPropertyNames @('oauth2PermissionGrants') `
+                -ExportPath $script:exportPath
+
+            Should -Invoke -ModuleName ZeroTrustAssessment -CommandName Invoke-ZtGraphBatchRequest -Times 0 -Exactly
+        }
+
         It "Invoke-ZtGraphBatchRequest is called once when the page has items" {
-            # Verifies the guard does not suppress normal (non-empty) pages.
+            # Verifies the guard does not suppress normal (non-empty) pages and correctly
+            # skips the batch call on an empty second page.
+            # The first page must include '@odata.nextLink' so the do-while loop makes a
+            # second call; without it the loop breaks immediately and the second branch
+            # of the mock is never reached.
             $script:call = 0
             Mock -ModuleName ZeroTrustAssessment Invoke-ZtRetry {
                 $script:call++
-                if ($script:call -eq 1) { return @{ value = @(@{ id = 'sp-1'; displayName = 'TestSP' }) } }
+                if ($script:call -eq 1) {
+                    return @{
+                        value             = @(@{ id = 'sp-1'; displayName = 'TestSP' })
+                        '@odata.nextLink' = 'https://graph.microsoft.com/beta/servicePrincipals?$skiptoken=abc'
+                    }
+                }
                 return @{ value = @() }
             }
             Mock -ModuleName ZeroTrustAssessment Invoke-ZtGraphBatchRequest { return @() }

--- a/code-tests/commands/Export-ZtGraphEntity.Tests.ps1
+++ b/code-tests/commands/Export-ZtGraphEntity.Tests.ps1
@@ -2,7 +2,7 @@ Describe "Export-ZtGraphEntity" {
     # Regression tests for the Add-GraphProperty guard:
     #
     #   Fix: Guard in Add-GraphProperty skips the batch call when Graph returns an empty page.
-    #     if (-not $Results -or @($Results).Count -eq 0) { return }
+    #     if (-not $Results) { return }
     #
     #   Without this guard, passing @() to Invoke-ZtGraphBatchRequest -ArgumentList caused:
     #     "Cannot bind argument to parameter 'ArgumentList' because it is an empty array."

--- a/code-tests/commands/Export-ZtGraphEntity.Tests.ps1
+++ b/code-tests/commands/Export-ZtGraphEntity.Tests.ps1
@@ -1,24 +1,11 @@
 Describe "Export-ZtGraphEntity" {
-    # Regression tests for customer bug v2.2.0:
+    # Regression tests for the Add-GraphProperty guard:
     #
-    #   Error 1 (WARNING): Export 'ServicePrincipal' failed:
-    #     Cannot bind argument to parameter 'ArgumentList' because it is an empty array.
-    #
-    #   Root cause: When a Graph API page returned { "value": [] }, Add-GraphProperty
-    #   passed the empty $Results.Value directly to Invoke-ZtGraphBatchRequest -ArgumentList.
-    #   PowerShell cannot bind @() to a mandatory [object[]] parameter.
-    #
-    #   Fix: Guard in Add-GraphProperty:
+    #   Fix: Guard in Add-GraphProperty skips the batch call when Graph returns an empty page.
     #     if (-not $Results -or @($Results).Count -eq 0) { return }
     #
-    #   Error 2 (Exception): Export-Database.ps1:115
-    #     Binder Error: Could not find key "userprincipalname" in struct
-    #
-    #   Root cause: When all role principals are Service Principals, DuckDB inferred the
-    #   principal struct without userPrincipalName, causing the vwRole SQL to fail.
-    #
-    #   Fix: Model JSON files pre-declare all principal fields as null.
-    #   See Export-Database.Tests.ps1 for Error 2 regression tests.
+    #   Without this guard, passing @() to Invoke-ZtGraphBatchRequest -ArgumentList caused:
+    #     "Cannot bind argument to parameter 'ArgumentList' because it is an empty array."
 
     BeforeAll {
         $srcRoot = Join-Path $PSScriptRoot "../../src/powershell"
@@ -34,27 +21,7 @@ Describe "Export-ZtGraphEntity" {
         }
     }
 
-    Context "Error 1 reproduction — empty page triggers ArgumentList error (old behaviour)" {
-        # Invoke-ZtGraphBatchRequest declares ArgumentList as mandatory [object[]].
-        # Before the fix, Add-GraphProperty passed $Results.Value directly with no guard,
-        # so an empty page caused the customer error.
-
-        It "Invoke-ZtGraphBatchRequest throws when ArgumentList is empty" {
-            { Invoke-ZtGraphBatchRequest -Path 'servicePrincipals/{0}/oauth2PermissionGrants' -ArgumentList @() } |
-                Should -Throw
-        }
-
-        It "The error message matches the customer warning ('ArgumentList')" {
-            $msg = $null
-            try {
-                Invoke-ZtGraphBatchRequest -Path 'servicePrincipals/{0}/oauth2PermissionGrants' -ArgumentList @()
-            }
-            catch { $msg = $_.Exception.Message }
-            $msg | Should -Match 'ArgumentList'
-        }
-    }
-
-    Context "Error 1 fix — guard in Add-GraphProperty skips batch when page is empty" {
+    Context "Add-GraphProperty — guard skips batch when page is empty" {
         BeforeAll {
             $script:exportPath = Join-Path $env:TEMP "zt-test-graphentity-$(Get-Random)"
             New-Item -ItemType Directory -Path $script:exportPath -Force | Out-Null

--- a/src/powershell/private/export/Export-ZtGraphEntity.ps1
+++ b/src/powershell/private/export/Export-ZtGraphEntity.ps1
@@ -130,6 +130,14 @@ function Export-ZtGraphEntity {
 		Write-PSFMessage -Message "Adding {0} to {1}" -StringValues $PropertyName, $Name -Tag Graph
 		Update-ZtProgressState -WorkerId $Name -WorkerName $Name -WorkerStatus 'Running' -WorkerDetail "Batch: $PropertyName"
 
+		# Guard against empty pages: Invoke-ZtGraphBatchRequest requires a non-empty ArgumentList.
+		# Graph API can return a page with an empty 'value' array (e.g. with $expand queries),
+		# which would cause a PowerShell parameter-binding error for the mandatory [object[]] param.
+		if (-not $Results -or @($Results).Count -eq 0) {
+			Write-PSFMessage -Level Verbose -Message "No items to batch for property '{0}' in '{1}'. Skipping." -StringValues $PropertyName, $Name -Tag Graph
+			return
+		}
+
 		$data = Invoke-ZtGraphBatchRequest -Path "$Uri/{0}/$PropertyName" -ArgumentList $Results -Properties id -Matched -ErrorAction SilentlyContinue -ErrorVariable failed
 		# Since the argument property is the original hashtable provided, we can update the hashtable as it is and thereby update the original object
 		foreach ($pair in $data) {

--- a/src/powershell/private/export/Export-ZtGraphEntity.ps1
+++ b/src/powershell/private/export/Export-ZtGraphEntity.ps1
@@ -131,8 +131,9 @@ function Export-ZtGraphEntity {
 		Update-ZtProgressState -WorkerId $Name -WorkerName $Name -WorkerStatus 'Running' -WorkerDetail "Batch: $PropertyName"
 
 		# Guard against empty pages: Invoke-ZtGraphBatchRequest requires a non-empty ArgumentList.
-		# Graph API can return a page with an empty 'value' array (e.g. with $expand queries),
-		# which would cause a PowerShell parameter-binding error for the mandatory [object[]] param.
+		# Graph API can return a page with an empty 'value' array (e.g. when the tenant has no items,
+		# or on the last page of a paginated response), which would cause a PowerShell
+		# parameter-binding error for the mandatory [object[]] param.
 		if (-not $Results) {
 			Write-PSFMessage -Level Verbose -Message "No items to batch for property '{0}' in '{1}'. Skipping." -StringValues $PropertyName, $Name -Tag Graph
 			return

--- a/src/powershell/private/export/Export-ZtGraphEntity.ps1
+++ b/src/powershell/private/export/Export-ZtGraphEntity.ps1
@@ -133,7 +133,7 @@ function Export-ZtGraphEntity {
 		# Guard against empty pages: Invoke-ZtGraphBatchRequest requires a non-empty ArgumentList.
 		# Graph API can return a page with an empty 'value' array (e.g. with $expand queries),
 		# which would cause a PowerShell parameter-binding error for the mandatory [object[]] param.
-		if (-not $Results -or @($Results).Count -eq 0) {
+		if (-not $Results) {
 			Write-PSFMessage -Level Verbose -Message "No items to batch for property '{0}' in '{1}'. Skipping." -StringValues $PropertyName, $Name -Tag Graph
 			return
 		}


### PR DESCRIPTION
When the Graph API returned a page with no items (`{ "value": [] }`) for `beta/servicePrincipals, Add-GraphProperty` passed the empty list directly to `Invoke-ZtGraphBatchRequest -ArgumentList`. PowerShell cannot bind an empty array to a mandatory `[object[]]` parameter, causing:

`WARNING: Export 'ServicePrincipal' failed: Cannot bind argument to parameter 'ArgumentList' because it is an empty array.`

This caused the entire ServicePrincipal export to fail.

Fix

Added a guard in Add-GraphProperty that returns early when the results list is empty, skipping the batch call entirely:
```
if (-not $Results -or @($Results).Count -eq 0) {
    return
}
```