### PR TITLE
Bugfix/issue 1274 - Test 24552 erroring

### DIFF
--- a/src/powershell/tests/Test-Assessment.24552.ps1
+++ b/src/powershell/tests/Test-Assessment.24552.ps1
@@ -94,11 +94,6 @@ function Test-Assessment-24552 {
         }
         $policySettingIds = @($firewallSetting.settingInstance.groupSettingCollectionValue[0].children.choiceSettingValue.value)
 
-        # Convert to array if it's a single value to ensure consistent handling
-        if ($policySettingIds -isnot [array]) {
-            $policySettingIds = @($policySettingIds)
-        }
-
         # Check if any of the policy's setting IDs match our valid setting IDs
         $hasValidSetting = $false
         foreach ($settingId in $policySettingIds) {

--- a/src/powershell/tests/Test-Assessment.24552.ps1
+++ b/src/powershell/tests/Test-Assessment.24552.ps1
@@ -12,7 +12,7 @@ function Test-Assessment-24552 {
         MinimumLicense = ('Intune'),
         Pillar = 'Devices',
         RiskLevel = 'Medium',
-        SfiPillar = 'Protect networks',
+        SfiPillar = 'Protect engineering systems',
         TenantType = ('Workforce'),
         TestId = 24552,
         Title = 'macOS Firewall policies protect against unauthorized network access',
@@ -57,47 +57,42 @@ function Test-Assessment-24552 {
     $activity = "Checking macOS Firewall Policy is Created and Assigned"
     Write-ZtProgress -Activity $activity -Status "Getting policy"
 
-    # Query: Retrieve all macOS policies with mdm and appleRemoteManagement technologies
-    # We use unnest(settings) to find the specific firewall setting we are interested in.
-    # We also cast assignments to JSON to simplify parsing in PowerShell.
+    # Query: Retrieve all macOS policies with mdm and appleRemoteManagement technologies.
+    # Settings and assignments are returned as JSON for PowerShell-side filtering,
+    # avoiding DuckDB list_transform lambda issues when data is null or absent.
     $sql = @"
-    SELECT
-        id,
-        name,
-        to_json(assignments) as assignments,
-        list_transform(
-            setting.settingInstance.groupSettingCollectionValue[1].children,
-            x -> x.choiceSettingValue."value"
-        ) as firewallSettingValues
-    FROM (
-        SELECT
-            id,
-            name,
-            assignments,
-            unnest(settings) as setting
-        FROM ConfigurationPolicy
-        WHERE platforms LIKE '%macOS%'
-          AND technologies LIKE '%mdm%'
-          AND technologies LIKE '%appleRemoteManagement%'
-    )
-    WHERE setting.settingInstance.SettingDefinitionID = 'com.apple.security.firewall_com.apple.security.firewall'
+    SELECT id, name, to_json(settings) as settings, to_json(assignments) as assignments
+    FROM ConfigurationPolicy
+    WHERE platforms LIKE '%macOS%'
+      AND technologies LIKE '%mdm%'
+      AND technologies LIKE '%appleRemoteManagement%'
 "@
-    $macOSFirewallPolicies = Invoke-DatabaseQuery -Database $Database -Sql $sql -AsCustomObject
+    $macOSAllPolicies = Invoke-DatabaseQuery -Database $Database -Sql $sql -AsCustomObject
 
-    # Parse JSON assignments field
-    foreach ($policy in $macOSFirewallPolicies) {
-        if ($policy.assignments) {
+    # Parse JSON fields
+    foreach ($policy in $macOSAllPolicies) {
+        if ($policy.settings -is [string]) {
+            $policy.settings = $policy.settings | ConvertFrom-Json
+        }
+        if ($policy.assignments -is [string]) {
             $policy.assignments = $policy.assignments | ConvertFrom-Json
         }
     }
+
+    # Filter to only policies that contain the macOS firewall setting definition
+    $macOSFirewallPolicies = @($macOSAllPolicies | Where-Object {
+        $_.settings.settingInstance.settingDefinitionId -contains 'com.apple.security.firewall_com.apple.security.firewall'
+    })
 
     # Filter policies to include only those related to firewall settings
     foreach ($macOSPolicy in $macOSFirewallPolicies) {
         $validSettingIds = @('com.apple.security.firewall_enablefirewall_true')
 
-        # Get all setting definition IDs from the policy (handle both single values and arrays)
-        # The SQL query returns this as a list of strings (or list of JSONs)
-        $policySettingIds = $macOSPolicy.firewallSettingValues
+        # Get all choice values from the firewall setting's children (PowerShell-side, avoids DuckDB lambda issues)
+        $firewallSetting = $macOSPolicy.settings | Where-Object {
+            $_.settingInstance.settingDefinitionId -eq 'com.apple.security.firewall_com.apple.security.firewall'
+        }
+        $policySettingIds = @($firewallSetting.settingInstance.groupSettingCollectionValue[0].children.choiceSettingValue.value)
 
         # Convert to array if it's a single value to ensure consistent handling
         if ($policySettingIds -isnot [array]) {
@@ -124,8 +119,8 @@ function Test-Assessment-24552 {
     $passed = $false
     $testResultMarkdown = ""
 
-    # Test macOS firewall policy assignments
-    $passed = Test-PolicyAssignment -Policies $macOSFirewallPolicies
+    # Test macOS firewall policy assignments — only policies with firewall actually enabled count
+    $passed = Test-PolicyAssignment -Policies ($macOSFirewallPolicies | Where-Object { $_.FirewallSettings -eq $true })
 
     if ($passed) {
         $testResultMarkdown = "A macOS firewall policy is configured and assigned in Intune.`n`n%TestResult%"
@@ -148,7 +143,7 @@ function Test-Assessment-24552 {
 
 ## {0}
 
-| Policy Name | Status | Assignment Target | Firewall Status |
+| Policy name | Status | Assignment target | Firewall status |
 | :---------- | :----- | :---------------- | :-------------- |
 {1}
 

--- a/src/powershell/tests/Test-Assessment.24552.ps1
+++ b/src/powershell/tests/Test-Assessment.24552.ps1
@@ -89,10 +89,12 @@ function Test-Assessment-24552 {
         $validSettingIds = @('com.apple.security.firewall_enablefirewall_true')
 
         # Get all choice values from the firewall setting's children (PowerShell-side, avoids DuckDB lambda issues)
-        $firewallSetting = $macOSPolicy.settings | Where-Object {
-            $_.settingInstance.settingDefinitionId -eq 'com.apple.security.firewall_com.apple.security.firewall'
+        $firewallSetting = $macOSPolicy.settings | Where-Object { $_.settingInstance.settingDefinitionId -eq 'com.apple.security.firewall_com.apple.security.firewall' } | Select-Object -First 1
+        $policySettingIds = if ($firewallSetting -and $firewallSetting.settingInstance.groupSettingCollectionValue) {
+            @($firewallSetting.settingInstance.groupSettingCollectionValue[0].children.choiceSettingValue.value)
+        } else {
+            @()
         }
-        $policySettingIds = @($firewallSetting.settingInstance.groupSettingCollectionValue[0].children.choiceSettingValue.value)
 
         # Check if any of the policy's setting IDs match our valid setting IDs
         $hasValidSetting = $false


### PR DESCRIPTION
Fixes #1274 
[Spec-24552](https://github.com/microsoft/ztspecs/blob/main/specs/devices/24552.md)

Fix: DuckDB query crash (Issue #1274)
- Replaced the list_transform(x -> ...) DuckDB lambda in the SQL query that crashed with "Referenced column 'x' not found in FROM clause" when no macOS settings were present
- Simplified SQL to return settings and assignments as JSON; moved all filtering to PowerShell

Fix: Incorrect pass/fail logic
- $passed was evaluated against all firewall-container policies, meaning a policy with firewall disabled but assigned would still produce a Pass
- Fixed to only consider policies where FirewallSettings -eq $true (i.e. com.apple.security.firewall_enablefirewall_true is present), matching the spec

Fix: Incorrect SfiPillar metadata
- Changed from 'Protect networks' to 'Protect engineering systems' per the spec

Cleanup: Removed redundant array check
- Removed the if ($policySettingIds -isnot [array]) guard since the preceding @(...) already guarantees an array