### PR TITLE
ci(pr-validation): import cert as exportable so SPO/PnP can sign JWTs

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -145,7 +145,7 @@ jobs:
           $imported = Import-PfxCertificate `
             -FilePath $pfxPath `
             -CertStoreLocation 'Cert:\CurrentUser\My' `
-            -Exportable:$false
+            -Exportable
           Remove-Item $pfxPath -Force
 
           "CERT_THUMBPRINT=$($imported.Thumbprint)" | Out-File -FilePath $env:GITHUB_ENV -Append


### PR DESCRIPTION
## Follow-up

`Connect-PnPOnline` (which `Connect-ZtAssessment` calls for SharePoint Online) signs its own `client_assertion` JWT with the private key. That requires extracting the key bytes, which Windows refuses when the key was imported non-exportable.

Workflow currently:

```
Import-PfxCertificate ... -Exportable:$false
```

Run output:

```
❌ Failed to export the certificate private key for SharePoint Online.
   The certificate's private key must be marked as exportable.
   Re-import the certificate with 'Mark this key as exportable' enabled and try again.
```

## Fix

Flip the import to `-Exportable`.

## Safety

- The runner is ephemeral (windows-latest hosted).
- The cert lives only in `Cert:\CurrentUser\My` for the duration of one job.
- The existing `Remove cert from runner store` step (`if: always()`) wipes it before the runner is recycled.
- The pfx file itself is already `Remove-Item`'d immediately after import.

## Scope

One file, one line:

- `.github/workflows/pr-validation.yml`
