### PR TITLE
Add SecurityIdentitiesHealth.Read.All in scope for secops pillar spec 41018

### DIFF
--- a/src/powershell/doc/readme.md
+++ b/src/powershell/doc/readme.md
@@ -82,6 +82,7 @@ The consent prompt is only displayed if the Graph PowerShell app does not alread
 - IdentityRiskyServicePrincipal.Read.All
 - CopilotPackages.Read.All
 - SecurityIdentitiesSensors.Read.All
+- SecurityIdentitiesHealth.Read.All
 
 Run the following command to connect to Microsoft Graph and consent to the permissions using a Global Administrator account.
 

--- a/src/powershell/public/Get-ZtGraphScope.ps1
+++ b/src/powershell/public/Get-ZtGraphScope.ps1
@@ -46,6 +46,7 @@
         'IdentityRiskyServicePrincipal.Read.All'
         'CopilotPackages.Read.All'
         'SecurityIdentitiesSensors.Read.All'
+        'SecurityIdentitiesHealth.Read.All'
     )
 
     $scopes | Sort-Object -Unique


### PR DESCRIPTION
The permission is needed for 41018 SecOps Tests