### PR TITLE
Group Membership Resolution - Increased pagesize

### DIFF
--- a/src/powershell/private/graph/Get-ZtGroupMember.ps1
+++ b/src/powershell/private/graph/Get-ZtGroupMember.ps1
@@ -42,10 +42,10 @@
 		Write-PSFMessage -Message "Retrieving group members for {0}." -StringValues "$GroupId"
 
 		if ($Recurse) {
-			Invoke-ZtGraphRequest -RelativeUri "groups/$GroupId/transitiveMembers" -ApiVersion v1.0 -OutputType $OutputType
+			Invoke-ZtGraphRequest -RelativeUri "groups/$GroupId/transitiveMembers" -Top 999 -ApiVersion v1.0 -OutputType $OutputType
 		}
 		else {
-			Invoke-ZtGraphRequest -RelativeUri "groups/$GroupId/members" -ApiVersion v1.0 -OutputType $OutputType
+			Invoke-ZtGraphRequest -RelativeUri "groups/$GroupId/members" -Top 999 -ApiVersion v1.0 -OutputType $OutputType
 		}
 	}
 }


### PR DESCRIPTION
Resolving members for large groups does not, after all, have to take half an hour.
Updated page-size from default to maximum