### PR TITLE
Bugfix/issue 1194: fix issues related to test 21835

### DIFF
--- a/src/powershell/tests/Test-Assessment.21835.ps1
+++ b/src/powershell/tests/Test-Assessment.21835.ps1
@@ -141,6 +141,20 @@ WHERE vr.roleDefinitionId = '62e90394-69f5-4237-9190-012177145e10'
     # Store CA policy info for ALL permanent GAs (not just candidates)
     $gaCAInfo = @{}
 
+    if ($enabledCAPolicies.Count -eq 0) {
+        # No enabled CA policies in the tenant: there is nothing to evaluate per user, and
+        # in particular nothing to exclude from. Vacuously, every user is "excluded from all"
+        # enabled policies. Skip the per-user Graph calls entirely.
+        Write-PSFMessage 'No enabled CA policies found; skipping per-user CA evaluation.' -Level Verbose
+        foreach ($user in $permanentGAUsers) {
+            $gaCAInfo[$user.id] = @{
+                PoliciesTargeting        = 0
+                ExcludedFromAll          = $true
+                PoliciesMissingExclusion = [System.Collections.Generic.List[object]]::new()
+            }
+        }
+    }
+    else {
     foreach ($user in $permanentGAUsers) {
         Write-PSFMessage "Checking CA policy targeting for: $($user.userPrincipalName)" -Level Verbose
 
@@ -244,6 +258,7 @@ WHERE vr.roleDefinitionId = '62e90394-69f5-4237-9190-012177145e10'
             ExcludedFromAll          = $excludedFromAll
             PoliciesMissingExclusion = $policiesMissingExclusion
         }
+    }
     }
 
     # Determine emergency access accounts: candidates that are excluded from all enabled CA policies

--- a/src/powershell/tests/Test-Assessment.21835.ps1
+++ b/src/powershell/tests/Test-Assessment.21835.ps1
@@ -304,7 +304,7 @@ WHERE vr.roleDefinitionId = '62e90394-69f5-4237-9190-012177145e10'
             $syncStatus = if ($account.onPremisesSyncEnabled -ne $true) { 'No' } else { 'Yes' }
             $authMethodDisplay = ($account.AuthenticationMethods | ForEach-Object {
                 $_ -replace '#microsoft.graph.', '' -replace 'AuthenticationMethod', ''
-            }) -join ', '
+            } | Select-Object -Unique) -join ', '
 
             $portalLink = "https://entra.microsoft.com/#view/Microsoft_AAD_UsersAndTenants/UserProfileMenuBlade/~/overview/userId/$($account.Id)"
 

--- a/src/powershell/tests/Test-Assessment.21835.ps1
+++ b/src/powershell/tests/Test-Assessment.21835.ps1
@@ -328,11 +328,13 @@ WHERE vr.roleDefinitionId = '62e90394-69f5-4237-9190-012177145e10'
             $cloudOnlyEmoji = if ($isCloudOnly) { '✅' } else { '❌' }
 
             # Check if excluded from all enabled CA policies (using per-user CA info, not emergency account membership)
-            $caExcludedEmoji = if ($gaCAInfo.ContainsKey($user.id) -and $gaCAInfo[$user.id].ExcludedFromAll) { '✅' } else { '❌' }
+            $isCAExcluded = ($gaCAInfo.ContainsKey($user.id) -and $gaCAInfo[$user.id].ExcludedFromAll)
+            $caExcludedEmoji = if ($isCAExcluded) { '✅' } else { '❌' }
 
             # Check if has phishing-resistant auth only
             $candidate = $emergencyAccountCandidates | Where-Object { $_.Id -eq $user.id }
-            $phishingResistantEmoji = if ($candidate) { '✅' } else { '❌' }
+            $isPhishingResistant = [bool]$candidate
+            $phishingResistantEmoji = if ($isPhishingResistant) { '✅' } else { '❌' }
 
             # Build CA policies missing exclusion cell
             if (-not $gaCAInfo.ContainsKey($user.id)) {
@@ -356,11 +358,16 @@ WHERE vr.roleDefinitionId = '62e90394-69f5-4237-9190-012177145e10'
                 CAExcluded = $caExcludedEmoji
                 PhishingResistant = $phishingResistantEmoji
                 CAPoliciesMissingExclusion = $caPoliciesCell
+                # Boolean values used for sorting so order is independent of glyph rendering / culture.
+                IsCloudOnly = $isCloudOnly
+                IsCAExcluded = $isCAExcluded
+                IsPhishingResistant = $isPhishingResistant
             }
         }
 
