### PR TITLE
Bugfix 1151 - RoleAssignment import fails with timestamp parse error

### DIFF
--- a/src/powershell/assets/export-model/RoleAssignment-model.json
+++ b/src/powershell/assets/export-model/RoleAssignment-model.json
@@ -15,6 +15,7 @@
         "uniqueName": null,
         "id": null,
         "createdDateTime": "1900-01-01T00:00:00Z",
+        "renewedDateTime": "1900-01-01T00:00:00Z",
         "refreshTokensValidFromDateTime": "1900-01-01T00:00:00Z",
         "signInSessionsValidFromDateTime": "1900-01-01T00:00:00Z",
         "assignedPlans": [

--- a/src/powershell/assets/export-model/RoleAssignment-model.json
+++ b/src/powershell/assets/export-model/RoleAssignment-model.json
@@ -13,7 +13,18 @@
         "displayName": null,
         "userPrincipalName": null,
         "uniqueName": null,
-        "id": null
+        "id": null,
+        "createdDateTime": "1900-01-01T00:00:00Z",
+        "refreshTokensValidFromDateTime": "1900-01-01T00:00:00Z",
+        "signInSessionsValidFromDateTime": "1900-01-01T00:00:00Z",
+        "assignedPlans": [
+          {
+            "assignedDateTime": "1900-01-01T00:00:00Z",
+            "capabilityStatus": null,
+            "service": null,
+            "servicePlanId": null
+          }
+        ]
       }
     }
   ]


### PR DESCRIPTION
Added `ISO 8601 sentinel` values `("1900-01-01T00:00:00Z")` for all four timestamp fields to `RoleAssignment-model.json` so DuckDB always infers the correct format.