### PR TITLE
Adding alias `Tenant` to the `TenantId` parameter

### DIFF
--- a/src/powershell/public/Connect-ZtAssessment.ps1
+++ b/src/powershell/public/Connect-ZtAssessment.ps1
@@ -20,7 +20,7 @@ function Connect-ZtAssessment {
 		Uses Graph Powershell's cached authentication tokens.
 
 	.PARAMETER TenantId
-		The tenant ID to connect to. If not specified, the default tenant will be used.
+		The tenant identifier to connect to. Accepts the tenant id (GUID) or any verified domain name of the tenant. If not specified, the default /organizations will be used. Alias: Tenant.
 
 	.PARAMETER ClientId
 		If specified, connects using a custom application identity. See https://learn.microsoft.com/powershell/microsoftgraph/authentication-commands
@@ -72,6 +72,7 @@ function Connect-ZtAssessment {
 		$UseTokenCache,
 
 		[string]
+		[Alias('Tenant')]
 		$TenantId,
 
 		[string]

--- a/src/powershell/public/Connect-ZtAssessment.ps1
+++ b/src/powershell/public/Connect-ZtAssessment.ps1
@@ -71,8 +71,8 @@ function Connect-ZtAssessment {
 		[switch]
 		$UseTokenCache,
 
-		[string]
 		[Alias('Tenant')]
+		[string]
 		$TenantId,
 
 		[string]


### PR DESCRIPTION
The parameter works equally same with both the tenant GUID and any verified domain name. The name TenantId very binding to the Guid. Adding `Tenant` as alias also aligns to [Connect-AzAccount](https://learn.microsoft.com/en-us/powershell/module/az.accounts/connect-azaccount?view=azps-16.0.0)'s `Tenant` property. This addition does not functionally change anything.