### PR TITLE
Add AI & SecOps pillar support to run the tests

### DIFF
--- a/src/powershell/private/export/Export-Database.ps1
+++ b/src/powershell/private/export/Export-Database.ps1
@@ -28,7 +28,7 @@ function Export-Database {
 		[PSFDirectorySingle]$ExportPath,
 
 		# The Zero Trust pillar to assess. Defaults to All.
-		[ValidateSet('All', 'Identity', 'Devices', 'Network', 'Data', 'Infrastructure')]
+		[ValidateSet('All', 'Identity', 'Devices', 'Network', 'Data', 'Infrastructure', 'SecOps', 'AI')]
 		[string]
 		$Pillar = 'All',
 

--- a/src/powershell/private/export/Export-ZtTenantData.ps1
+++ b/src/powershell/private/export/Export-ZtTenantData.ps1
@@ -46,7 +46,7 @@ function Export-ZtTenantData {
 		[int]
 		$MaximumSignInLogQueryTime,
 
-		[ValidateSet('All', 'Identity', 'Devices', 'Network', 'Data', 'Infrastructure')]
+		[ValidateSet('All', 'Identity', 'Devices', 'Network', 'Data', 'Infrastructure', 'SecOps', 'AI')]
 		[string]
 		$Pillar = 'All',
 

--- a/src/powershell/private/tenantinfo/Invoke-ZtTenantInfo.ps1
+++ b/src/powershell/private/tenantinfo/Invoke-ZtTenantInfo.ps1
@@ -10,7 +10,7 @@ function Invoke-ZtTenantInfo {
         $Database,
 
         # The Zero Trust pillar to assess. Defaults to All.
-        [ValidateSet('All', 'Identity', 'Devices', 'Network', 'Data', 'Infrastructure')]
+        [ValidateSet('All', 'Identity', 'Devices', 'Network', 'Data', 'Infrastructure', 'SecOps', 'AI')]
         [string]
         $Pillar = 'All'
     )

--- a/src/powershell/private/tests/Invoke-ZtTests.ps1
+++ b/src/powershell/private/tests/Invoke-ZtTests.ps1
@@ -115,8 +115,10 @@
 	$testsToRun = $testsToRun.Where{ $_.TestId -notin $skippedTestsForService.TestId }
 
 	# Separate Sync Tests (Compliance/ExchangeOnline/SharePointOnline) from Parallel Tests (because of DLL order to manage in runspaces & remoting into WPS)
-	# AI pillar tests also run sync as they depend on SecurityCompliance remoting which is only available on the main thread.
-	[int[]]$syncTestIds   = $testsToRun.Where{ $_.Pillar -in @('Data', 'AI') }.TestId
+	# Tests that depend on SecurityCompliance remoting must run on the main thread regardless of pillar.
+	[int[]]$syncTestIds   = $testsToRun.Where{
+		$_.Pillar -eq 'Data' -or $_.Service -contains 'SecurityCompliance'
+	}.TestId
 	$syncTests     = $testsToRun.Where{ $_.TestId -in $syncTestIds }
 	$parallelTests = $testsToRun.Where{ $_.TestId -notin $syncTestIds }
 

--- a/src/powershell/private/tests/Invoke-ZtTests.ps1
+++ b/src/powershell/private/tests/Invoke-ZtTests.ps1
@@ -53,7 +53,7 @@
 		[string[]]
 		$Tests,
 
-		[ValidateSet('All', 'Identity', 'Devices', 'Network', 'Data', 'Infrastructure')]
+		[ValidateSet('All', 'Identity', 'Devices', 'Network', 'Data', 'Infrastructure', 'SecOps', 'AI')]
 		[string]
 		$Pillar = 'All',
 

--- a/src/powershell/public/Invoke-ZtAssessment.ps1
+++ b/src/powershell/public/Invoke-ZtAssessment.ps1
@@ -260,7 +260,7 @@ $titleLine
 	}
 
 	# Validate preview pillar requirements
-	$previewPillars = @('Infrastructure')
+	$previewPillars = @('Infrastructure', 'AI')
 	if ($Pillar -in $previewPillars -and -not $Preview) {
 		Write-Host
 		Write-Host "❌ " -NoNewline -ForegroundColor Red

--- a/src/powershell/public/Invoke-ZtAssessment.ps1
+++ b/src/powershell/public/Invoke-ZtAssessment.ps1
@@ -63,6 +63,12 @@ proceed even when PowerShell reports a non-Full language mode (e.g. in WDAC-mana
 where the module's signing certificate is trusted by policy).
 WARNING: Some tests may fail or return incomplete results if CLM restrictions are truly in effect.
 
+.PARAMETER Pillar
+The Zero Trust pillar to assess. Valid values are 'All', 'Identity', 'Devices', 'Network', 'Data', 'Infrastructure', 'SecOps', or 'AI'. Defaults to 'All' which runs all tests. Infrastructure, SecOps, and AI pillars require the -Preview switch.
+
+.PARAMETER Preview
+When specified, enables running preview pillars (Infrastructure, SecOps, AI) that are not publically available yet.
+
 .EXAMPLE
 Invoke-ZtAssessment
 
@@ -72,9 +78,6 @@ Run the Zero Trust Assessment against the signed in tenant and generates a repor
 Invoke-ZtAssessment -Path "C:\Reports\ZT" -Days 7 -ShowLog
 
 Run the Zero Trust Assessment with a custom output path, querying 7 days of logs, and showing detailed logging.
-
-.PARAMETER Pillar
-The Zero Trust pillar to assess. Valid values are 'All', 'Identity', 'Devices', 'Network', or 'Data'. Defaults to 'All' which runs all tests.
 
 .EXAMPLE
 Invoke-ZtAssessment -ConfigurationFile "C:\Config\zt-config.json"

--- a/src/powershell/public/Invoke-ZtAssessment.ps1
+++ b/src/powershell/public/Invoke-ZtAssessment.ps1
@@ -260,7 +260,7 @@ $titleLine
 	}
 
 	# Validate preview pillar requirements
-	$previewPillars = @('Infrastructure', 'AI')
+	$previewPillars = @('Infrastructure', 'SecOps', 'AI')
 	if ($Pillar -in $previewPillars -and -not $Preview) {
 		Write-Host
 		Write-Host "❌ " -NoNewline -ForegroundColor Red

--- a/src/powershell/public/Invoke-ZtAssessment.ps1
+++ b/src/powershell/public/Invoke-ZtAssessment.ps1
@@ -67,7 +67,7 @@ WARNING: Some tests may fail or return incomplete results if CLM restrictions ar
 The Zero Trust pillar to assess. Valid values are 'All', 'Identity', 'Devices', 'Network', 'Data', 'Infrastructure', 'SecOps', or 'AI'. Defaults to 'All' which runs all tests. Infrastructure, SecOps, and AI pillars require the -Preview switch.
 
 .PARAMETER Preview
-When specified, enables running preview pillars (Infrastructure, SecOps, AI) that are not publically available yet.
+When specified, enables running preview pillars (Infrastructure, SecOps, AI) that are not publicly available yet.
 
 .EXAMPLE
 Invoke-ZtAssessment


### PR DESCRIPTION
### AI & SecOps pillar support
Added `'SecOps'` and `'AI'` to the `[ValidateSet]` for the `$Pillar` parameter in the four private functions, this will help in running tests from those pillars.

| File | Change |
|---|---|
| `private/tests/Invoke-ZtTests.ps1` | Added `'SecOps', 'AI'` |
| `private/export/Export-Database.ps1` | Added `'SecOps', 'AI'` |
| `private/export/Export-ZtTenantData.ps1` | Added `'SecOps', 'AI'` |
| `private/tenantinfo/Invoke-ZtTenantInfo.ps1` | Added `'SecOps', 'AI'` |
| `public/Invoke-ZtAssessment.ps1` | Added `'SecOps', 'AI'` in preview pillars array |

## Testing

```powershell
Invoke-ZtAssessment -Pillar AI -Preview