### PR TITLE
Update test category from 'Device' to 'Devices' for consistency

### DIFF
--- a/src/powershell/tests/Test-Assessment.24540.ps1
+++ b/src/powershell/tests/Test-Assessment.24540.ps1
@@ -8,7 +8,7 @@
 
 function Test-Assessment-24540 {
     [ZtTest(
-        Category = 'Device',
+        Category = 'Devices',
         ImplementationCost = 'Low',
         MinimumLicense = ('Intune'),
         Pillar = 'Devices',

--- a/src/powershell/tests/Test-Assessment.24551.ps1
+++ b/src/powershell/tests/Test-Assessment.24551.ps1
@@ -5,7 +5,7 @@
 
 function Test-Assessment-24551 {
     [ZtTest(
-    	Category = 'Device',
+    	Category = 'Devices',
     	ImplementationCost = 'Medium',
     	MinimumLicense = ('Intune'),
     	Pillar = 'Devices',

--- a/src/powershell/tests/Test-Assessment.24552.ps1
+++ b/src/powershell/tests/Test-Assessment.24552.ps1
@@ -7,7 +7,7 @@
 
 function Test-Assessment-24552 {
     [ZtTest(
-        Category = 'Device',
+        Category = 'Devices',
         ImplementationCost = 'Low',
         MinimumLicense = ('Intune'),
         Pillar = 'Devices',

--- a/src/powershell/tests/Test-Assessment.24553.ps1
+++ b/src/powershell/tests/Test-Assessment.24553.ps1
@@ -5,7 +5,7 @@
 
 function Test-Assessment-24553 {
     [ZtTest(
-    	Category = 'Device',
+    	Category = 'Devices',
     	ImplementationCost = 'Medium',
     	MinimumLicense = ('Intune'),
     	Pillar = 'Devices',

--- a/src/powershell/tests/Test-Assessment.24554.ps1
+++ b/src/powershell/tests/Test-Assessment.24554.ps1
@@ -8,7 +8,7 @@
 
 function Test-Assessment-24554 {
     [ZtTest(
-    	Category = 'Device',
+    	Category = 'Devices',
     	ImplementationCost = 'Low',
     	MinimumLicense = ('Intune'),
     	Pillar = 'Devices',

--- a/src/powershell/tests/Test-Assessment.24560.ps1
+++ b/src/powershell/tests/Test-Assessment.24560.ps1
@@ -5,7 +5,7 @@
 
 function Test-Assessment-24560 {
     [ZtTest(
-    	Category = 'Device',
+    	Category = 'Devices',
     	ImplementationCost = 'Low',
     	MinimumLicense = ('Intune'),
     	Pillar = 'Devices',

--- a/src/powershell/tests/Test-Assessment.24561.ps1
+++ b/src/powershell/tests/Test-Assessment.24561.ps1
@@ -5,7 +5,7 @@
 
 function Test-Assessment-24561 {
     [ZtTest(
-    	Category = 'Device',
+    	Category = 'Devices',
     	ImplementationCost = 'Low',
     	MinimumLicense = ('Intune'),
     	Pillar = 'Devices',

--- a/src/powershell/tests/Test-Assessment.24564.ps1
+++ b/src/powershell/tests/Test-Assessment.24564.ps1
@@ -8,7 +8,7 @@
 
 function Test-Assessment-24564 {
     [ZtTest(
-        Category = 'Device',
+        Category = 'Devices',
         ImplementationCost = 'Low',
         MinimumLicense = ('Intune'),
         Pillar = 'Devices',

--- a/src/powershell/tests/Test-Assessment.24569.ps1
+++ b/src/powershell/tests/Test-Assessment.24569.ps1
@@ -5,7 +5,7 @@
 
 function Test-Assessment-24569 {
     [ZtTest(
-    	Category = 'Device',
+    	Category = 'Devices',
     	ImplementationCost = 'Low',
     	MinimumLicense = ('Intune'),
     	Pillar = 'Devices',

--- a/src/powershell/tests/Test-Assessment.24574.ps1
+++ b/src/powershell/tests/Test-Assessment.24574.ps1
@@ -5,7 +5,7 @@
 
 function Test-Assessment-24574 {
     [ZtTest(
-    	Category = 'Device',
+    	Category = 'Devices',
     	ImplementationCost = 'Medium',
     	MinimumLicense = ('Intune'),
     	Pillar = 'Devices',

--- a/src/powershell/tests/Test-Assessment.24575.ps1
+++ b/src/powershell/tests/Test-Assessment.24575.ps1
@@ -5,7 +5,7 @@
 
 function Test-Assessment-24575 {
     [ZtTest(
-        Category = 'Device',
+        Category = 'Devices',
         ImplementationCost = 'Medium',
         MinimumLicense = ('Intune'),
         Pillar = 'Devices',

--- a/src/powershell/tests/Test-Assessment.24690.ps1
+++ b/src/powershell/tests/Test-Assessment.24690.ps1
@@ -8,7 +8,7 @@
 
 function Test-Assessment-24690 {
     [ZtTest(
-    	Category = 'Device',
+    	Category = 'Devices',
     	ImplementationCost = 'Low',
     	MinimumLicense = ('Intune'),
     	Pillar = 'Devices',

--- a/src/powershell/tests/Test-Assessment.24784.ps1
+++ b/src/powershell/tests/Test-Assessment.24784.ps1
@@ -5,7 +5,7 @@
 
 function Test-Assessment-24784 {
     [ZtTest(
-        Category = 'Device',
+        Category = 'Devices',
         ImplementationCost = 'Low',
         MinimumLicense = ('Intune'),
         Pillar = 'Devices',

--- a/src/powershell/tests/Test-Assessment.51001.ps1
+++ b/src/powershell/tests/Test-Assessment.51001.ps1
@@ -5,7 +5,7 @@
 
 function Test-Assessment-51001 {
     [ZtTest(
-        Category = 'Devices',
+        Category = 'Device',
         CompatibleLicense = ('Intune_Suite'),
         ImplementationCost = 'Medium',
         Pillar = 'Devices',

--- a/src/powershell/tests/Test-Assessment.51001.ps1
+++ b/src/powershell/tests/Test-Assessment.51001.ps1
@@ -5,7 +5,7 @@
 
 function Test-Assessment-51001 {
     [ZtTest(
-        Category = 'Device',
+        Category = 'Devices',
         CompatibleLicense = ('Intune_Suite'),
         ImplementationCost = 'Medium',
         Pillar = 'Devices',


### PR DESCRIPTION
This pull request standardizes the `Category` attribute in multiple PowerShell test scripts by changing its value from `'Device'` to `'Devices'`. 