### PR TITLE
ci(pr-validation): write tee log outside -Path to avoid CI auto-clean collision

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -160,9 +160,14 @@ jobs:
             -ClientId    $env:AZURE_CLIENT_ID `
             -Certificate $env:CERT_THUMBPRINT
 
+          # Keep the tee log OUTSIDE -Path. Invoke-ZtAssessment auto-cleans a
+          # non-empty -Path in CI before starting, and Tee-Object holds an open
+          # handle for the entire run — putting the log under -Path causes the
+          # cleanup to fail with a sharing violation.
           $reportPath = Join-Path $env:RUNNER_TEMP 'ZeroTrustReport'
-          New-Item -ItemType Directory -Force -Path $reportPath | Out-Null
-          $logFile = Join-Path $reportPath 'invoke-zt.log'
+          $logDir     = Join-Path $env:RUNNER_TEMP 'zta-logs'
+          New-Item -ItemType Directory -Force -Path $logDir | Out-Null
+          $logFile = Join-Path $logDir 'invoke-zt.log'
 
           $invokeArgs = @{
             Path      = $reportPath
@@ -184,6 +189,10 @@ jobs:
           Invoke-ZtAssessment @invokeArgs *>&1 |
             Tee-Object -FilePath $logFile |
             Out-Null
+
+          # Now that the cmdlet (and the tee handle) have completed, fold the
+          # log into the report folder so it ships with the upload.
+          Copy-Item $logFile (Join-Path $reportPath 'invoke-zt.log') -Force
 
           Get-ChildItem -File $reportPath |
             Select-Object Name, @{n='SizeKB';e={[math]::Round($_.Length/1KB,1)}} |


### PR DESCRIPTION
## Follow-up to #1254

First dispatch of the new PR validation workflow successfully authenticated via WIF + cert, but the `Run assessment (Connect + Invoke, no browser)` step crashed before any tests ran.

## Root cause

`Invoke-ZtAssessment` (`src/powershell/public/Invoke-ZtAssessment.ps1`) treats a non-empty `-Path` as a stale-report folder and auto-cleans it under CI (`$env:GITHUB_ACTIONS`, `$env:TF_BUILD`, `$env:CI`, `$env:JENKINS_URL`) via `Remove-Item -Recurse -Force -ErrorAction Stop`. That behaviour is correct.

The workflow piped the cmdlet through `Tee-Object -FilePath $logFile`, with `$logFile` placed **inside** `-Path`. `Tee-Object` opens the file at the start of the pipeline and keeps the handle open until the pipeline ends, so by the time the cmdlet tried to clean its own `-Path` the log file inside it was locked → sharing violation → step exited 1.

## Fix

Workflow-only change: write the tee log to a sibling folder under `$env:RUNNER_TEMP\zta-logs\`, and `Copy-Item` it into the report folder after the cmdlet returns so it still ships with the private blob upload.

No changes to `Invoke-ZtAssessment.ps1` (the CI auto-clean is intentional and correct).

## Diff scope

One file, ~11 lines:

- `.github/workflows/pr-validation.yml` — `Run assessment (Connect + Invoke, no browser)` step

## Validation

Will dispatch the workflow against this PR after merge to confirm a full end-to-end run.