### PR TITLE
PS5 implicit remoting

### DIFF
--- a/src/powershell/public/Connect-ZtAssessment.ps1
+++ b/src/powershell/public/Connect-ZtAssessment.ps1
@@ -455,7 +455,9 @@ function Connect-ZtAssessment {
 				Write-PSFMessage -Message ('Loading Azure Information Protection required modules: {0}' -f ($resolvedRequiredModules.AipService.Name -join ', ')) -Level Verbose
 				$loadedAipServiceModules = $resolvedRequiredModules.AipService.ForEach{
 					#TODO: only add -UseWindowsPowerShell for the modules in WindowsRequiredModules based on module manifest.
-					$_ | Import-Module -Global -ErrorAction Stop -PassThru -UseWindowsPowerShell -WarningAction SilentlyContinue
+
+					# Use Path (full path to the .psd1 manifest) so WinPS5 implicit remoting can locate the module, even when it is installed under the PS7 module path ([..]\PowerShell\Modules) rather than the WinPS5 path ([..]\WindowsPowerShell\Modules)
+					Import-Module -Name $_.Path -Global -ErrorAction Stop -PassThru -UseWindowsPowerShell -WarningAction SilentlyContinue
 				}
 
 				$loadedAipServiceModules.ForEach{


### PR DESCRIPTION
PS5 implicit remoting does not support auto-loading of nested modules, so we need to explicitly import the required nested modules for AIPService with -UseWindowsPowerShell to ensure they are loaded in the WinPS5 session, as Connect-ZtAssessment is run from PS7.