### PR TITLE
Refactor export logic to conditionally import tables

### DIFF
--- a/src/powershell/assets/export-model/AgentIdentity-model.json
+++ b/src/powershell/assets/export-model/AgentIdentity-model.json
@@ -1,0 +1,24 @@
+{
+  "@odata.context": "https://graph.microsoft.com/beta/$metadata#servicePrincipals/microsoft.graph.agentIdentity(sponsors(id))",
+  "value": [
+    {
+      "isZtModelRow": true,
+      "id": null,
+      "agentIdentityBlueprintId": null,
+      "agentAppId": null,
+      "displayName": null,
+      "accountEnabled": false,
+      "servicePrincipalType": null,
+      "disabledByMicrosoftStatus": null,
+      "createdByAppId": null,
+      "createdDateTime": "1900-01-01T00:00:00Z",
+      "tags": [],
+      "sponsors": [
+        {
+          "id": null,
+          "@odata.type": null
+        }
+      ]
+    }
+  ]
+}

--- a/src/powershell/assets/export-model/AgentIdentityBlueprint-model.json
+++ b/src/powershell/assets/export-model/AgentIdentityBlueprint-model.json
@@ -1,0 +1,104 @@
+{
+  "@odata.context": "https://graph.microsoft.com/beta/$metadata#applications/microsoft.graph.agentIdentityBlueprint(sponsors(id))",
+  "value": [
+    {
+      "isZtModelRow": true,
+      "disabledByMicrosoftStatus": null,
+      "publisherDomain": null,
+      "keyCredentials": [],
+      "verifiedPublisher": {
+        "displayName": null,
+        "verifiedPublisherId": null,
+        "addedDateTime": "1900-01-01T00:00:00Z"
+      },
+      "orgRestrictions": [],
+      "isDeviceOnlyAuthSupported": null,
+      "createdDateTime": "1900-01-01T00:00:00Z",
+      "appId": null,
+      "migrationStatus": null,
+      "createdByAppId": null,
+      "displayName": null,
+      "optionalClaims": null,
+      "addIns": [],
+      "owners": [],
+      "sponsors": [
+        {
+          "id": null,
+          "@odata.type": null
+        }
+      ],
+      "parentalControlSettings": {
+        "legalAgeGroupRule": null,
+        "countriesBlockedForMinors": []
+      },
+      "api": {
+        "oauth2PermissionScopes": [],
+        "requestedAccessTokenVersion": 2,
+        "knownClientApplications": [],
+        "tokenEncryptionSetting": {
+          "automatedTokenVersion": {
+            "available": [],
+            "current": null
+          },
+          "scheme": null,
+          "audience": null
+        },
+        "acceptMappedClaims": null,
+        "preAuthorizedApplications": []
+      },
+      "appRoles": [],
+      "isDisabled": null,
+      "info": {
+        "logoUrl": null,
+        "privacyStatementUrl": null,
+        "marketingUrl": null,
+        "supportUrl": null,
+        "termsOfServiceUrl": null
+      },
+      "oauth2RequirePostResponse": false,
+      "isAuthorizationServiceEnabled": false,
+      "requiredResourceAccess": [],
+      "requestSignatureVerification": null,
+      "servicePrincipalLockConfiguration": null,
+      "uniqueName": null,
+      "defaultRedirectUri": null,
+      "groupMembershipClaims": null,
+      "tokenEncryptionKeyId": null,
+      "deletedDateTime": "1900-01-01T00:00:00Z",
+      "web": {
+        "redirectUris": [],
+        "redirectUriSettings": [],
+        "logoutUrl": null,
+        "enabledResponseModes": null,
+        "implicitGrantSettings": {
+          "enableIdTokenIssuance": false,
+          "enableAccessTokenIssuance": false
+        },
+        "homePageUrl": null
+      },
+      "isManagementRestricted": null,
+      "windows": null,
+      "appCapabilities": [],
+      "certification": null,
+      "samlMetadataUrl": null,
+      "nativeAuthenticationApisEnabled": null,
+      "identifierUris": [],
+      "tags": [],
+      "applicationTemplateId": null,
+      "serviceManagementReference": null,
+      "managerApplications": [],
+      "publicClient": {
+        "redirectUris": []
+      },
+      "description": null,
+      "id": null,
+      "passwordCredentials": [],
+      "isFallbackPublicClient": null,
+      "notes": null,
+      "spa": {
+        "redirectUris": []
+      },
+      "signInAudience": null
+    }
+  ]
+}

