### PR TITLE
fix: issue-1230 - updated AIP service env for USGovDOD & SecurityCompliance AADAuthEndpointUri

### DIFF
--- a/src/powershell/public/Connect-ZtAssessment.ps1
+++ b/src/powershell/public/Connect-ZtAssessment.ps1
@@ -481,7 +481,7 @@ function Connect-ZtAssessment {
 				$aipEnvironmentName = switch ($Environment) {
 					'China'    { 'AzureChinaCloud' }
 					'USGov'    { 'AzureUSGovernment' }
-					'USGovDoD' { 'AzureUSGovernment2' }
+					'USGovDoD' { 'AzureUSGovernment' }
 					default    { 'AzureCloud' }
 				}
 				if ($ClientId -and $Certificate) {
@@ -585,27 +585,27 @@ function Connect-ZtAssessment {
 			$Environments = @{
 				'O365China'        = @{
 					ConnectionUri    = 'https://ps.compliance.protection.partner.outlook.cn/powershell-liveid'
-					AuthZEndpointUri = 'https://login.chinacloudapi.cn/common'
+					AuthZEndpointUri = 'https://login.chinacloudapi.cn/organizations'
 				}
 				'O365GermanyCloud' = @{
 					ConnectionUri    = 'https://ps.compliance.protection.outlook.com/powershell-liveid/'
-					AuthZEndpointUri = 'https://login.microsoftonline.com/common'
+					AuthZEndpointUri = 'https://login.microsoftonline.com/organizations'
 				}
 				'O365Default'      = @{
 					ConnectionUri    = 'https://ps.compliance.protection.outlook.com/powershell-liveid/'
-					AuthZEndpointUri = 'https://login.microsoftonline.com/common'
+					AuthZEndpointUri = 'https://login.microsoftonline.com/organizations'
 				}
 				'O365USGovGCCHigh' = @{
 					ConnectionUri    = 'https://ps.compliance.protection.office365.us/powershell-liveid/'
-					AuthZEndpointUri = 'https://login.microsoftonline.us/common'
+					AuthZEndpointUri = 'https://login.microsoftonline.us/organizations'
 				}
 				'O365USGovDoD'     = @{
 					ConnectionUri    = 'https://l5.ps.compliance.protection.office365.us/powershell-liveid/'
-					AuthZEndpointUri = 'https://login.microsoftonline.us/common'
+					AuthZEndpointUri = 'https://login.microsoftonline.us/organizations'
 				}
 				Default            = @{
 					ConnectionUri    = 'https://ps.compliance.protection.outlook.com/powershell-liveid/'
-					AuthZEndpointUri = 'https://login.microsoftonline.com/common'
+					AuthZEndpointUri = 'https://login.microsoftonline.com/organizations'
 				}
 			}
 


### PR DESCRIPTION
This PR addresses #1230 

**Issue**

Two bugs were found in `Connect-ZtAssessment` affecting USGovDoD connections:

1. **AIP** : The `USGovDoD` environment path passed `AzureUSGovernment2` to `Connect-AipService`, which is not a valid value. Per the [official docs](https://learn.microsoft.com/en-us/powershell/module/aipservice/connect-aipservice?view=azureipps#-environmentname), the only accepted values are `AzureCloud`, `AzureChinaCloud`, and `AzureUSGovernment`, causing the connection to fail.

2. **Security & Compliance** : The `AzureADAuthorizationEndpointUri` values used `/common` for all environments. The [Connect-IPPSSession docs](https://learn.microsoft.com/en-us/powershell/module/exchangepowershell/connect-ippssession?view=exchange-ps#-azureadauthorizationendpointuri) explicitly recommend `/organizations` for enterprise and government tenants.

**Fix**

1. `USGovDoD` now maps to `AzureUSGovernment` (matching `USGov`) when connecting to AIP via `Connect-AipService`.
2. All `AzureADAuthorizationEndpointUri` values in the Security & Compliance environment map updated from `/common` to `/organizations`.