### PR TITLE
Add AI pillar support to DB export pipeline

### DIFF
--- a/src/powershell/assets/export-tenant.config.psd1
+++ b/src/powershell/assets/export-tenant.config.psd1
@@ -75,10 +75,10 @@ Note: Avoid using the same names as used for the "General Parameters" section of
 	Name = 'Application'
 	Uri = 'beta/applications'
 	QueryString = '$top=999'
-	RelatedPropertyNames = @()
+	RelatedPropertyNames = @('sponsors')
 	Type = 'Default' # PrivilegedGroup
 
-	Pillar = @('Identity', 'Network')
+	Pillar = @('Identity', 'Network', 'AI')
 	# Environment = $null # 'Global'
 	# IncludePlan = @('Free') # P2, Governance
 	# ExcludePlan = @('Free') # Free
@@ -87,11 +87,11 @@ Note: Avoid using the same names as used for the "General Parameters" section of
 @{
 	Name = 'ServicePrincipal'
 	Uri = 'beta/servicePrincipals'
-	QueryString = '$expand=appRoleAssignments&$top=999&$select=id,deletedDateTime,accountEnabled,alternativeNames,createdByAppId,createdDateTime,deviceManagementAppType,appDescription,appDisplayName,appId,applicationTemplateId,appOwnerOrganizationId,appRoleAssignmentRequired,assignmentRequiredForPrincipalTypes,description,disabledByMicrosoftStatus,displayName,errorUrl,homepage,isAuthorizationServiceEnabled,isDisabled,isManagementRestricted,loginUrl,logoutUrl,notes,notificationEmailAddresses,preferredSingleSignOnMode,preferredTokenSigningKeyEndDateTime,preferredTokenSigningKeyThumbprint,publisherName,replyUrls,samlMetadataUrl,samlSLOBindingType,servicePrincipalNames,servicePrincipalType,signInAudience,tags,tokenEncryptionKeyId,certification,samlSingleSignOnSettings,addIns,api,appRoles,info,keyCredentials,publishedPermissionScopes,passwordCredentials,resourceSpecificApplicationPermissions,verifiedPublisher,customSecurityAttributes'
-	RelatedPropertyNames = @('oauth2PermissionGrants', 'owners')
+	QueryString = '$expand=appRoleAssignments&$top=999&$select=id,deletedDateTime,accountEnabled,alternativeNames,createdByAppId,createdDateTime,deviceManagementAppType,appDescription,appDisplayName,appId,applicationTemplateId,appOwnerOrganizationId,appRoleAssignmentRequired,assignmentRequiredForPrincipalTypes,description,disabledByMicrosoftStatus,displayName,errorUrl,homepage,isAuthorizationServiceEnabled,isDisabled,isManagementRestricted,loginUrl,logoutUrl,notes,notificationEmailAddresses,preferredSingleSignOnMode,preferredTokenSigningKeyEndDateTime,preferredTokenSigningKeyThumbprint,publisherName,replyUrls,samlMetadataUrl,samlSLOBindingType,servicePrincipalNames,servicePrincipalType,signInAudience,tags,tokenEncryptionKeyId,certification,samlSingleSignOnSettings,addIns,api,appRoles,info,keyCredentials,publishedPermissionScopes,passwordCredentials,resourceSpecificApplicationPermissions,verifiedPublisher,customSecurityAttributes,agentIdentityBlueprintId'
+	RelatedPropertyNames = @('oauth2PermissionGrants', 'owners', 'sponsors')
 	Type = 'Default' # PrivilegedGroup
 
-	Pillar = @('Identity', 'Network')
+	Pillar = @('Identity', 'Network', 'AI')
 	# Environment = $null # 'Global'
 	# IncludePlan = @('Free') # P2, Governance
 	# ExcludePlan = @('Free') # Free
@@ -104,7 +104,7 @@ Note: Avoid using the same names as used for the "General Parameters" section of
 	RelatedPropertyNames = @()
 	Type = 'Default' # PrivilegedGroup
 
-	Pillar = 'Identity'
+	Pillar = @('Identity', 'AI')
 	# Environment = 'Global' # 'Global'
 	# IncludePlan = @('P2', 'Governance') # P2, Governance
 	ExcludePlan = @('Free') # Free
@@ -156,7 +156,7 @@ Note: Avoid using the same names as used for the "General Parameters" section of
 	RelatedPropertyNames = @()
 	Type = 'Default' # PrivilegedGroup
 
-	Pillar = @('Identity', 'Network')
+	Pillar = @('Identity', 'Network', 'AI')
 	# Environment = 'Global' # 'Global'
 	# IncludePlan = @('Free') # P2, Governance
 	# ExcludePlan = @('Free') # Free
@@ -169,7 +169,7 @@ Note: Avoid using the same names as used for the "General Parameters" section of
 	RelatedPropertyNames = @()
 	Type = 'Default' # PrivilegedGroup
 
-	Pillar = @('Identity', 'Network')
+	Pillar = @('Identity', 'Network', 'AI')
 	# Environment = 'Global' # 'Global'
 	# IncludePlan = @('Free') # P2, Governance
 	# ExcludePlan = @('Free') # Free
@@ -182,7 +182,7 @@ Note: Avoid using the same names as used for the "General Parameters" section of
 	RelatedPropertyNames = @()
 	Type = 'Default' # PrivilegedGroup
 
-	Pillar = @('Identity', 'Network')
+	Pillar = @('Identity', 'Network', 'AI')
 	# Environment = 'Global' # 'Global'
 	IncludePlan = @('P2', 'Governance') # P2, Governance
 	# ExcludePlan = @('Free') # Free
@@ -195,7 +195,7 @@ Note: Avoid using the same names as used for the "General Parameters" section of
 	RelatedPropertyNames = @()
 	Type = 'Default' # PrivilegedGroup
 
-	Pillar = @('Identity', 'Network')
+	Pillar = @('Identity', 'Network', 'AI')
 	# Environment = 'Global' # 'Global'
 	IncludePlan = @('P2', 'Governance') # P2, Governance
 	# ExcludePlan = @('Free') # Free
@@ -237,7 +237,7 @@ They will block their worker until their dependency is completed and could risk 
 	InputName = 'RoleAssignment'
 	Type = 'PrivilegedGroup' # PrivilegedGroup
 
-	Pillar = @('Identity', 'Network')
+	Pillar = @('Identity', 'Network', 'AI')
 	# Environment = 'Global' # 'Global'
 	# IncludePlan = @('P2', 'Governance') # P2, Governance
 	# ExcludePlan = @('Free') # Free
@@ -249,7 +249,7 @@ They will block their worker until their dependency is completed and could risk 
 	InputName = 'RoleEligibilityScheduleInstance'
 	Type = 'PrivilegedGroup' # PrivilegedGroup
 
-	Pillar = @('Identity', 'Network')
+	Pillar = @('Identity', 'Network', 'AI')
 	# Environment = 'Global' # 'Global'
 	IncludePlan = @('P2', 'Governance') # P2, Governance
 	# ExcludePlan = @('Free') # Free
@@ -262,7 +262,7 @@ They will block their worker until their dependency is completed and could risk 
 	InputName = 'RoleAssignmentScheduleInstance'
 	Type = 'PrivilegedGroup' # PrivilegedGroup
 
-	Pillar = @('Identity', 'Network')
+	Pillar = @('Identity', 'Network', 'AI')
 	# Environment = 'Global' # 'Global'
 	IncludePlan = @('P2', 'Governance') # P2, Governance
 	# ExcludePlan = @('Free') # Free

--- a/src/powershell/private/export/Export-Database.ps1
+++ b/src/powershell/private/export/Export-Database.ps1
@@ -196,8 +196,6 @@ as
 		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleEligibilityScheduleInstanceGroup' -LogsPath $LogsPath
 		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleManagementPolicyAssignment' -LogsPath $LogsPath
 		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'UserRegistrationDetails' -LogsPath $LogsPath
-
-		New-ViewRole -Database $database
 	}
 
 	if ($Pillar -in ('All', 'Devices')) {
@@ -216,8 +214,6 @@ as
 		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleAssignmentScheduleInstanceGroup' -LogsPath $LogsPath
 		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleEligibilityScheduleInstance' -LogsPath $LogsPath
 		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleEligibilityScheduleInstanceGroup' -LogsPath $LogsPath
-
-		New-ViewRole -Database $database
 	}
 
 	if ($Pillar -in ('All', 'AI')) {
@@ -231,7 +227,9 @@ as
 		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleAssignmentScheduleInstanceGroup' -LogsPath $LogsPath
 		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleEligibilityScheduleInstance' -LogsPath $LogsPath
 		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleEligibilityScheduleInstanceGroup' -LogsPath $LogsPath
+	}
 