--- a/src/powershell/assets/export-model/AgentIdentityBlueprint-model.json
+++ b/src/powershell/assets/export-model/AgentIdentityBlueprint-model.json
@@ -11,15 +11,11 @@
         "verifiedPublisherId": null,
         "addedDateTime": "1900-01-01T00:00:00Z"
       },
-      "orgRestrictions": [],
-      "isDeviceOnlyAuthSupported": null,
       "createdDateTime": "1900-01-01T00:00:00Z",
       "appId": null,
-      "migrationStatus": null,
       "createdByAppId": null,
       "displayName": null,
       "optionalClaims": null,
-      "addIns": [],
       "owners": [],
       "sponsors": [
         {
@@ -27,10 +23,6 @@
           "@odata.type": null
         }
       ],
-      "parentalControlSettings": {
-        "legalAgeGroupRule": null,
-        "countriesBlockedForMinors": []
-      },
       "api": {
         "oauth2PermissionScopes": [],
         "requestedAccessTokenVersion": 2,
@@ -47,7 +39,6 @@
         "preAuthorizedApplications": []
       },
       "appRoles": [],
-      "isDisabled": null,
       "info": {
         "logoUrl": null,
         "privacyStatementUrl": null,
@@ -55,16 +46,10 @@
         "supportUrl": null,
         "termsOfServiceUrl": null
       },
-      "oauth2RequirePostResponse": false,
-      "isAuthorizationServiceEnabled": false,
       "requiredResourceAccess": [],
-      "requestSignatureVerification": null,
-      "servicePrincipalLockConfiguration": null,
       "uniqueName": null,
-      "defaultRedirectUri": null,
       "groupMembershipClaims": null,
       "tokenEncryptionKeyId": null,
-      "deletedDateTime": "1900-01-01T00:00:00Z",
       "web": {
         "redirectUris": [],
         "redirectUriSettings": [],
@@ -76,28 +61,14 @@
         },
         "homePageUrl": null
       },
-      "isManagementRestricted": null,
-      "windows": null,
-      "appCapabilities": [],
       "certification": null,
-      "samlMetadataUrl": null,
-      "nativeAuthenticationApisEnabled": null,
       "identifierUris": [],
       "tags": [],
-      "applicationTemplateId": null,
       "serviceManagementReference": null,
       "managerApplications": [],
-      "publicClient": {
-        "redirectUris": []
-      },
       "description": null,
       "id": null,
       "passwordCredentials": [],
-      "isFallbackPublicClient": null,
-      "notes": null,
-      "spa": {
-        "redirectUris": []
-      },
       "signInAudience": null
     }
   ]

