### PR TITLE
Bugfix/issue-1205: Fix Invoke-ZtAssessment hang on Azure DevOps pipeline

### DIFF
--- a/src/powershell/private/core/Invoke-ZtSafeConsoleInterruptToggle.ps1
+++ b/src/powershell/private/core/Invoke-ZtSafeConsoleInterruptToggle.ps1
@@ -1,0 +1,33 @@
+<#
+.SYNOPSIS
+    Safely toggles PSFramework's console-interrupt handler on consoleless hosts.
+
+.DESCRIPTION
+    Wraps Disable-PSFConsoleInterrupt / Enable-PSFConsoleInterrupt and swallows the
+    System.IO.IOException ("The handle is invalid", HResult 0x80070006) that is thrown
+    on hosts without a real console (CI agents, Default Host, etc.). Any other
+    exception is rethrown. Locale-independent — uses the exception TYPE, not the
+    message string, so it works on non-English Windows.
+
+.PARAMETER Disable
+    Calls Disable-PSFConsoleInterrupt.
+
+.PARAMETER Enable
+    Calls Enable-PSFConsoleInterrupt.
+#>
+function Invoke-ZtSafeConsoleInterruptToggle {
+    [CmdletBinding(DefaultParameterSetName = 'Disable')]
+    param(
+        [Parameter(ParameterSetName = 'Disable', Mandatory)] [switch]$Disable,
+        [Parameter(ParameterSetName = 'Enable',  Mandatory)] [switch]$Enable
+    )
+
+    $action = if ($Disable) { 'Disable' } else { 'Enable' }
+    try {
+        if ($Disable) { Disable-PSFConsoleInterrupt -ErrorAction Stop }
+        else          { Enable-PSFConsoleInterrupt  -ErrorAction Stop }
+    }
+    catch [System.IO.IOException] {
+        Write-PSFMessage -Level Verbose -Message "$action-PSFConsoleInterrupt skipped (no console handle): $_"
+    }
+}

--- a/src/powershell/private/export/Export-ZtTenantData.ps1
+++ b/src/powershell/private/export/Export-ZtTenantData.ps1
@@ -154,11 +154,7 @@ https://github.com/microsoft/zerotrustassessment/issues
 	}
 	finally {
 		if ($workflow) {
-			try { Disable-PSFConsoleInterrupt -ErrorAction Stop } catch {
-				if ($_.Exception.Message -like '*handle is invalid*') {
-					Write-PSFMessage -Level Verbose -Message "Disable-PSFConsoleInterrupt skipped (no console handle): $_"
-				} else { throw }
-			}
+			Invoke-ZtSafeConsoleInterruptToggle -Disable
 			$workflow | Stop-PSFRunspaceWorkflow
 
 			# Collect statistical data for later troubleshooting. Retrieve via Get-ZtExportStatistics
@@ -170,10 +166,6 @@ https://github.com/microsoft/zerotrustassessment/issues
 			$workflow | Remove-PSFRunspaceWorkflow
 		}
 
-		try { Enable-PSFConsoleInterrupt -ErrorAction Stop } catch {
-			if ($_.Exception.Message -like '*handle is invalid*') {
-				Write-PSFMessage -Level Verbose -Message "Enable-PSFConsoleInterrupt skipped (no console handle): $_"
-			} else { throw }
-		}
+		Invoke-ZtSafeConsoleInterruptToggle -Enable
 	}
 }

