### PR TITLE
ci(pr-validation): add -Preview as a workflow_dispatch checkbox (default on)

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -53,7 +53,7 @@ on:
         required: true
         type: string
       pillar:
-        description: 'Pillar (Infrastructure/SecOps/AI auto-enable -Preview)'
+        description: 'Pillar'
         required: false
         default: 'AI'
         type: choice
@@ -70,6 +70,11 @@ on:
         description: 'Comma-separated test IDs (overrides Pillar when set)'
         required: false
         type: string
+      preview:
+        description: 'Include preview tests (-Preview)'
+        required: false
+        default: true
+        type: boolean
 
 permissions:
   id-token: write     # GitHub OIDC token — exchanged for an Entra access token via WIF
@@ -178,15 +183,15 @@ jobs:
             Path      = $reportPath
             NoBrowser = $true
           }
+          if ([System.Convert]::ToBoolean('${{ inputs.preview }}')) {
+            $invokeArgs['Preview'] = $true
+          }
           $pillar = '${{ inputs.pillar }}'
           $tests  = '${{ inputs.tests }}'.Trim()
           if ($tests) {
             $invokeArgs['Tests'] = ($tests -split ',').Trim()
           } elseif ($pillar -and $pillar -ne 'All') {
             $invokeArgs['Pillar'] = $pillar
-            if ($pillar -in 'Infrastructure','SecOps','AI') {
-              $invokeArgs['Preview'] = $true
-            }
           }
 
           try {


### PR DESCRIPTION
## Follow-up

Currently `-Preview` is hard-wired: only added when the dispatcher picks `Infrastructure`, `SecOps`, or `AI`. Every other dispatch shape (`pillar=All`, `Identity`, `Devices`, `Network`, `Data`, or explicit `-Tests`) silently skips preview tests.

## Fix

Promote `-Preview` to an explicit `workflow_dispatch` input — a checkbox, pre-ticked.

- New input `preview` (boolean, `default: true`).
- Dispatcher decides per-run: tick = run preview tests too, untick = skip them.
- Decoupled from `pillar` — works the same regardless of which pillar (or `Tests` list) you pick.

Pillar description updated to drop the now-stale `(Infrastructure/SecOps/AI auto-enable -Preview)` note.

## Scope

One file, ~9 lines:

- `.github/workflows/pr-validation.yml`
