### PR TITLE
fix: prevent Sankey crash on empty data with graceful empty state

### DIFF
--- a/src/powershell/private/tenantinfo/devices/Add-ZtDeviceOverview.ps1
+++ b/src/powershell/private/tenantinfo/devices/Add-ZtDeviceOverview.ps1
@@ -326,7 +326,7 @@ order by operatingSystem, deviceOwnership, isCompliant
         @{
             "description"  = "Mobile devices by compliance status."
             "nodes"        = $nodes
-            "totalDevices" = $results | Measure-Object -Property count -Sum | Select-Object -ExpandProperty Sum
+            "totalDevices" = ($results | Measure-Object -Property count -Sum).Sum ?? 0
         }
     }
 

--- a/src/report/src/components/nivo/sankey.tsx
+++ b/src/report/src/components/nivo/sankey.tsx
@@ -13,20 +13,28 @@ type SankeyNode = {
 
 type SankeyData = {
     nodes: SankeyNode[];
-    links: any[]; // replace with the actual type of links
+    links: {
+        source: string;
+        target: string;
+        value: number | null;
+    }[];
 };
 
 export const ZtResponsiveSankey = ({ isDark, data }: { isDark:boolean, data: SankeyData }) => {
-    // Filter out nodes that have no connected links to avoid Nivo rendering errors
-    const connectedNodeIds = new Set<string>();
-    for (const link of data.links) {
-        connectedNodeIds.add(link.source);
-        connectedNodeIds.add(link.target);
-    }
-    const filteredData: SankeyData = {
-        nodes: data.nodes.filter(node => connectedNodeIds.has(node.id)),
-        links: data.links,
+    const filteredData = {
+        ...data,
+        links: data.links
+            .filter(link => Number.isFinite(Number(link.value)) && Number(link.value) > 0)
+            .map(link => ({ ...link, value: Number(link.value) }))
     };
+
+    if (filteredData.links.length === 0) {
+        return (
+            <div className={`flex h-full min-h-32 w-full items-center justify-center px-4 text-center text-sm text-muted-foreground ${isDark ? 'sankey-dark-mode' : 'sankey-light-mode'}`}>
+                No Sankey data available.
+            </div>
+        );
+    }
 
     const theme = {
         tooltip: {

--- a/src/report/src/components/nivo/sankey.tsx
+++ b/src/report/src/components/nivo/sankey.tsx
@@ -16,21 +16,38 @@ type SankeyData = {
     links: {
         source: string;
         target: string;
+        value: number;
+    }[];
+};
+
+type SankeyInputData = {
+    nodes: SankeyNode[];
+    links: {
+        source: string;
+        target: string;
         value: number | null;
     }[];
 };
 
-export const ZtResponsiveSankey = ({ isDark, data }: { isDark:boolean, data: SankeyData }) => {
-    const filteredData = {
-        ...data,
-        links: data.links
-            .filter(link => Number.isFinite(Number(link.value)) && Number(link.value) > 0)
-            .map(link => ({ ...link, value: Number(link.value) }))
+export const ZtResponsiveSankey = ({ isDark, data }: { isDark:boolean, data: SankeyInputData }) => {
+    const sanitizedLinks = data.links
+        .filter(link => Number.isFinite(Number(link.value)) && Number(link.value) > 0)
+        .map(link => ({ ...link, value: Number(link.value) }));
+
+    const connectedNodeIds = new Set<string>();
+    for (const link of sanitizedLinks) {
+        connectedNodeIds.add(link.source);
+        connectedNodeIds.add(link.target);
+    }
+
+    const filteredData: SankeyData = {
+        nodes: data.nodes.filter(node => connectedNodeIds.has(node.id)),
+        links: sanitizedLinks
     };
 
-    if (filteredData.links.length === 0) {
+    if (filteredData.links.length === 0 || filteredData.nodes.length === 0) {
         return (
-            <div className={`flex h-full min-h-32 w-full items-center justify-center px-4 text-center text-sm text-muted-foreground ${isDark ? 'sankey-dark-mode' : 'sankey-light-mode'}`}>
+            <div className={`flex h-full min-h-[8rem] w-full items-center justify-center px-4 text-center text-sm text-muted-foreground ${isDark ? 'sankey-dark-mode' : 'sankey-light-mode'}`}>
                 No data available.
             </div>
         );

--- a/src/report/src/components/nivo/sankey.tsx
+++ b/src/report/src/components/nivo/sankey.tsx
@@ -31,7 +31,7 @@ export const ZtResponsiveSankey = ({ isDark, data }: { isDark:boolean, data: San
     if (filteredData.links.length === 0) {
         return (
             <div className={`flex h-full min-h-32 w-full items-center justify-center px-4 text-center text-sm text-muted-foreground ${isDark ? 'sankey-dark-mode' : 'sankey-light-mode'}`}>
-                No Sankey data available.
+                No data available.
             </div>
         );
     }


### PR DESCRIPTION
## Summary
Fixes the Sankey report crash issue (#1235) with defense-in-depth approach.

## Root Cause
PowerShell \Measure-Object -Sum\ on empty pipeline returns \\\ instead of 0. When serialized to JSON, this becomes \alue: null\ in link data, causing D3 Sankey to crash when calculating link widths.

## Changes
### Backend (PowerShell)
- **src/powershell/private/tenantinfo/devices/Add-ZtDeviceOverview.ps1** (line 329)
  - Changed: \Measure-Object -Property count -Sum | Select-Object -ExpandProperty Sum\
  - To: \(Measure-Object -Property count -Sum).Sum ?? 0\
  - Ensures \	otalDevices\ is always 0 instead of null on empty mobile device results

### Frontend (React)
- **src/report/src/components/nivo/sankey.tsx**
  - Added type-safe link structure: \alue: number | null\
  - Implemented filtering: removes links with non-numeric or non-positive values
  - Added graceful empty state: shows generic 'No data available' message while maintaining card layout
  - Prevents D3 Sankey crash by ensuring only valid numeric links reach renderer

## UX Improvements
- Generic message ('No data available') instead of technical terminology
- Maintains card layout consistency when no data exists
- Works across all Sankey variations in report (Desktop, Mobile, CA, Auth Methods)

## Testing
- Tested against tenant with zero mobile devices (previously crashed)
- Empty state displays correctly with proper styling and formatting

Closes #1235