### PR TITLE
fix: sankey regression

### DIFF
--- a/src/report/src/components/nivo/sankey.tsx
+++ b/src/report/src/components/nivo/sankey.tsx
@@ -11,47 +11,32 @@ type SankeyNode = {
     // other properties...
 };
 
-type SankeyData = {
+export type SankeyData = {
     nodes: SankeyNode[];
-    links: {
-        source: string;
-        target: string;
-        value: number;
-    }[];
+    links: any[]; // replace with the actual type of links
 };
 
-type SankeyInputData = {
-    nodes: SankeyNode[];
-    links: {
-        source: string;
-        target: string;
-        value: number | null;
-    }[];
-};
-
-export const ZtResponsiveSankey = ({ isDark, data }: { isDark:boolean, data: SankeyInputData }) => {
-    const sanitizedLinks = data.links
-        .filter(link => Number.isFinite(Number(link.value)) && Number(link.value) > 0)
-        .map(link => ({ ...link, value: Number(link.value) }));
-
+export const ZtResponsiveSankey = ({ isDark, data }: { isDark:boolean, data: SankeyData }) => {
+    // Filter out nodes that have no connected links to avoid Nivo rendering errors
     const connectedNodeIds = new Set<string>();
-    for (const link of sanitizedLinks) {
+    for (const link of data.links) {
         connectedNodeIds.add(link.source);
         connectedNodeIds.add(link.target);
     }
-
+    const filteredNodes = data.nodes.filter(node => connectedNodeIds.has(node.id));
     const filteredData: SankeyData = {
-        nodes: data.nodes.filter(node => connectedNodeIds.has(node.id)),
-        links: sanitizedLinks
+        nodes: filteredNodes,
+        links: data.links,
     };
 
-    if (filteredData.links.length === 0 || filteredData.nodes.length === 0) {
+    if (data.links.length === 0 || filteredNodes.length === 0) {
         return (
-            <div className={`flex h-full min-h-[8rem] w-full items-center justify-center px-4 text-center text-sm text-muted-foreground ${isDark ? 'sankey-dark-mode' : 'sankey-light-mode'}`}>
+            <div className={`flex h-full min-h-32 w-full items-center justify-center px-4 text-center text-sm text-muted-foreground ${isDark ? 'sankey-dark-mode' : 'sankey-light-mode'}`}>
                 No data available.
             </div>
         );
     }
+
 
     const theme = {
         tooltip: {

--- a/src/report/src/components/nivo/sankey.tsx
+++ b/src/report/src/components/nivo/sankey.tsx
@@ -31,7 +31,7 @@ export const ZtResponsiveSankey = ({ isDark, data }: { isDark:boolean, data: San
 
     if (data.links.length === 0 || filteredNodes.length === 0) {
         return (
-             <div className={`flex h-full min-h-[8rem] w-full items-center justify-center px-4 text-center text-sm text-muted-foreground ${isDark ? 'sankey-dark-mode' : 'sankey-light-mode'}`}>
+            <div className={`flex h-full min-h-[8rem] w-full items-center justify-center px-4 text-center text-sm text-muted-foreground ${isDark ? 'sankey-dark-mode' : 'sankey-light-mode'}`}>
                 No data available.
             </div>
         );

--- a/src/report/src/components/nivo/sankey.tsx
+++ b/src/report/src/components/nivo/sankey.tsx
@@ -31,7 +31,7 @@ export const ZtResponsiveSankey = ({ isDark, data }: { isDark:boolean, data: San
 
     if (data.links.length === 0 || filteredNodes.length === 0) {
         return (
-            <div className={`flex h-full min-h-32 w-full items-center justify-center px-4 text-center text-sm text-muted-foreground ${isDark ? 'sankey-dark-mode' : 'sankey-light-mode'}`}>
+             <div className={`flex h-full min-h-[8rem] w-full items-center justify-center px-4 text-center text-sm text-muted-foreground ${isDark ? 'sankey-dark-mode' : 'sankey-light-mode'}`}>
                 No data available.
             </div>
         );

--- a/src/report/tests/sankey-data.test.ts
+++ b/src/report/tests/sankey-data.test.ts
@@ -1,0 +1,66 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { ZtResponsiveSankey, type SankeyData } from "@/components/nivo/sankey";
+
+function renderComponent(data: SankeyData, isDark = false) {
+  return renderToStaticMarkup(
+    React.createElement(ZtResponsiveSankey, {
+      isDark,
+      data,
+    })
+  );
+}
+
+describe("ZtResponsiveSankey", () => {
+  it("renders the empty state when there are no links", () => {
+    const markup = renderComponent({
+      nodes: [
+        {
+          id: "A",
+          nodeColor: "hsl(28, 100%, 53%)",
+        },
+        {
+          id: "B",
+          nodeColor: "hsl(28, 100%, 53%)",
+        },
+      ],
+      links: [],
+    });
+
+    expect(markup).toContain("No data available.");
+    expect(markup).toContain("sankey-light-mode");
+  });
+
+  it("renders a Sankey chart with real Nivo components when connected nodes and links exist", () => {
+    const renderChart = () =>
+      renderComponent(
+        {
+          nodes: [
+            {
+              id: "Users",
+              nodeColor: "hsl(28, 100%, 53%)",
+            },
+            {
+              id: "MFA",
+              nodeColor: "hsl(200, 100%, 42%)",
+            },
+          ],
+          links: [
+            {
+              source: "Users",
+              target: "MFA",
+              value: 12,
+            },
+          ],
+        },
+        true
+      );
+
+    expect(renderChart).not.toThrow();
+    const markup = renderChart();
+    expect(markup).toContain("sankey-dark-mode");
+    expect(markup).not.toContain("No data available.");
+  });
+});


### PR DESCRIPTION
Rollback previous Sankey fix and apply a minimal `if` guard instead.

The regression test confirms the Sankey path now works for empty links input without the broader previous change. @alexandair 