### PR TITLE
Made changes for SPO service to use modern authentication

### DIFF
--- a/src/powershell/public/Connect-ZtAssessment.ps1
+++ b/src/powershell/public/Connect-ZtAssessment.ps1
@@ -812,7 +812,7 @@ function Connect-ZtAssessment {
 						}
 					}
 					else {
-						Connect-SPOService -Url $adminUrl -ErrorAction Stop
+						Connect-SPOService -Url $adminUrl -UseSystemBrowser $true -ErrorAction Stop
 					}
 					Write-Host -Object "   ✅ Connected" -ForegroundColor Green
 					Add-ZtConnectedService -Service 'SharePointOnline'


### PR DESCRIPTION
closes #1193 

## Problem

`Connect-SPOService` defaults to legacy ADAL-based authentication. When a tenant's Conditional Access policies block legacy authentication (e.g. to enforce phishing-resistant MFA, Windows Hello, or FIDO2), the connection fails silently with:

```
Connect-SPOService: Could not connect to SharePoint Online.
```

## Change

Added `-UseSystemBrowser $true` to `Connect-SPOService` call:

**Before:**
```powershell
Connect-SPOService -Url $adminUrl -ErrorAction Stop
```

<img width="1515" height="334" alt="image" src="https://github.com/user-attachments/assets/1d86fd62-e650-420a-92d5-e1e414478024" />


**After:**
```powershell
Connect-SPOService -Url $adminUrl -UseSystemBrowser $true -ErrorAction Stop
```

<img width="1426" height="241" alt="image" src="https://github.com/user-attachments/assets/31a8f5eb-4691-404d-a884-dd985df3bddf" />

## References
- [`Connect-SPOService` docs](https://learn.microsoft.com/powershell/module/microsoft.online.sharepoint.powershell/connect-sposervice?view=sharepoint-ps)
- [Can't connect to SharePoint Online when you run Connect-SPOService](https://learn.microsoft.com/troubleshoot/sharepoint/administration/connect-sposervice-error)