### PR TITLE
ci(pr-validation): generate PSF support package and include it in upload

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -200,6 +200,18 @@ jobs:
 
           "REPORT_PATH=$reportPath" | Out-File -FilePath $env:GITHUB_ENV -Append
 
+      - name: Generate PSF support package
+        shell: pwsh
+        run: |
+          # Writes powershell_support_pack_<timestamp>.zip directly into
+          # $env:REPORT_PATH so the next step uploads it alongside the report.
+          # Non-fatal: a missing diagnostic bundle must not block upload.
+          try {
+            New-PSFSupportPackage -Path $env:REPORT_PATH -Force
+          } catch {
+            Write-Warning "New-PSFSupportPackage failed: $($_.Exception.Message)"
+          }
+
       - name: Upload report to private blob container
         shell: pwsh
         run: |


### PR DESCRIPTION
## Follow-up to #1255

Adds a single workflow step that runs `New-PSFSupportPackage` after the assessment completes. The cmdlet writes `powershell_support_pack_<timestamp>.zip` directly into the report folder, so the existing `az storage blob upload-batch` step picks it up alongside the JSON/HTML/log without any path juggling.

## Why

The repo already ships a `psf-support-package-analyzer` skill that consumes these zips for post-mortem analysis of failed runs. Capturing the bundle on every CI run gives maintainers a one-click diagnostic artefact next to every uploaded report — no extra fetch step needed.

## Safety

Wrapped in `try`/`catch` with `Write-Warning`. If PSF bundle generation ever fails, the step logs a warning and the workflow continues to the upload — the diagnostic zip is nice-to-have, the report itself is the must-have.

## Diff scope

Workflow-only, 12 added lines:

- `.github/workflows/pr-validation.yml` — new `Generate PSF support package` step between `Run assessment` and `Upload report to private blob container`.