### PR TITLE
Mark of the Web unblock when loading dependencies

### DIFF
--- a/src/powershell/Initialize-Dependencies.ps1
+++ b/src/powershell/Initialize-Dependencies.ps1
@@ -219,9 +219,12 @@ function Initialize-Dependencies {
                 if ($IsWindows) {
                     $savedModulePath = Join-Path -Path $RequiredModulesPath -ChildPath $moduleSpec.Name
                     if (Test-Path -Path $savedModulePath) {
-Get-ChildItem -Path $savedModulePath -Recurse -File -Filter '*.dll' -ErrorAction SilentlyContinue | Where-Object {
-    (Get-Item -LiteralPath $_.FullName -Stream Zone.Identifier -ErrorAction SilentlyContinue) -and ((Get-Content -LiteralPath $_.FullName -Stream Zone.Identifier -ErrorAction SilentlyContinue) -match 'ZoneId\s*=\s*(3|4)\b')
-} | Unblock-File -ErrorAction SilentlyContinue
+                        Get-ChildItem -Path $savedModulePath -Recurse -File -Filter '*.dll' -ErrorAction SilentlyContinue | ForEach-Object {
+                            $zoneData = Get-Content -LiteralPath $_.FullName -Stream Zone.Identifier -ErrorAction SilentlyContinue
+                            if ($zoneData -match 'ZoneId\s*=\s*(3|4)\b') {
+                                Unblock-File -LiteralPath $_.FullName -ErrorAction SilentlyContinue
+                            }
+                        }
                     }
                 }
             }

--- a/src/powershell/Initialize-Dependencies.ps1
+++ b/src/powershell/Initialize-Dependencies.ps1
@@ -213,6 +213,17 @@ function Initialize-Dependencies {
                     $moduleSpec | &$saveModuleCmd @saveModuleCmdParams
                     Write-Host -Object ('    ⬇️ Module {0} saved successfully.' -f $moduleSpec.Name) -ForegroundColor Green
                 }
+
+                # Unblock files downloaded from the internet so WinPS5 implicit remoting can load their DLLs.
+                # Downloaded files carry a Zone.Identifier ADS mark that causes 0x80131515 when .NET tries to load them.
+                if ($IsWindows) {
+                    $savedModulePath = Join-Path -Path $RequiredModulesPath -ChildPath $moduleSpec.Name
+                    if (Test-Path -Path $savedModulePath) {
+                        Get-ChildItem -Path $savedModulePath -Recurse -File -ErrorAction SilentlyContinue | Where-Object {
+                            ($_ | Get-Item -Stream Zone.Identifier -ErrorAction SilentlyContinue) -and (Get-Content -LiteralPath $_.FullName -Stream Zone.Identifier -ErrorAction SilentlyContinue) -match 'ZoneId\s*=\s*[34]'
+                        } | Unblock-File -ErrorAction SilentlyContinue
+                    }
+                }
             }
             catch
             {

--- a/src/powershell/Initialize-Dependencies.ps1
+++ b/src/powershell/Initialize-Dependencies.ps1
@@ -219,9 +219,9 @@ function Initialize-Dependencies {
                 if ($IsWindows) {
                     $savedModulePath = Join-Path -Path $RequiredModulesPath -ChildPath $moduleSpec.Name
                     if (Test-Path -Path $savedModulePath) {
-                        Get-ChildItem -Path $savedModulePath -Recurse -File -ErrorAction SilentlyContinue | Where-Object {
-                            ($_ | Get-Item -Stream Zone.Identifier -ErrorAction SilentlyContinue) -and (Get-Content -LiteralPath $_.FullName -Stream Zone.Identifier -ErrorAction SilentlyContinue) -match 'ZoneId\s*=\s*[34]'
-                        } | Unblock-File -ErrorAction SilentlyContinue
+Get-ChildItem -Path $savedModulePath -Recurse -File -Filter '*.dll' -ErrorAction SilentlyContinue | Where-Object {
+    (Get-Item -LiteralPath $_.FullName -Stream Zone.Identifier -ErrorAction SilentlyContinue) -and ((Get-Content -LiteralPath $_.FullName -Stream Zone.Identifier -ErrorAction SilentlyContinue) -match 'ZoneId\s*=\s*(3|4)\b')
+} | Unblock-File -ErrorAction SilentlyContinue
                     }
                 }
             }


### PR DESCRIPTION
0x80131515 is the result of Windows Mark of the Web (Zone.Identifier) block. During dependency loading, confirm if MotW would block load and unblock if applicable. Resolves issue #1330 