--- a/src/powershell/assets/export-model/AgentIdentityBlueprintPrincipal-model.json
+++ b/src/powershell/assets/export-model/AgentIdentityBlueprintPrincipal-model.json
@@ -1,0 +1,67 @@
+{
+  "@odata.context": "https://graph.microsoft.com/beta/$metadata#servicePrincipals/microsoft.graph.agentIdentityBlueprintPrincipal(sponsors(id))",
+  "value": [
+    {
+      "isZtModelRow": true,
+      "id": null,
+      "appId": null,
+      "displayName": null,
+      "appDisplayName": null,
+      "appDescription": null,
+      "publisherName": null,
+      "accountEnabled": false,
+      "appRoleAssignmentRequired": false,
+      "servicePrincipalType": null,
+      "signInAudience": null,
+      "disabledByMicrosoftStatus": null,
+      "createdByAppId": null,
+      "appOwnerOrganizationId": null,
+      "tags": [],
+      "servicePrincipalNames": [],
+      "publishedPermissionScopes": [
+        {
+          "id": null,
+          "value": null,
+          "isEnabled": false,
+          "adminConsentDisplayName": null,
+          "adminConsentDescription": null,
+          "userConsentDisplayName": null,
+          "isPrivate": false,
+          "userConsentDescription": null,
+          "type": null
+        }
+      ],
+      "appRoles": [
+        {
+          "id": null,
+          "value": null,
+          "isEnabled": false,
+          "isPreAuthorizationRequired": false,
+          "origin": null,
+          "description": null,
+          "allowedMemberTypes": [],
+          "isPrivate": false,
+          "displayName": null
+        }
+      ],
+      "info": {
+        "privacyStatementUrl": null,
+        "marketingUrl": null,
+        "logoUrl": null,
+        "supportUrl": null,
+        "termsOfServiceUrl": null
+      },
+      "verifiedPublisher": {
+        "addedDateTime": "1900-01-01T00:00:00Z",
+        "displayName": null,
+        "verifiedPublisherId": null
+      },
+      "sponsors": [
+        {
+          "id": null,
+          "@odata.type": null
+        }
+      ]
+    }
+  ]
+}

--- a/src/powershell/assets/export-tenant.config.psd1
+++ b/src/powershell/assets/export-tenant.config.psd1
@@ -75,7 +75,7 @@ Note: Avoid using the same names as used for the "General Parameters" section of
 	Name = 'Application'
 	Uri = 'beta/applications'
 	QueryString = '$top=999'
-	RelatedPropertyNames = @('sponsors')
+	RelatedPropertyNames = @()
 	Type = 'Default' # PrivilegedGroup
 
 	Pillar = @('Identity', 'Network', 'AI')
@@ -88,7 +88,7 @@ Note: Avoid using the same names as used for the "General Parameters" section of
 	Name = 'ServicePrincipal'
 	Uri = 'beta/servicePrincipals'
 	QueryString = '$expand=appRoleAssignments&$top=999&$select=id,deletedDateTime,accountEnabled,alternativeNames,createdByAppId,createdDateTime,deviceManagementAppType,appDescription,appDisplayName,appId,applicationTemplateId,appOwnerOrganizationId,appRoleAssignmentRequired,assignmentRequiredForPrincipalTypes,description,disabledByMicrosoftStatus,displayName,errorUrl,homepage,isAuthorizationServiceEnabled,isDisabled,isManagementRestricted,loginUrl,logoutUrl,notes,notificationEmailAddresses,preferredSingleSignOnMode,preferredTokenSigningKeyEndDateTime,preferredTokenSigningKeyThumbprint,publisherName,replyUrls,samlMetadataUrl,samlSLOBindingType,servicePrincipalNames,servicePrincipalType,signInAudience,tags,tokenEncryptionKeyId,certification,samlSingleSignOnSettings,addIns,api,appRoles,info,keyCredentials,publishedPermissionScopes,passwordCredentials,resourceSpecificApplicationPermissions,verifiedPublisher,customSecurityAttributes,agentIdentityBlueprintId'
-	RelatedPropertyNames = @('oauth2PermissionGrants', 'owners', 'sponsors')
+	RelatedPropertyNames = @('oauth2PermissionGrants', 'owners')
 	Type = 'Default' # PrivilegedGroup
 
 	Pillar = @('Identity', 'Network', 'AI')
@@ -109,6 +109,36 @@ Note: Avoid using the same names as used for the "General Parameters" section of
 	# IncludePlan = @('P2', 'Governance') # P2, Governance
 	ExcludePlan = @('Free') # Free
 	MaximumQueryTime = '%MaximumSignInLogQueryTime%'
