### PR TITLE
Fixed the remaining concrete Sankey producer bug and added one narrow renderer guard.

### DIFF
--- a/code-tests/commands/Add-ZtOverviewCaDevicesAllUsers.Tests.ps1
+++ b/code-tests/commands/Add-ZtOverviewCaDevicesAllUsers.Tests.ps1
@@ -1,0 +1,57 @@
+Describe "Add-ZtOverviewCaDevicesAllUsers" {
+	BeforeAll {
+		$here = $PSScriptRoot
+		$srcRoot = Join-Path $here "../../src/powershell"
+
+		if (-not (Get-Command Write-PSFMessage -ErrorAction SilentlyContinue)) {
+			function global:Write-PSFMessage {
+				param($Level, $Message, $Tag)
+			}
+		}
+
+		if (-not (Get-Command Write-ZtProgress -ErrorAction SilentlyContinue)) {
+			function global:Write-ZtProgress {
+				param($Activity, $Status)
+			}
+		}
+
+		. (Join-Path $srcRoot "private/tenantinfo/Add-ZtOverviewCaDevicesAllUsers.ps1")
+	}
+
+	BeforeEach {
+		$script:tenantInfo = $null
+
+		Mock Write-PSFMessage {}
+		Mock Write-ZtProgress {}
+		Mock Get-ZtLicenseInformation { 'P2' }
+		Mock Get-ZtSignInDuration { '30 days' }
+		Mock Get-ZtPercentLabel { param($Value, $Total) "$Value/$Total" }
+		Mock Add-ZtTenantInfo {
+			param($Name, $Value)
+			$script:tenantInfo = [pscustomobject]@{
+				Name  = $Name
+				Value = $Value
+			}
+		}
+	}
+
+	It "Should sum managed sign-ins across compliance buckets for Sankey data" {
+		Mock Invoke-DatabaseQuery {
+			@(
+				[pscustomobject]@{ isManaged = $true;  isCompliant = $true;  cnt = 83 }
+				[pscustomobject]@{ isManaged = $true;  isCompliant = $false; cnt = 19 }
+				[pscustomobject]@{ isManaged = $false; isCompliant = $false; cnt = 455 }
+			)
+		}
+
+		Add-ZtOverviewCaDevicesAllUsers -Database 'test'
+
+		$script:tenantInfo.Name | Should -Be 'OverviewCaDevicesAllUsers'
+
+		$nodes = $script:tenantInfo.Value.nodes
+		($nodes | Where-Object { $_.source -eq 'User sign in' -and $_.target -eq 'Managed' }).value | Should -Be 102
+		($nodes | Where-Object { $_.source -eq 'User sign in' -and $_.target -eq 'Unmanaged' }).value | Should -Be 455
+		($nodes | Where-Object { $_.source -eq 'Managed' -and $_.target -eq 'Compliant' }).value | Should -Be 83
+		($nodes | Where-Object { $_.source -eq 'Managed' -and $_.target -eq 'Non-compliant' }).value | Should -Be 19
+	}
+}

--- a/src/powershell/private/tenantinfo/Add-ZtOverviewCaDevicesAllUsers.ps1
+++ b/src/powershell/private/tenantinfo/Add-ZtOverviewCaDevicesAllUsers.ps1
@@ -11,6 +11,16 @@ function Add-ZtOverviewCaDevicesAllUsers {
 	)
 
 	#region Utility Functions
+	function Get-ZtiOverviewCaDevicesCount {
+		[CmdletBinding()]
+		param (
+			[AllowNull()]
+			$Rows
+		)
+
+		(($Rows | Measure-Object -Property cnt -Sum).Sum -as [int]) ?? 0
+	}
+
 	function Get-ZtiOverviewCaDevicesAllUsers {
 		[CmdletBinding()]
 		param (
@@ -19,10 +29,10 @@ function Add-ZtOverviewCaDevicesAllUsers {
 			$Database
 		)
 
-		$managed = ($Results | Where-Object isManaged).cnt -as [int]
-		$unmanaged = ($Results | Where-Object isManaged -EQ $false).cnt -as [int]
-		$compliant = $Results.Where{ $_.isManaged -and $_.isCompliant }.cnt -as [int]
-		$nonCompliant = $Results.Where{ $_.isManaged -and -not $_.isCompliant }.cnt -as [int]
+		$managed = Get-ZtiOverviewCaDevicesCount -Rows ($Results | Where-Object isManaged)
+		$unmanaged = Get-ZtiOverviewCaDevicesCount -Rows ($Results | Where-Object isManaged -EQ $false)
+		$compliant = Get-ZtiOverviewCaDevicesCount -Rows ($Results.Where{ $_.isManaged -and $_.isCompliant })
+		$nonCompliant = Get-ZtiOverviewCaDevicesCount -Rows ($Results.Where{ $_.isManaged -and -not $_.isCompliant })
 
 		$nodes = @(
 			@{

--- a/src/report/src/components/nivo/sankey.tsx
+++ b/src/report/src/components/nivo/sankey.tsx
@@ -30,8 +30,14 @@ type SankeyInputData = {
 };
 
 export const ZtResponsiveSankey = ({ isDark, data }: { isDark:boolean, data: SankeyInputData }) => {
+    const validNodeIds = new Set(data.nodes.map(node => node.id));
     const sanitizedLinks = data.links
-        .filter(link => Number.isFinite(Number(link.value)) && Number(link.value) > 0)
+        .filter(link =>
+            validNodeIds.has(link.source) &&
+            validNodeIds.has(link.target) &&
+            Number.isFinite(Number(link.value)) &&
+            Number(link.value) > 0
+        )
         .map(link => ({ ...link, value: Number(link.value) }));
 
     const connectedNodeIds = new Set<string>();


### PR DESCRIPTION
This fix should close #1310

`src\powershell\private\tenantinfo\Add-ZtOverviewCaDevicesAllUsers.ps1` now sums cnt values before casting. The old code did `($Results | Where-Object isManaged).cnt -as [int]`, which turns the two managed rows into $null instead of the total. That was the likeliest remaining way to emit a broken homepage Sankey graph.

`src\report\src\components\nivo\sankey.tsx` now also drops links whose source or target is not in the declared node list, on top of the existing null/non-positive filtering. That keeps malformed graph topology away from d3-sankey, which is where the Invalid array length error originates.

`code-tests\commands\Add-ZtOverviewCaDevicesAllUsers.Tests.ps1` covers the exact issue shape from #1235/#1272: two managed buckets plus one unmanaged bucket must produce a valid User sign in -> Managed total.