+	if ($Pillar -in ('All', 'Identity', 'Network', 'AI')) {
 		New-ViewRole -Database $database
 	}
 

--- a/src/powershell/private/export/Export-Database.ps1
+++ b/src/powershell/private/export/Export-Database.ps1
@@ -220,5 +220,20 @@ as
 		New-ViewRole -Database $database
 	}
 
+	if ($Pillar -in ('All', 'AI')) {
+		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'Application' -LogsPath $LogsPath
+		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'ServicePrincipal' -LogsPath $LogsPath
+		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'SignIn' -LogsPath $LogsPath
+		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleDefinition' -LogsPath $LogsPath
+		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleAssignment' -LogsPath $LogsPath
+		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleAssignmentGroup' -LogsPath $LogsPath
+		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleAssignmentScheduleInstance' -LogsPath $LogsPath
+		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleAssignmentScheduleInstanceGroup' -LogsPath $LogsPath
+		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleEligibilityScheduleInstance' -LogsPath $LogsPath
+		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleEligibilityScheduleInstanceGroup' -LogsPath $LogsPath
+
+		New-ViewRole -Database $database
+	}
+
 	$database
 }


### PR DESCRIPTION
The AI pillar assessment checks require additional properties to be included in the Graph API exports, and the AI pillar needs to be registered across the export configuration and DB loading pipeline so that `-Pillar AI` works end-to-end.

### Changes

**Export configuration (`export-tenant.config.psd1`)**
- `Application`: added `sponsors` to `RelatedPropertyNames`; added `AI` to `Pillar`
- `ServicePrincipal`: added `agentIdentityBlueprintId` to `$select`; added `sponsors` to `RelatedPropertyNames`; added `AI` to `Pillar`
- `SignIn`, `RoleDefinition`, `RoleAssignment`, `RoleAssignmentGroup`, `RoleEligibilityScheduleInstance`, `RoleEligibilityScheduleInstanceGroup`: added `AI` to `Pillar`

**DB loading (`Export-Database.ps1`)**
- Added an `AI` pillar block that loads the required tables into DuckDB when `-Pillar AI` is passed

### Tables that can be loaded for the AI pillar specs

| Spec | Tables |
|---|---|
| 61006 | `RoleDefinition`, `RoleAssignment`, `RoleAssignmentGroup`, `RoleEligibilityScheduleInstance`, `RoleEligibilityScheduleInstanceGroup` |
| 61008  | `ServicePrincipal` |
| 61011 | `Application`, `ServicePrincipal`, `SignIn` |
| 61013 | `Application`, `ServicePrincipal` |
| 61014 | `ServicePrincipal` |