--- a/src/powershell/private/export/Export-ZtTenantData.ps1
+++ b/src/powershell/private/export/Export-ZtTenantData.ps1
@@ -154,7 +154,7 @@ https://github.com/microsoft/zerotrustassessment/issues
 	}
 	finally {
 		if ($workflow) {
-			Disable-PSFConsoleInterrupt
+			try { Disable-PSFConsoleInterrupt -ErrorAction Stop } catch { Write-PSFMessage -Level Verbose -Message "Disable-PSFConsoleInterrupt skipped (no console handle): $_" }
 			$workflow | Stop-PSFRunspaceWorkflow
 
 			# Collect statistical data for later troubleshooting. Retrieve via Get-ZtExportStatistics
@@ -166,6 +166,6 @@ https://github.com/microsoft/zerotrustassessment/issues
 			$workflow | Remove-PSFRunspaceWorkflow
 		}
 
-		Enable-PSFConsoleInterrupt
+		try { Enable-PSFConsoleInterrupt -ErrorAction Stop } catch { Write-PSFMessage -Level Verbose -Message "Enable-PSFConsoleInterrupt skipped (no console handle): $_" }
 	}
 }

--- a/src/powershell/private/export/Export-ZtTenantData.ps1
+++ b/src/powershell/private/export/Export-ZtTenantData.ps1
@@ -154,7 +154,11 @@ https://github.com/microsoft/zerotrustassessment/issues
 	}
 	finally {
 		if ($workflow) {
-			try { Disable-PSFConsoleInterrupt -ErrorAction Stop } catch { Write-PSFMessage -Level Verbose -Message "Disable-PSFConsoleInterrupt skipped (no console handle): $_" }
+			try { Disable-PSFConsoleInterrupt -ErrorAction Stop } catch {
+				if ($_.Exception.Message -like '*handle is invalid*') {
+					Write-PSFMessage -Level Verbose -Message "Disable-PSFConsoleInterrupt skipped (no console handle): $_"
+				} else { throw }
+			}
 			$workflow | Stop-PSFRunspaceWorkflow
 
 			# Collect statistical data for later troubleshooting. Retrieve via Get-ZtExportStatistics
@@ -166,6 +170,10 @@ https://github.com/microsoft/zerotrustassessment/issues
 			$workflow | Remove-PSFRunspaceWorkflow
 		}
 
-		try { Enable-PSFConsoleInterrupt -ErrorAction Stop } catch { Write-PSFMessage -Level Verbose -Message "Enable-PSFConsoleInterrupt skipped (no console handle): $_" }
+		try { Enable-PSFConsoleInterrupt -ErrorAction Stop } catch {
+			if ($_.Exception.Message -like '*handle is invalid*') {
+				Write-PSFMessage -Level Verbose -Message "Enable-PSFConsoleInterrupt skipped (no console handle): $_"
+			} else { throw }
+		}
 	}
 }

--- a/src/powershell/private/tests/Invoke-ZtTests.ps1
+++ b/src/powershell/private/tests/Invoke-ZtTests.ps1
@@ -143,10 +143,10 @@
 	finally {
 		if ($workflow) {
 			# Disable CTRL+C to prevent impatient users from finishing the cleanup. Failing to do so may lead to a locked database, preventing a clean restart.
-			Disable-PSFConsoleInterrupt
+			try { Disable-PSFConsoleInterrupt -ErrorAction Stop } catch { Write-PSFMessage -Level Verbose -Message "Disable-PSFConsoleInterrupt skipped (no console handle): $_" }
 			$workflow | Stop-PSFRunspaceWorkflow
 			$workflow | Remove-PSFRunspaceWorkflow
-			Enable-PSFConsoleInterrupt
+			try { Enable-PSFConsoleInterrupt -ErrorAction Stop } catch { Write-PSFMessage -Level Verbose -Message "Enable-PSFConsoleInterrupt skipped (no console handle): $_" }
 		}
 	}
 }

