### PR TITLE
fix: handle TestPillar array type in flyout Infrastructure checks

### DIFF
--- a/src/report/src/components/test-table/data-table.tsx
+++ b/src/report/src/components/test-table/data-table.tsx
@@ -244,11 +244,10 @@ export function DataTable<TData extends Test, TValue>({
 
     const [sheetOpen, setSheetOpen] = React.useState(false);
     const [selectedRow, setSelectedRow] = React.useState<Test | null>(null);
-    const isInfrastructureRow = selectedRow
-        ? (Array.isArray(selectedRow.TestPillar)
-            ? selectedRow.TestPillar.includes("Infrastructure")
-            : selectedRow.TestPillar === "Infrastructure")
-        : false;
+    const selectedPillar = selectedRow?.TestPillar ?? null;
+    const isInfrastructureRow = Array.isArray(selectedPillar)
+        ? selectedPillar.includes("Infrastructure")
+        : selectedPillar === "Infrastructure";
     const mdRehypePlugins = isInfrastructureRow
         ? [rehypeRaw, rehypeSanitize]
         : [];

--- a/src/report/src/components/test-table/data-table.tsx
+++ b/src/report/src/components/test-table/data-table.tsx
@@ -244,7 +244,12 @@ export function DataTable<TData extends Test, TValue>({
 
     const [sheetOpen, setSheetOpen] = React.useState(false);
     const [selectedRow, setSelectedRow] = React.useState<Test | null>(null);
-    const mdRehypePlugins = selectedRow?.TestPillar === "Infrastructure"
+    const isInfrastructureRow = selectedRow
+        ? (Array.isArray(selectedRow.TestPillar)
+            ? selectedRow.TestPillar.includes("Infrastructure")
+            : selectedRow.TestPillar === "Infrastructure")
+        : false;
+    const mdRehypePlugins = isInfrastructureRow
         ? [rehypeRaw, rehypeSanitize]
         : [];
 
@@ -515,20 +520,20 @@ export function DataTable<TData extends Test, TValue>({
                     <div className="grid pt-10 gap-6">
                         <Card>
                             <CardHeader>
-                                <div className={`mt-2 text-sm ${selectedRow?.TestPillar === "Infrastructure" ? "flex flex-col gap-y-2" : "grid grid-cols-3 gap-y-2"}`}>
+                                <div className={`mt-2 text-sm ${isInfrastructureRow ? "flex flex-col gap-y-2" : "grid grid-cols-3 gap-y-2"}`}>
                                     <div className="flex items-center gap-2">
                                         <AlertTriangle className="h-4 w-4 text-foreground" />
-                                        <span className="font-semibold">{selectedRow?.TestPillar === "Infrastructure" ? "Severity:" : "Risk:"}</span>
+                                        <span className="font-semibold">{isInfrastructureRow ? "Severity:" : "Risk:"}</span>
                                         <span>{selectedRow?.TestRisk ?? "N/A"}</span>
                                     </div>
-                                    {selectedRow?.TestPillar !== "Infrastructure" && (
+                                    {!isInfrastructureRow && (
                                     <div className="flex items-center gap-2">
                                         <Users className="h-4 w-4 text-foreground" />
                                         <span className="font-semibold">User Impact:</span>
                                         <span>{selectedRow?.TestImpact ?? "N/A"}</span>
                                     </div>
                                     )}
-                                    {selectedRow?.TestPillar !== "Infrastructure" && (
+                                    {!isInfrastructureRow && (
                                     <div className="flex items-center gap-2">
                                         <Settings className="h-4 w-4 text-foreground" />
                                         <span className="font-semibold">Implementation Effort:</span>
@@ -540,7 +545,7 @@ export function DataTable<TData extends Test, TValue>({
                                         <span className="font-semibold">Test ID:</span>
                                         <span>{selectedRow?.TestId ?? "N/A"}</span>
                                     </div>
-                                    {selectedRow?.TestPillar !== "Infrastructure" && (
+                                    {!isInfrastructureRow && (
                                     <div className="flex items-center gap-2">
                                         <BadgeCheck className="h-4 w-4 text-foreground" />
                                         <span className="font-semibold">License:</span>


### PR DESCRIPTION
## Problem

Follows up on #1273. The PR was merged but a type-safety issue flagged in the GHCP review was not included.

`TestPillar` is typed as `string | string[] | null` in `report-data.ts`, but the flyout used strict string comparisons (`=== "Infrastructure"`) that return `false` when `TestPillar` is an array.

This caused wrong label, layout, and field visibility in the flyout for Infrastructure rows when TestPillar is an array.

## Fix

Introduced `isInfrastructureRow` boolean handling all three types (string, string[], null). Replaced all 6 raw comparisons in the flyout.

## Related

Addresses GHCP review: https://github.com/microsoft/zerotrustassessment/pull/1273#pullrequestreview-4420582281
