### PR TITLE
ci(pr-validation): generate PSF bundle in-process inside finally

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -166,8 +166,13 @@ jobs:
           # cleanup to fail with a sharing violation.
           $reportPath = Join-Path $env:RUNNER_TEMP 'ZeroTrustReport'
           $logDir     = Join-Path $env:RUNNER_TEMP 'zta-logs'
-          New-Item -ItemType Directory -Force -Path $logDir | Out-Null
+          New-Item -ItemType Directory -Force -Path $reportPath | Out-Null
+          New-Item -ItemType Directory -Force -Path $logDir     | Out-Null
           $logFile = Join-Path $logDir 'invoke-zt.log'
+
+          # Export REPORT_PATH up-front so the upload step (if: always()) has
+          # somewhere to look even if the assessment throws.
+          "REPORT_PATH=$reportPath" | Out-File -FilePath $env:GITHUB_ENV -Append
 
           $invokeArgs = @{
             Path      = $reportPath
@@ -184,35 +189,37 @@ jobs:
             }
           }
 
-          # Capture verbose output to a file (uploaded with the report);
-          # keep the public Actions log limited to file listing + counts.
-          Invoke-ZtAssessment @invokeArgs *>&1 |
-            Tee-Object -FilePath $logFile |
-            Out-Null
-
-          # Now that the cmdlet (and the tee handle) have completed, fold the
-          # log into the report folder so it ships with the upload.
-          Copy-Item $logFile (Join-Path $reportPath 'invoke-zt.log') -Force
-
-          Get-ChildItem -File $reportPath |
-            Select-Object Name, @{n='SizeKB';e={[math]::Round($_.Length/1KB,1)}} |
-            Format-Table | Out-String | Write-Host
-
-          "REPORT_PATH=$reportPath" | Out-File -FilePath $env:GITHUB_ENV -Append
-
-      - name: Generate PSF support package
-        shell: pwsh
-        run: |
-          # Writes powershell_support_pack_<timestamp>.zip directly into
-          # $env:REPORT_PATH so the next step uploads it alongside the report.
-          # Non-fatal: a missing diagnostic bundle must not block upload.
           try {
-            New-PSFSupportPackage -Path $env:REPORT_PATH -Force
-          } catch {
-            Write-Warning "New-PSFSupportPackage failed: $($_.Exception.Message)"
+            # Capture verbose output to a file (uploaded with the report);
+            # keep the public Actions log limited to file listing + counts.
+            Invoke-ZtAssessment @invokeArgs *>&1 |
+              Tee-Object -FilePath $logFile |
+              Out-Null
+          }
+          finally {
+            # Collect the PSF support bundle in the SAME process that ran the
+            # assessment — otherwise the imported ZeroTrustAssessment module,
+            # Write-PSFMessage history, $Error records, and command history
+            # are all gone (each `shell: pwsh` step is a fresh process).
+            # Runs on success AND on failure so we always get a diagnostic zip.
+            try {
+              New-PSFSupportPackage -Path $reportPath -Force
+            } catch {
+              Write-Warning "New-PSFSupportPackage failed: $($_.Exception.Message)"
+            }
+
+            # Fold the tee log into the report folder so it ships with the upload.
+            if (Test-Path $logFile) {
+              Copy-Item $logFile (Join-Path $reportPath 'invoke-zt.log') -Force
+            }
+
+            Get-ChildItem -File $reportPath -ErrorAction SilentlyContinue |
+              Select-Object Name, @{n='SizeKB';e={[math]::Round($_.Length/1KB,1)}} |
+              Format-Table | Out-String | Write-Host
           }
 
       - name: Upload report to private blob container
+        if: always() && env.REPORT_PATH != ''
         shell: pwsh
         run: |
           # No URL, account, container, or prefix is echoed. Maintainers locate

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -205,7 +205,11 @@ jobs:
             try {
               New-PSFSupportPackage -Path $reportPath -Force
             } catch {
-              Write-Warning "New-PSFSupportPackage failed: $($_.Exception.Message)"
+              # Public Actions log stays generic (no paths/details echoed);
+              # the full exception goes only to the private tee log shipped
+              # with the report.
+              Write-Warning 'New-PSFSupportPackage failed; see invoke-zt.log for details.'
+              $_ | Out-String | Add-Content -Path $logFile
             }
 
             # Fold the tee log into the report folder so it ships with the upload.


### PR DESCRIPTION
## Follow-up to #1258 — fixes the empty support bundle

## What was wrong

The standalone `Generate PSF support package` step (added in #1258) collected an empty bundle on every run: 2 messages total, 0 errors, 0 history, no `ZeroTrustAssessment` module loaded, no `Microsoft.Graph.*` modules — just PSFramework's own self-narration from inside `New-PSFSupportPackage`.

Root cause: every `shell: pwsh` step spawns a **fresh** `pwsh` process, so the support-package step had its own empty PSF state and never saw:

- the imported `ZeroTrustAssessment` module
- `Write-PSFMessage` entries from the run (PSF message state is per-process)
- command history
- `$Error` records
- the cmdlet's `_ZTA_ExportStatistics` / `_ZTA_TestStatistics`

Secondary issue: `Invoke-ZtAssessment @args *>&1 | Tee-Object | Out-Null` is a terminating pipeline — even if the steps were merged, a thrown error would skip `New-PSFSupportPackage` entirely.

## Fix

1. **Collapse** the standalone step into the `Run assessment` step so the bundle is collected in the same `pwsh` process that ran the assessment.
2. **Wrap** the `Invoke-ZtAssessment` pipeline in `try { … } finally { New-PSFSupportPackage; copy log; list files }` so the bundle is produced on both success and failure.
3. **Export `REPORT_PATH` up-front** (before the try) so the upload step has somewhere to look even if the assessment throws.
4. **Pre-create `$reportPath`** so the bundle has a target even if the cmdlet bails before creating it.
5. **Flip the upload step** to `if: always() && env.REPORT_PATH != ''` so a failure-case diagnostic bundle actually reaches the blob container.

Inner `try/catch` around `New-PSFSupportPackage` itself is preserved so a bundle hiccup doesn't mask the original assessment error.

## Scope

One file:

- `.github/workflows/pr-validation.yml`
