### PR TITLE
Skip database tables with no export files

### DIFF
--- a/src/powershell/private/db/content/New-EntraTable.ps1
+++ b/src/powershell/private/db/content/New-EntraTable.ps1
@@ -22,7 +22,7 @@ function New-EntraTable {
         $FilePath
     )
 
-    $matchingFiles = Get-ChildItem -Path $FilePath -File -ErrorAction SilentlyContinue
+    $matchingFiles = Get-ChildItem -Path $FilePath -File -ErrorAction SilentlyContinue | Select-Object -First 1
     if (-not $matchingFiles) {
         Write-PSFMessage "Skipping table $TableName because no files matched the pattern $FilePath" -Level Warning -Tag DB
         return

--- a/src/powershell/private/db/content/New-EntraTable.ps1
+++ b/src/powershell/private/db/content/New-EntraTable.ps1
@@ -22,6 +22,12 @@ function New-EntraTable {
         $FilePath
     )
 
+    $matchingFiles = Get-ChildItem -Path $FilePath -File -ErrorAction SilentlyContinue
+    if (-not $matchingFiles) {
+        Write-PSFMessage "Skipping table $TableName because no files matched the pattern $FilePath" -Level Warning -Tag DB
+        return
+    }
+
     # Get schema configuration if available for this table
     $schemaConfig = Get-TableSchemaConfig -TableName $TableName
 


### PR DESCRIPTION
## Description
Fixes a crash in `New-EntraTable` when processing exports with no matching files.

When Graph API role restrictions prevent certain exports (e.g., `User`, `ServicePrincipalSignIn`), the table creation step fails with "No files found that match the pattern" because DuckDB cannot create a table from an empty file set.

## Changes
- Added an early guard in `New-EntraTable` to skip table creation when no export JSON files match the expected pattern
- Allows the assessment to continue past role-restricted exports instead of aborting

## Testing
- Validated by re-running the assessment with restricted permissions; the export step now gracefully skips missing files instead of crashing during database creation