+}
+@{
+	Name = 'AgentIdentityBlueprint'
+	Uri = 'beta/applications/microsoft.graph.agentIdentityBlueprint'
+	QueryString = '$top=999&$expand=sponsors($select=id)'
+	RelatedPropertyNames = @()
+	Type = 'Default'
+
+	Pillar = 'AI'
+	# Environment = $null # 'Global'
+}
+@{
+	Name = 'AgentIdentity'
+	Uri = 'beta/servicePrincipals/microsoft.graph.agentIdentity'
+	QueryString = '$top=999&$expand=sponsors($select=id)'
+	RelatedPropertyNames = @()
+	Type = 'Default'
+
+	Pillar = 'AI'
+	# Environment = $null # 'Global'
+}
+@{
+	Name = 'AgentIdentityBlueprintPrincipal'
+	Uri = 'beta/servicePrincipals/microsoft.graph.agentIdentityBlueprintPrincipal'
+	QueryString = '$top=999&$expand=sponsors($select=id)'
+	RelatedPropertyNames = @()
+	Type = 'Default'
+
+	Pillar = 'AI'
+	# Environment = $null # 'Global'
 }
 @{
 	Name = 'User'

--- a/src/powershell/private/export/Export-Database.ps1
+++ b/src/powershell/private/export/Export-Database.ps1
@@ -181,12 +181,55 @@ as
 		throw $_
 	}
 
