### PR TITLE
add SecurityIdentitiesSensors.Read.All in scope for secops pillar

### DIFF
--- a/src/powershell/doc/readme.md
+++ b/src/powershell/doc/readme.md
@@ -81,6 +81,7 @@ The consent prompt is only displayed if the Graph PowerShell app does not alread
 - NetworkAccess.Read.All
 - IdentityRiskyServicePrincipal.Read.All
 - CopilotPackages.Read.All
+- SecurityIdentitiesSensors.Read.All
 
 Run the following command to connect to Microsoft Graph and consent to the permissions using a Global Administrator account.
 

--- a/src/powershell/public/Get-ZtGraphScope.ps1
+++ b/src/powershell/public/Get-ZtGraphScope.ps1
@@ -45,6 +45,7 @@
         'NetworkAccess.Read.All'
         'IdentityRiskyServicePrincipal.Read.All'
         'CopilotPackages.Read.All'
+        'SecurityIdentitiesSensors.Read.All'
     )
 
     $scopes | Sort-Object -Unique


### PR DESCRIPTION
The permission is needed for 41002, 41003 SecOps Tests 