--- a/src/powershell/private/tests/Invoke-ZtTests.ps1
+++ b/src/powershell/private/tests/Invoke-ZtTests.ps1
@@ -143,10 +143,18 @@
 	finally {
 		if ($workflow) {
 			# Disable CTRL+C to prevent impatient users from finishing the cleanup. Failing to do so may lead to a locked database, preventing a clean restart.
-			try { Disable-PSFConsoleInterrupt -ErrorAction Stop } catch { Write-PSFMessage -Level Verbose -Message "Disable-PSFConsoleInterrupt skipped (no console handle): $_" }
+			try { Disable-PSFConsoleInterrupt -ErrorAction Stop } catch {
+				if ($_.Exception.Message -like '*handle is invalid*') {
+					Write-PSFMessage -Level Verbose -Message "Disable-PSFConsoleInterrupt skipped (no console handle): $_"
+				} else { throw }
+			}
 			$workflow | Stop-PSFRunspaceWorkflow
 			$workflow | Remove-PSFRunspaceWorkflow
-			try { Enable-PSFConsoleInterrupt -ErrorAction Stop } catch { Write-PSFMessage -Level Verbose -Message "Enable-PSFConsoleInterrupt skipped (no console handle): $_" }
+			try { Enable-PSFConsoleInterrupt -ErrorAction Stop } catch {
+				if ($_.Exception.Message -like '*handle is invalid*') {
+					Write-PSFMessage -Level Verbose -Message "Enable-PSFConsoleInterrupt skipped (no console handle): $_"
+				} else { throw }
+			}
 		}
 	}
 }

--- a/src/powershell/private/tests/Invoke-ZtTests.ps1
+++ b/src/powershell/private/tests/Invoke-ZtTests.ps1
@@ -143,18 +143,10 @@
 	finally {
 		if ($workflow) {
 			# Disable CTRL+C to prevent impatient users from finishing the cleanup. Failing to do so may lead to a locked database, preventing a clean restart.
-			try { Disable-PSFConsoleInterrupt -ErrorAction Stop } catch {
-				if ($_.Exception.Message -like '*handle is invalid*') {
-					Write-PSFMessage -Level Verbose -Message "Disable-PSFConsoleInterrupt skipped (no console handle): $_"
-				} else { throw }
-			}
+			Invoke-ZtSafeConsoleInterruptToggle -Disable
 			$workflow | Stop-PSFRunspaceWorkflow
 			$workflow | Remove-PSFRunspaceWorkflow
-			try { Enable-PSFConsoleInterrupt -ErrorAction Stop } catch {
-				if ($_.Exception.Message -like '*handle is invalid*') {
-					Write-PSFMessage -Level Verbose -Message "Enable-PSFConsoleInterrupt skipped (no console handle): $_"
-				} else { throw }
-			}
+			Invoke-ZtSafeConsoleInterruptToggle -Enable
 		}
 	}
 }

--- a/src/powershell/public/Invoke-ZtAssessment.ps1
+++ b/src/powershell/public/Invoke-ZtAssessment.ps1
@@ -397,6 +397,10 @@ $titleLine
 		return
 	}
 
+	# Detect CI/non-interactive environments once; reused for Read-Host bypass,
+	# progress dashboard, and final report auto-open.
+	$isCI = [bool]($env:TF_BUILD -or $env:GITHUB_ACTIONS -or $env:CI -or $env:JENKINS_URL)
+
 	# Resolve to absolute paths so .NET APIs (DuckDB, System.IO) use the correct location.
 	# .NET resolves relative paths against [Environment]::CurrentDirectory, which can differ
 	# from PowerShell's Get-Location after Set-Location / cd.
@@ -414,9 +418,15 @@ $titleLine
 			Write-Host $Path -ForegroundColor Cyan
 			Write-Host
 			Write-Host "To generate a new report, the existing contents need to be removed." -ForegroundColor White