-	if ($Pillar -in ('All', 'Identity')) {
+	# ---------------------------------------------------------------------------
+	# Resolve which table groups are needed. Each table is imported at most once.
+	# ---------------------------------------------------------------------------
+
+	# Identity and Network need User; AI does not.
+	$needsUser            = $Pillar -in ('All', 'Identity', 'Network')
+
+	# All pillars except Devices need Application and ServicePrincipal.
+	$needsApplicationAndServicePrincipal = $Pillar -in ('All', 'Identity', 'Network', 'AI')
+
+	# AI-specific derived-type tables that carry sponsor relationships inline.
+	$needsAgentIdentity   = $Pillar -in ('All', 'AI')
+
+	# Identity and AI need SignIn; Network does not.
+	$needsSignIn          = $Pillar -in ('All', 'Identity', 'AI')
+
+	# All pillars except Devices share the Role table family.
+	$needsRoles           = $Pillar -in ('All', 'Identity', 'Network', 'AI')
+
+	# Tables exclusive to the Identity pillar.
+	$needsIdentityExtras  = $Pillar -in ('All', 'Identity')
+
+	# Tables exclusive to the Devices pillar.
+	$needsDevices         = $Pillar -in ('All', 'Devices')
+
+	# ---------------------------------------------------------------------------
+	# Import tables — each table loaded exactly once.
+	# ---------------------------------------------------------------------------
+
+	if ($needsUser) {
 		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'User' -LogsPath $LogsPath
+	}
+
+	if ($needsApplicationAndServicePrincipal) {
 		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'Application' -LogsPath $LogsPath
 		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'ServicePrincipal' -LogsPath $LogsPath
-		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'ServicePrincipalSignIn' -LogsPath $LogsPath
+	}
+
+	if ($needsAgentIdentity) {
+		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'AgentIdentityBlueprint' -LogsPath $LogsPath
+		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'AgentIdentity' -LogsPath $LogsPath
+		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'AgentIdentityBlueprintPrincipal' -LogsPath $LogsPath
+	}
+
+	if ($needsSignIn) {
 		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'SignIn' -LogsPath $LogsPath
+	}
+
+	if ($needsRoles) {
 		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleDefinition' -LogsPath $LogsPath
 		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleAssignment' -LogsPath $LogsPath
 		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleAssignmentGroup' -LogsPath $LogsPath
@@ -194,42 +237,20 @@ as
 		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleAssignmentScheduleInstanceGroup' -LogsPath $LogsPath
 		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleEligibilityScheduleInstance' -LogsPath $LogsPath
 		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleEligibilityScheduleInstanceGroup' -LogsPath $LogsPath
+	}
+
+	if ($needsIdentityExtras) {
+		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'ServicePrincipalSignIn' -LogsPath $LogsPath
 		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleManagementPolicyAssignment' -LogsPath $LogsPath
 		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'UserRegistrationDetails' -LogsPath $LogsPath
 	}
 
-	if ($Pillar -in ('All', 'Devices')) {
+	if ($needsDevices) {
 		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'Device' -LogsPath $LogsPath
 		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'ConfigurationPolicy' -LogsPath $LogsPath
 	}
 
-	if ($Pillar -in ('All', 'Network')) {
-		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'User' -LogsPath $LogsPath
-		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'Application' -LogsPath $LogsPath
-		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'ServicePrincipal' -LogsPath $LogsPath
-		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleDefinition' -LogsPath $LogsPath
-		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleAssignment' -LogsPath $LogsPath
-		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleAssignmentGroup' -LogsPath $LogsPath
-		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleAssignmentScheduleInstance' -LogsPath $LogsPath
-		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleAssignmentScheduleInstanceGroup' -LogsPath $LogsPath
-		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleEligibilityScheduleInstance' -LogsPath $LogsPath
-		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleEligibilityScheduleInstanceGroup' -LogsPath $LogsPath
-	}
-
-	if ($Pillar -in ('All', 'AI')) {
-		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'Application' -LogsPath $LogsPath
-		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'ServicePrincipal' -LogsPath $LogsPath
-		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'SignIn' -LogsPath $LogsPath
-		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleDefinition' -LogsPath $LogsPath
-		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleAssignment' -LogsPath $LogsPath
-		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleAssignmentGroup' -LogsPath $LogsPath
-		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleAssignmentScheduleInstance' -LogsPath $LogsPath
-		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleAssignmentScheduleInstanceGroup' -LogsPath $LogsPath
-		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleEligibilityScheduleInstance' -LogsPath $LogsPath
-		Import-EntraTableLogged -Database $database -ExportPath $ExportPath -TableName 'RoleEligibilityScheduleInstanceGroup' -LogsPath $LogsPath
-	}
-
-	if ($Pillar -in ('All', 'Identity', 'Network', 'AI')) {
+	if ($needsRoles) {
 		New-ViewRole -Database $database
 	}
 


### PR DESCRIPTION
Refactor export logic to conditionally import tables based on selected pillars, adding support for AgentIdentity tables.

This pull request refactors how export table groups are determined and imported in the PowerShell export process, making the logic more maintainable and extensible. It also adds support for new AI-related tables and updates configuration to reflect these changes. The main improvements are:

**Refactoring and Logic Simplification:**

* Replaces repetitive pillar checks with clear, reusable variables (like `$needsUser`, `$needsAgentIdentity`, etc.) to decide which tables to import, ensuring each table is only loaded once and making future changes easier.

**Support for AI-related Tables:**

* Adds three new table configurations to `export-tenant.config.psd1` for AI features: `AgentIdentityBlueprint`, `AgentIdentity`, and `AgentIdentityBlueprintPrincipal`, each with their own API URIs and query strings.
* Updates the import logic to include these new tables when the `AI` pillar is selected.

**Configuration Updates:**

* Removes the `sponsors` property from the `RelatedPropertyNames` for `Application` and `ServicePrincipal` in `export-tenant.config.psd1`, reflecting the new way sponsor relationships are handled for AI tables. [[1]](diffhunk://#diff-11446de02748a3bf2e70ce5dec6560ba8890aacca4dbc895e48575f2c2ad7bc7L78-R78) [[2]](diffhunk://#diff-11446de02748a3bf2e70ce5dec6560ba8890aacca4dbc895e48575f2c2ad7bc7L91-R91)

These changes streamline the table import process, add support for new AI data, and clarify how sponsor relationships are managed.