### PR TITLE
Bugfix/ServicePrincipal sql error when running Invoke-ZtAssessment

### DIFF
--- a/src/powershell/private/export/Export-Database.ps1
+++ b/src/powershell/private/export/Export-Database.ps1
@@ -56,8 +56,8 @@ function Export-Database {
         cast(r.principal.displayName as varchar)        as principalDisplayName,
         rd.displayName                                  as roleDisplayName,
         coalesce(
-            json_extract_string(r.principal::JSON, '$.userPrincipalName'),
-            json_extract_string(r.principal::JSON, '$.uniqueName')
+            json_extract_string(to_json(r.principal), '$.userPrincipalName'),
+            json_extract_string(to_json(r.principal), '$.uniqueName')
         )                                               as userPrincipalName,
         cast(r.principal."@odata.type" as varchar)      as "@odata.type",
         cast(r.principalId as varchar)                  as principalId,

--- a/src/powershell/private/export/Export-Database.ps1
+++ b/src/powershell/private/export/Export-Database.ps1
@@ -55,7 +55,10 @@ function Export-Database {
         cast(r."roleDefinitionId" as varchar)           as roleDefinitionId,
         cast(r.principal.displayName as varchar)        as principalDisplayName,
         rd.displayName                                  as roleDisplayName,
-        cast(r.principal.userPrincipalName as varchar)  as userPrincipalName,
+        coalesce(
+            json_extract_string(r.principal::JSON, '$.userPrincipalName'),
+            json_extract_string(r.principal::JSON, '$.uniqueName')
+        )                                               as userPrincipalName,
         cast(r.principal."@odata.type" as varchar)      as "@odata.type",
         cast(r.principalId as varchar)                  as principalId,
         '$PrivilegeType'                                as privilegeType


### PR DESCRIPTION
## Fix: Handle `uniqueName` field in role principal struct for DuckDB view creation

Resolves #1152
Resolves #1151

### Problem
Binder Error: Could not find key "userprincipalname" in struct
Candidate Entries: "uniqueName"

`Invoke-ZtAssessment` fails during the "Creating database" step with:

The SQL in `Get-RoleSelectSql` (`Export-Database.ps1`) accessed `r.principal.userPrincipalName`
directly on the DuckDB struct. A recent Microsoft Graph API change renamed this field to
`uniqueName` in the `principal` object on role assignment tables
(`RoleAssignmentScheduleInstance`, `RoleAssignment`, `RoleEligibilityScheduleInstance`).
When the exported JSON contains `uniqueName` instead of `userPrincipalName`, DuckDB throws
a binder error and the entire database creation fails.

<img width="1461" height="408" alt="image" src="https://github.com/user-attachments/assets/d584c297-2365-4cf9-b790-13c742752e58" />
### Fix

Replaced the direct struct field access:

```sql
cast(r.principal.userPrincipalName as varchar) as userPrincipalName,
```

With a coalesce over json_extract_string, falling back between both field names:

```sql
coalesce(
    json_extract_string(r.principal::JSON, '$.userPrincipalName'),
    json_extract_string(r.principal::JSON, '$.uniqueName')
) as userPrincipalName,
```

This makes the query resilient to both the old and new Graph API schema — userPrincipalName
is tried first (returns NULL if absent rather than throwing), and uniqueName is used
as the fallback.