-        # show users that have passed every criteria first
-        $userSummary = $userSummary | Sort-Object -Property CAExcluded, PhishingResistant, CloudOnly
+        # Show users that have passed every criteria first. Sort by the underlying booleans
+        # ($true sorts after $false, so use -Descending) instead of the rendered emoji glyphs.
+        $userSummary = $userSummary | Sort-Object -Property IsCAExcluded, IsPhishingResistant, IsCloudOnly -Descending
 
         foreach ($user in $userSummary) {
             $testResultMarkdown += "| $(Get-SafeMarkdown -Text $user.DisplayName) | [$(Get-SafeMarkdown -Text $user.UserPrincipalName)]($($user.PortalLink)) | $($user.CloudOnly) | $($user.PhishingResistant) | $($user.CAExcluded) | $($user.CAPoliciesMissingExclusion) |`n"

--- a/src/powershell/tests/Test-Assessment.21835.ps1
+++ b/src/powershell/tests/Test-Assessment.21835.ps1
@@ -8,7 +8,10 @@
     - Phishing-resistant authentication methods (FIDO2 and/or Certificate)
     - Exclusion from all enabled Conditional Access policies
 
-    The test evaluates whether 2-4 emergency accounts are configured per Microsoft guidance.
+    Per spec, the result is:
+    - Fail        when fewer than two emergency access accounts are identified
+    - Pass        when exactly two emergency access accounts are identified
+    - Investigate when more than two emergency access accounts are identified
 #>
 
 function Test-Assessment-21835 {
@@ -285,21 +288,25 @@ WHERE vr.roleDefinitionId = '62e90394-69f5-4237-9190-012177145e10'
     $accountCount = $emergencyAccessAccounts.Count
     Write-PSFMessage "Total emergency access accounts identified: $accountCount" -Level Verbose
 
-    # Determine pass/fail status
+    # Determine pass/fail/investigate status per spec:
+    #   <  2 -> Fail
+    #   == 2 -> Pass
+    #   >  2 -> Investigate (set on the splat below based on $accountCount)
     $passed = $false
     $testResultMarkdown = ''
 
     if ($accountCount -lt 2) {
         $passed = $false
-        $testResultMarkdown = "Fewer than two emergency access accounts were identified based on cloud-only state, registered phishing-resistant credentials and Conditional Access policy exclusions.`n`n"
+        $testResultMarkdown = "Fewer than two emergency access accounts were identified based on cloud-only state, registered phishing-resistant credentials and CA policy exclusions.`n`n"
     }
-    elseif ($accountCount -ge 2 -and $accountCount -le 4) {
+    elseif ($accountCount -eq 2) {
         $passed = $true
-        $testResultMarkdown = "Emergency access accounts appear to be configured as per Microsoft guidance based on cloud-only state, registered phishing-resistant credentials and Conditional Access policy exclusions.`n`n"
+        $testResultMarkdown = "Two emergency access accounts appear to be configured as per Microsoft guidance based on cloud-only state, registered phishing-resistant credentials and CA policy exclusions.`n`n"
     }
     else {
+        # Investigate: more than two candidate emergency access accounts identified.
         $passed = $false
-        $testResultMarkdown = "$accountCount emergency access accounts appear to be configured based on cloud-only state, registered phishing-resistant credentials and Conditional Access policy exclusions. Review these accounts to determine whether this volume is excessive for your organization.`n`n"
+        $testResultMarkdown = "More than 2 emergency access accounts were found. This should be investigated to ensure account purpose and usage is limited to emergency or `"break glass`" scenarios.`n`n"
     }
 
     # Add summary information
@@ -393,7 +400,16 @@ WHERE vr.roleDefinitionId = '62e90394-69f5-4237-9190-012177145e10'
 
     #endregion
 
-    Add-ZtTestResultDetail -TestId '21835' `
-        -Status $passed `
-        -Result $testResultMarkdown
+    $params = @{
+        TestId = '21835'
+        Status = $passed
+        Result = $testResultMarkdown
+    }
+
+    # Only add CustomStatus when it's "Investigate" (more than 2 emergency access accounts)
+    if ($accountCount -gt 2) {
+        $params.CustomStatus = 'Investigate'
+    }
+
+    Add-ZtTestResultDetail @params
 }

--- a/src/powershell/tests/Test-Assessment.21835.ps1
+++ b/src/powershell/tests/Test-Assessment.21835.ps1
@@ -162,7 +162,9 @@ WHERE vr.roleDefinitionId = '62e90394-69f5-4237-9190-012177145e10'
             throw
         }
         $userGroupIds = @($userGroups | Select-Object -ExpandProperty id)
-        $userRoleIds = @($userRoles | Select-Object -ExpandProperty id)
+        # Precompute role template ids once per user so policy evaluation can do plain
+        # -contains checks instead of an O(n*m) Where-Object lookup per policy/role.
+        $userRoleTemplateIds = @($userRoles | Select-Object -ExpandProperty roleTemplateId)
 
         $policiesTargetingUser = 0
         $excludedFromAll = $true
@@ -193,10 +195,9 @@ WHERE vr.roleDefinitionId = '62e90394-69f5-4237-9190-012177145e10'
                     }
                 }
             }
-            if (-not $isIncluded -and $userRoleIds.Count -gt 0) {
-                foreach ($roleId in $userRoleIds) {
-                    $role = $userRoles | Where-Object { $_.id -eq $roleId }
-                    if ($includeRoles -contains $role.roleTemplateId) {
+            if (-not $isIncluded -and $userRoleTemplateIds.Count -gt 0) {
+                foreach ($templateId in $userRoleTemplateIds) {
+                    if ($includeRoles -contains $templateId) {
                         $isIncluded = $true
                         break
                     }
@@ -216,10 +217,9 @@ WHERE vr.roleDefinitionId = '62e90394-69f5-4237-9190-012177145e10'
                     }
                 }
             }
-            if (-not $isExcluded -and $userRoleIds.Count -gt 0) {
-                foreach ($roleId in $userRoleIds) {
-                    $role = $userRoles | Where-Object { $_.id -eq $roleId }
-                    if ($excludeRoles -contains $role.roleTemplateId) {
+            if (-not $isExcluded -and $userRoleTemplateIds.Count -gt 0) {
+                foreach ($templateId in $userRoleTemplateIds) {
+                    if ($excludeRoles -contains $templateId) {
                         $isExcluded = $true
                         break
                     }

--- a/src/powershell/tests/Test-Assessment.21835.ps1
+++ b/src/powershell/tests/Test-Assessment.21835.ps1
@@ -16,8 +16,8 @@
 
 function Test-Assessment-21835 {
     [ZtTest(
-    	Category = 'Application management',
-    	ImplementationCost = 'High',
+    	Category = 'Privileged access',
+    	ImplementationCost = 'Medium',
     	MinimumLicense = ('P1'),
     	Pillar = 'Identity',
     	RiskLevel = 'High',
@@ -28,7 +28,7 @@ function Test-Assessment-21835 {
     	UserImpact = 'Low'
     )]
     [CmdletBinding()]
-    param()
+    param($Database)
 
     Write-PSFMessage '🟦 Start' -Tag Test -Level VeryVerbose
     if ( -not (Get-ZtLicense EntraIDP1) ) {
@@ -46,16 +46,17 @@ function Test-Assessment-21835 {
     $sql = @"
 SELECT
     vr.principalId as id,
-    vr.principalDisplayName as displayName,
-    vr.userPrincipalName,
-    vr.privilegeType,
-    u.onPremisesSyncEnabled,
-    vr."@odata.type"
+    ANY_VALUE(vr.principalDisplayName) as displayName,
+    ANY_VALUE(vr.userPrincipalName)    as userPrincipalName,
+    ANY_VALUE(vr.privilegeType)        as privilegeType,
+    ANY_VALUE(u.onPremisesSyncEnabled) as onPremisesSyncEnabled,
+    ANY_VALUE(vr."@odata.type")        as "@odata.type"
 FROM vwRole vr
 LEFT JOIN "User" u ON vr.principalId = u.id
 WHERE vr.roleDefinitionId = '62e90394-69f5-4237-9190-012177145e10'
     AND vr.privilegeType = 'Permanent'
     AND vr."@odata.type" = '#microsoft.graph.user'
+GROUP BY vr.principalId
 "@
 
     $permanentGAUsers = @(Invoke-DatabaseQuery -Database $Database -Sql $sql)
@@ -90,23 +91,22 @@ WHERE vr.roleDefinitionId = '62e90394-69f5-4237-9190-012177145e10'
             $authMethods = $userAuthInfo.AuthenticationMethods
 
             if ($authMethods) {
-                # Check if user has at least one phishing-resistant auth method (FIDO2 or Certificate)
-                # Note: Passwords are always present and cannot be removed, but CA policies can enforce phishing-resistant MFA
-                # fix for issue #579 - The logic now checks if users have at least one phishing-resistant authentication method (FIDO2 or Certificate) instead of requiring only those methods.
-                # This resolves the issue where passwords auth method were causing all accounts to be filtered out.
-                $hasPhishingResistant = $false
-                $authMethodTypes = @()
+                # Spec: accounts must have ONLY phishing-resistant auth methods (FIDO2 / CBA).
+                # passwordAuthenticationMethod is always present and cannot be removed (see #579),
+                # so it is treated as ignorable. All remaining methods must be FIDO2 or CBA.
+                $phishingResistantTypes = @(
+                    '#microsoft.graph.fido2AuthenticationMethod'
+                    '#microsoft.graph.x509CertificateAuthenticationMethod'
+                )
+                $ignorableTypes = @(
+                    '#microsoft.graph.passwordAuthenticationMethod'
+                )
 
-                foreach ($method in $authMethods) {
-                    $methodType = $method.'@odata.type'
-                    $authMethodTypes += $methodType
+                $authMethodTypes = @($authMethods | ForEach-Object { $_.'@odata.type' })
+                $relevantTypes   = @($authMethodTypes | Where-Object { $_ -notin $ignorableTypes })
 
-                    # Check if this method is FIDO2 or Certificate
-                    if ($methodType -eq '#microsoft.graph.fido2AuthenticationMethod' -or
-                        $methodType -eq '#microsoft.graph.x509CertificateAuthenticationMethod') {
-                        $hasPhishingResistant = $true
-                    }
-                }
+                $hasPhishingResistant = $relevantTypes.Count -gt 0 -and
+                    -not ($relevantTypes | Where-Object { $_ -notin $phishingResistantTypes })
 
                 if ($hasPhishingResistant) {
                     # This is a candidate emergency account

--- a/src/powershell/tests/Test-Assessment.21835.ps1
+++ b/src/powershell/tests/Test-Assessment.21835.ps1
@@ -306,7 +306,7 @@ GROUP BY vr.principalId
     else {
         # Investigate: more than two candidate emergency access accounts identified.
         $passed = $false
-        $testResultMarkdown = "More than 2 emergency access accounts were found. This should be investigated to ensure account purpose and usage is limited to emergency or `"break glass`" scenarios.`n`n"
+        $testResultMarkdown = "Three or more emergency access accounts appear to be configured based on cloud-only state, registered phishing-resistant credentials and CA policy exclusions. Review these accounts to determine whether this volume is excessive for your organization.`n`n"
     }
 
     # Add summary information


### PR DESCRIPTION
- Align pass/fail thresholds with spec: <2 Fail, ==2 Pass, >2 Investigate (via -CustomStatus Investigate, matching Test-Assessment-21816).
- Update Pass/Fail messages to spec wording; Investigate message focuses on break-glass scope.
- Use splatting for Add-ZtTestResultDetail to conditionally include CustomStatus.
- Precompute $userRoleTemplateIds to drop the O(n·m) Where-Object role lookup per CA policy.
- Short-circuit per-user CA evaluation when there are zero enabled CA policies.
- ~~Use transitiveMemberOf/microsoft.graph.directoryRole so role-assignable group memberships are included.~~ --> to be taken care in separate issue #1250 
- Sort the permanent GA table on underlying booleans instead of emoji glyphs.
- Deduplicate authentication methods in the Emergency access accounts table.

Fixes #1194 