### PR TITLE
Add Application.Read.All permission to readme

### DIFF
--- a/src/powershell/doc/readme.md
+++ b/src/powershell/doc/readme.md
@@ -56,6 +56,7 @@ The consent prompt is only displayed if the Graph PowerShell app does not alread
 
 > **Note:** To read Custom Security Attributes on service principals, the account running the assessment must also be assigned the **Attribute Assignment Reader** (or **Attribute Assignment Administrator**) Entra ID role. Without this role, Custom Security Attribute values will be returned as null.
 
+- Application.Read.All
 - AuditLog.Read.All
 - CrossTenantInformation.ReadBasic.All
 - CustomSecAttributeAssignment.Read.All


### PR DESCRIPTION
#1221 

`Application.Read.All` needs to be included as there are 3 tests dependent on it: 61008, 61011, and 61014