### PR TITLE
Tests requiring EXO or SPO must not be run in parallel. 

### DIFF
--- a/src/powershell/private/tests/Invoke-ZtTests.ps1
+++ b/src/powershell/private/tests/Invoke-ZtTests.ps1
@@ -118,9 +118,9 @@
 	$testsToRun = $testsToRun.Where{ $_.TestId -notin $skippedTestsForService.TestId }
 
 	# Separate Sync Tests (Compliance/ExchangeOnline/SharePointOnline/AIP) from Parallel Tests (because of DLL order to manage in runspaces & remoting into WPS)
-	# Tests that depend on SecurityCompliance/ExchangeOnline/SharePointOnline must run on the main thread
+	# Tests that depend on SecurityCompliance/ExchangeOnline/SharePointOnline/AIPService must run on the main thread
 	# regardless of pillar: those services expose their cmdlets through dynamically-generated, connection-bound
-	# proxy modules (Connect-IPPSSession / Connect-ExchangeOnline / Connect-SPOService) that only exist in the
+	# proxy modules (Connect-IPPSSession / Connect-ExchangeOnline / Connect-SPOService / Connect-AipService) that only exist in the
 	# main runspace where Connect-ZtAssessment ran. In a worker runspace those cmdlets are "not recognized",
 	# so such tests would incorrectly skip (e.g. Get-SafeLinksPolicy, Get-OrganizationConfig, Get-SPOTenant).
 	$mainThreadServices = 'SecurityCompliance', 'ExchangeOnline', 'SharePointOnline', 'AipService'

--- a/src/powershell/private/tests/Invoke-ZtTests.ps1
+++ b/src/powershell/private/tests/Invoke-ZtTests.ps1
@@ -111,15 +111,21 @@
 	$skippedTestsForService.ForEach{
 		$notConnectedService = ($_).Service.Where{ $_ -notin $ConnectedService }
 		# Mark the test as skipped.
+		Write-PSFMessage -Message ('Test {0} is skipped because no service connection was found' -f $_.TestId) -Level Verbose
 		Add-ZtTestResultDetail -SkippedBecause NotConnectedToService -TestId $_.TestId -NotConnectedService $notConnectedService
 	}
 
 	$testsToRun = $testsToRun.Where{ $_.TestId -notin $skippedTestsForService.TestId }
 
 	# Separate Sync Tests (Compliance/ExchangeOnline/SharePointOnline) from Parallel Tests (because of DLL order to manage in runspaces & remoting into WPS)
-	# Tests that depend on SecurityCompliance remoting must run on the main thread regardless of pillar.
+	# Tests that depend on SecurityCompliance/ExchangeOnline/SharePointOnline must run on the main thread
+	# regardless of pillar: those services expose their cmdlets through dynamically-generated, connection-bound
+	# proxy modules (Connect-IPPSSession / Connect-ExchangeOnline / Connect-SPOService) that only exist in the
+	# main runspace where Connect-ZtAssessment ran. In a worker runspace those cmdlets are "not recognized",
+	# so such tests would incorrectly skip (e.g. Get-SafeLinksPolicy, Get-OrganizationConfig, Get-SPOTenant).
+	[string[]]$mainThreadServices = @('SecurityCompliance', 'ExchangeOnline', 'SharePointOnline')
 	[int[]]$syncTestIds   = $testsToRun.Where{
-		$_.Pillar -contains 'Data' -or $_.Service -contains 'SecurityCompliance'
+		$_.Pillar -contains 'Data' -or ($_.Service | Where-Object { $_ -in $mainThreadServices })
 	}.TestId
 	$syncTests     = $testsToRun.Where{ $_.TestId -in $syncTestIds }
 	$parallelTests = $testsToRun.Where{ $_.TestId -notin $syncTestIds }

--- a/src/powershell/private/tests/Invoke-ZtTests.ps1
+++ b/src/powershell/private/tests/Invoke-ZtTests.ps1
@@ -117,18 +117,18 @@
 
 	$testsToRun = $testsToRun.Where{ $_.TestId -notin $skippedTestsForService.TestId }
 
-	# Separate Sync Tests (Compliance/ExchangeOnline/SharePointOnline) from Parallel Tests (because of DLL order to manage in runspaces & remoting into WPS)
+	# Separate Sync Tests (Compliance/ExchangeOnline/SharePointOnline/AIP) from Parallel Tests (because of DLL order to manage in runspaces & remoting into WPS)
 	# Tests that depend on SecurityCompliance/ExchangeOnline/SharePointOnline must run on the main thread
 	# regardless of pillar: those services expose their cmdlets through dynamically-generated, connection-bound
 	# proxy modules (Connect-IPPSSession / Connect-ExchangeOnline / Connect-SPOService) that only exist in the
 	# main runspace where Connect-ZtAssessment ran. In a worker runspace those cmdlets are "not recognized",
 	# so such tests would incorrectly skip (e.g. Get-SafeLinksPolicy, Get-OrganizationConfig, Get-SPOTenant).
-	[string[]]$mainThreadServices = @('SecurityCompliance', 'ExchangeOnline', 'SharePointOnline')
-	[int[]]$syncTestIds   = $testsToRun.Where{
-		$_.Pillar -contains 'Data' -or ($_.Service | Where-Object { $_ -in $mainThreadServices })
-	}.TestId
-	$syncTests     = $testsToRun.Where{ $_.TestId -in $syncTestIds }
-	$parallelTests = $testsToRun.Where{ $_.TestId -notin $syncTestIds }
+	$mainThreadServices = 'SecurityCompliance', 'ExchangeOnline', 'SharePointOnline', 'AipService'
+
+	$syncTests, $parallelTests = $testsToRun.Where({
+		$_.Pillar -contains 'Data' -or
+		@($_.Service).Where({ $_ -in $mainThreadServices })
+	}, 'Split')
 
 	[dateTime] $startTime = [datetime]::Now
 	$workflow = $null


### PR DESCRIPTION
The current check only does this for _all_ Data pillar tests, or tests that use SecurityCompliance service. This change adds EXO and SPO to the SecurityCompliance as services.

Potential further improvement - completely remove the Pillar check and only leave the required services check. This is more reliable and even can have the side effect of pushing Data checks to parallel if there is now (or in the future) such that only use Graph or Azure.

Addresses #1360