### PR TITLE
ci(pr-validation): refresh WIF login before blob upload to fix AADSTS700024

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -227,6 +227,20 @@ jobs:
               Format-Table | Out-String | Write-Host
           }
 
+      - name: Refresh Azure login before upload (WIF assertion expires on long runs)
+        # The GitHub OIDC token used as the WIF client assertion is short-lived and
+        # has no refresh token. On long assessments the original assertion expires
+        # before the upload requests a Storage data-plane token (AADSTS700024), so
+        # re-login here to mint a fresh assertion. Runs on success AND failure so the
+        # diagnostic report still uploads. Report files live on the runner disk and
+        # are untouched by re-login.
+        if: always() && env.REPORT_PATH != ''
+        uses: azure/login@v2
+        with:
+          client-id:       ${{ env.AZURE_CLIENT_ID }}
+          tenant-id:       ${{ env.AZURE_TENANT_ID }}
+          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
+
       - name: Upload report to private blob container
         if: always() && env.REPORT_PATH != ''
         shell: pwsh
@@ -243,6 +257,13 @@ jobs:
             --source            $env:REPORT_PATH `
             --auth-mode         login `
             --overwrite         true *> $null
+          $uploadExit = $LASTEXITCODE
+
+          # Never report success on a non-zero az exit. az output is intentionally
+          # suppressed (log hygiene); surface only the exit code, not its content.
+          if ($uploadExit -ne 0) {
+            throw "Blob upload failed (az exit $uploadExit)."
+          }
 
           Write-Host "Upload complete."
 


### PR DESCRIPTION
## What
Fixes the `PR Validation (Run Assessment)` workflow, which has been failing since ~Jun 18 at the **Upload report to private blob container** step.

## Root cause
On long assessment runs the GitHub OIDC token used as the WIF **client assertion** expires before the upload step requests an Azure **Storage data-plane** token, so `az storage blob upload-batch` fails with **AADSTS700024** (client assertion not within its valid time range). A newer `windows-latest` runner image slowed the job (~4.5m -> ~12m), pushing the upload past the assertion lifetime and exposing the latent issue. Confirmed via an Entra sign-in log entry (resource: Azure Storage, error 700024).

## Fix
- Add an `azure/login@v2` step immediately before the upload to mint a fresh assertion just-in-time (`if: always()` so the diagnostic report still uploads on failure; report files persist on the runner disk and are untouched by re-login).
- Check `az`'s exit code and `throw` on non-zero so the step can no longer print `Upload complete.` on a failed upload (this false-positive masked the failure).

## Scope
Workflow-only change (`.github/workflows/pr-validation.yml`), branched off `main` — no other commits included.

## Validation
- YAML parses cleanly.
- Log hygiene preserved: no env values, az output, or report paths are echoed.