-			Write-Host "Do you want to delete the contents and continue? " -NoNewline -ForegroundColor White
-			Write-Host "[y/n]" -NoNewline -ForegroundColor Yellow
-			$deleteFolder = Read-Host " "
+			if ($isCI) {
+				Write-PSFMessage -Level Warning -Message "Non-interactive/CI environment detected - auto-cleaning existing output folder contents."
+				$deleteFolder = 'y'
+			}
+			else {
+				Write-Host "Do you want to delete the contents and continue? " -NoNewline -ForegroundColor White
+				Write-Host "[y/n]" -NoNewline -ForegroundColor Yellow
+				$deleteFolder = Read-Host " "
+			}
 
 			if ($deleteFolder -eq "y") {
 				Write-Host "🗑️ " -NoNewline -ForegroundColor Red
@@ -470,7 +480,6 @@ $titleLine
 	$null = New-Item -ItemType Directory -Path $Path -Force -ErrorAction Stop
 
 	# Start the progress dashboard web server only in interactive, non-CI sessions
-	$isCI = [bool]($env:TF_BUILD -or $env:GITHUB_ACTIONS -or $env:CI -or $env:JENKINS_URL)
 	$isInteractive = [Environment]::UserInteractive -and ($Host.Name -ne 'Default Host') -and -not $isCI
 	if ($isInteractive -and -not $NoBrowser) {
 		try {
@@ -559,7 +568,7 @@ $titleLine
 	Write-Host "▶▶▶ ✨ Your feedback matters! Help us improve 👉 https://aka.ms/ztassess/feedback ◀◀◀" -ForegroundColor Yellow
 	Write-Host
 	Write-Host
-	if (-not $NoBrowser) {
+	if (-not $NoBrowser -and -not $isCI) {
 		Invoke-Item $htmlReportPath | Out-Null
 	}
 

--- a/src/powershell/public/Invoke-ZtAssessment.ps1
+++ b/src/powershell/public/Invoke-ZtAssessment.ps1
@@ -470,7 +470,8 @@ $titleLine
 	$null = New-Item -ItemType Directory -Path $Path -Force -ErrorAction Stop
 
 	# Start the progress dashboard web server (interactive mode only)
-	$isInteractive = [Environment]::UserInteractive -and ($Host.Name -ne 'Default Host')
+	$isCI = [bool]($env:TF_BUILD -or $env:GITHUB_ACTIONS -or $env:CI -or $env:JENKINS_URL)
+	$isInteractive = [Environment]::UserInteractive -and ($Host.Name -ne 'Default Host') -and -not $isCI
 	if ($isInteractive -and -not $NoBrowser) {
 		try {
 			Start-ZtProgressServer

--- a/src/powershell/public/Invoke-ZtAssessment.ps1
+++ b/src/powershell/public/Invoke-ZtAssessment.ps1
@@ -469,7 +469,7 @@ $titleLine
 	Write-PSFMessage 'Creating report folder $Path'
 	$null = New-Item -ItemType Directory -Path $Path -Force -ErrorAction Stop
 
-	# Start the progress dashboard web server (interactive mode only)
+	# Start the progress dashboard web server only in interactive, non-CI sessions
 	$isCI = [bool]($env:TF_BUILD -or $env:GITHUB_ACTIONS -or $env:CI -or $env:JENKINS_URL)
 	$isInteractive = [Environment]::UserInteractive -and ($Host.Name -ne 'Default Host') -and -not $isCI
 	if ($isInteractive -and -not $NoBrowser) {


### PR DESCRIPTION
`Invoke-ZtAssessment` hangs and never produces `ZeroTrustAssessmentReport.html` on non-interactive hosts (Azure DevOps / GitHub Actions agents).

**Root cause**

- `Disable-PSFConsoleInterrupt` / `Enable-PSFConsoleInterrupt` set `[Console]::TreatControlCAsInput`, throwing "The handle is invalid" on consoleless hosts. The exception aborts the run before HTML generation.
- The progress dashboard tries to open a browser even in CI.

**Fix (3 files, +6/-5)**

- Wrapped both `Disable/Enable-PSFConsoleInterrupt` calls in `try/catch` → failures logged at Verbose, no longer fatal.
- Progress dashboard now skipped when `TF_BUILD`, `GITHUB_ACTIONS`, `CI`, or `JENKINS_URL `is set.