### PR TITLE
fix: added skip scenario to Test 25392 when there are no private access connectors installed

### DIFF
--- a/code-tests/test-assessments/Test-Assessment.25392.Tests.ps1
+++ b/code-tests/test-assessments/Test-Assessment.25392.Tests.ps1
@@ -42,17 +42,17 @@ Describe "Test-Assessment-25392" {
     }
 
     Context "When no connectors are found" {
-        It "Should pass with 'No connectors found' message" {
+        It "Should skip with 'No Private Access connectors were detected' message" {
             Mock Invoke-ZtGraphRequest { return @() }
             Mock Add-ZtTestResultDetail {
-                param($TestId, $Title, $Status, $Result)
+                param($SkippedBecause, $Result)
                 "## Scenario: No connectors found`n`n$Result`n" | Add-Content $script:outputFile
             }
 
             Test-Assessment-25392
 
             Should -Invoke Add-ZtTestResultDetail -ParameterFilter {
-                $Status -eq $true -and $Result -match "No private network connectors found"
+                $SkippedBecause -eq 'NotApplicable' -and $Result -match "No Private Access connectors were detected"
             }
         }
     }

--- a/src/powershell/tests/Test-Assessment.25392.ps1
+++ b/src/powershell/tests/Test-Assessment.25392.ps1
@@ -76,19 +76,19 @@ function Test-Assessment-25392 {
     $latestVersion = $null
 
     # Step 1: Check if any connectors exist
-    if ($connectors -and $connectors.Count -gt 0) {
-        # Step 2: Get the latest version from documentation
-        Write-ZtProgress -Activity $activity -Status 'Getting latest version from documentation'
-        $latestVersion = Get-LatestConnectorVersion
+    if (-not $connectors -or $connectors.Count -eq 0) {
+        Write-PSFMessage 'No Private Access connectors found' -Tag Test -Level VeryVerbose
+        Add-ZtTestResultDetail -SkippedBecause NotApplicable -Result 'No Private Access connectors were detected.'
+        return
     }
+
+    # Step 2: Get the latest version from documentation
+    Write-ZtProgress -Activity $activity -Status 'Getting latest version from documentation'
+    $latestVersion = Get-LatestConnectorVersion
     #endregion Data Collection
 
     #region Assessment Logic
-    if (-not $connectors -or $connectors.Count -eq 0) {
-        $testResultMarkdown = "ℹ️ No private network connectors found in this tenant.`n`n%TestResult%"
-        $passed = $true  # No connectors means nothing to check - pass by default
-    }
-    elseif (-not $latestVersion) {
+    if (-not $latestVersion) {
         $testResultMarkdown = "⚠️ Could not retrieve the latest connector version from documentation. Manual verification required.`n`n%TestResult%"
         $passed = $false # Fail if we can't verify
     }


### PR DESCRIPTION
closes #1264 

Made changes to test 25392 to show skip scenario when there are no private access connectors installed with user facing message: `No Private Access connectors were detected.`

<img width="656" height="284" alt="image" src="https://github.com/user-attachments/assets/29e725c6-f1a6-431f-be02-6d2a3b46f6e8" />
