### PR TITLE
Implement error sanitization and reporting improvements in tests

### DIFF
--- a/code-tests/commands/ErrorSanitization.Tests.ps1
+++ b/code-tests/commands/ErrorSanitization.Tests.ps1
@@ -1,0 +1,138 @@
+Describe "Error sanitization" {
+	BeforeAll {
+		$here = $PSScriptRoot
+		$srcRoot = Join-Path $here "../../src/powershell"
+
+		. (Join-Path $srcRoot "private/core/Protect-ZtReportText.ps1")
+		. (Join-Path $srcRoot "private/core/Get-ZtHttpStatusCode.ps1")
+		. (Join-Path $srcRoot "private/tests/Get-ZtSafeErrorMessage.ps1")
+		. (Join-Path $srcRoot "private/tests/New-ZtSafeErrorRecord.ps1")
+		. (Join-Path $srcRoot "private/tests/Format-ZtTestErrorDetail.ps1")
+		. (Join-Path $srcRoot "private/tests/Write-ZtTestError.ps1")
+		. (Join-Path $srcRoot "private/tests/Write-ZtTestLog.ps1")
+		. (Join-Path $srcRoot "private/core/Add-ZtTestResultDetail.ps1")
+
+		function New-CanaryErrorRecord {
+			$script:canaryToken = 'eyJhbGciOiJub25lIn0.eyJhcHBpZCI6InJlZGFjdGlvbi10ZXN0In0.signature'
+			$request = [System.Net.Http.HttpRequestMessage]::new([System.Net.Http.HttpMethod]::Get, "https://graph.microsoft.com/beta/example?access_token=$script:canaryToken")
+			$request.Headers.Authorization = [System.Net.Http.Headers.AuthenticationHeaderValue]::new('Bearer', $script:canaryToken)
+			$exception = [System.Exception]::new(@"
+Exception calling ""InvokeGlobal"" with ""1"" argument(s): ""GET https://graph.microsoft.com/beta/example?access_token=$script:canaryToken
+HTTP/1.1 401 Unauthorized
+request-id: 11111111-1111-1111-1111-111111111111
+client-request-id: 22222222-2222-2222-2222-222222222222
+Authorization: Bearer $script:canaryToken
+Cookie: session=example-cookie
+{"error":{"code":"UnknownError","message":"example response body"}}
+"@)
+
+			return [System.Management.Automation.ErrorRecord]::new(
+				$exception,
+				'GraphRequestFailed',
+				[System.Management.Automation.ErrorCategory]::PermissionDenied,
+				$request
+			)
+		}
+	}
+
+	BeforeEach {
+		$script:__ZtSession = @{
+			TestResultDetail = [PSCustomObject]@{ Value = @{} }
+		}
+		$script:loggedErrorRecord = $null
+		$script:addedResult = $null
+
+		function Write-PSFMessage {
+			param($Level, $Message, $StringValues, $Target, $ErrorRecord, $Tag)
+			$script:loggedErrorRecord = $ErrorRecord
+		}
+
+		function Update-ZtProgressState {}
+		function Write-ZtProgress {}
+
+		function Get-ZtTest {
+			param([switch] $Current, $Tests)
+			return [PSCustomObject]@{
+				TestId = '99999'
+				Title = 'Canary test'
+				Pillar = 'Identity'
+				SfiPillar = $null
+				MinimumLicense = $null
+				CompatibleLicense = $null
+			}
+		}
+	}
+
+	It "formats Graph failures with safe troubleshooting details only" {
+		$errorRecord = New-CanaryErrorRecord
+		$test = [PSCustomObject]@{ TestID = '99999' }
+
+		$result = Format-ZtTestErrorDetail -Test $test -ErrorRecord $errorRecord
+
+		$result | Should -Match 'Graph request failed: GET https://graph.microsoft.com/beta/example'
+		$result | Should -Match 'HTTP status: 401 Unauthorized'
+		$result | Should -Match 'Graph error code: UnknownError'
+		$result | Should -Match 'Request ID: 11111111-1111-1111-1111-111111111111'
+		$result | Should -Match 'Client request ID: 22222222-2222-2222-2222-222222222222'
+		$result | Should -Match 'HTTP Status Code: 401'
+		$result | Should -Match 'GraphRequestFailed'
+		$result | Should -Not -Match [regex]::Escape($script:canaryToken)
+		$result | Should -Not -Match 'Authorization:|Cookie:|example response body|access_token='
+	}
+
+	It "stores and logs only a sanitized error record for parallel failures" {
+		$errorRecord = New-CanaryErrorRecord
+		$test = [PSCustomObject]@{ TestID = '99999'; Title = 'Canary test' }
+		$executionResult = [PSCustomObject]@{ Success = $true; Error = $null; DisplayName = 'Canary test' }
+
+		Mock Add-ZtTestResultDetail {
+			param($TestId, $Title, $Status, $Result, $CustomStatus)
+			$script:addedResult = $Result
+		}
+
+		Write-ZtTestError -Test $test -Result $executionResult -ErrorRecord $errorRecord
+
+		$executionResult.Error.TargetObject | Should -BeNullOrEmpty
+		$script:loggedErrorRecord.TargetObject | Should -BeNullOrEmpty
+		$script:addedResult | Should -Not -Match [regex]::Escape($script:canaryToken)
+		$script:addedResult | Should -Not -Match 'Authorization:'
+	}
+
+	It "redacts credential headers at the TestResult persistence boundary" {
+		$unsafeResult = @(
+			'Authorization: Bearer example-canary-token'
+			'Cookie: session=example-cookie'
+			'X-Api-Key: example-api-key'
+		) -join "`n"
+
+		Add-ZtTestResultDetail -TestId '99999' -Title 'Canary test' -Description 'Canary description' -Status $false -Result $unsafeResult -CustomStatus Error
+
+		$storedResult = $script:__ZtSession.TestResultDetail.Value['99999'].TestResult
+		$storedResult | Should -Not -Match 'example-canary-token|example-cookie|example-api-key'
+		$storedResult | Should -Match '<redacted>'
+	}
+
+	It "writes only the safe error summary to optional test logs" {
+		$errorRecord = New-CanaryErrorRecord
+		$safeError = New-ZtSafeErrorRecord -ErrorRecord $errorRecord
+		$logsPath = Join-Path $TestDrive 'logs'
+		$test = [PSCustomObject]@{ TestID = '99999'; Title = 'Canary test' }
+		$executionResult = [PSCustomObject]@{
+			TestID = '99999'
+			Test = $test
+			Success = $false
+			TimedOut = $false
+			Duration = [TimeSpan]::Zero
+			Start = Get-Date
+			End = Get-Date
+			Error = $safeError
+			Messages = @()
+		}
+
+		Write-ZtTestLog -Result $executionResult -LogsPath $logsPath
+
+		$logContent = Get-Content (Join-Path $logsPath '2-Tests/99999.md') -Raw
+		$logContent | Should -Not -Match [regex]::Escape($script:canaryToken)
+		$logContent | Should -Not -Match 'Authorization:'
+	}
+}

--- a/code-tests/commands/ErrorSanitization.Tests.ps1
+++ b/code-tests/commands/ErrorSanitization.Tests.ps1
@@ -5,6 +5,7 @@ Describe "Error sanitization" {
 
 		. (Join-Path $srcRoot "private/core/Protect-ZtReportText.ps1")
 		. (Join-Path $srcRoot "private/core/Get-ZtHttpStatusCode.ps1")
+		. (Join-Path $srcRoot "private/core/Get-ZtTestStatus.ps1")
 		. (Join-Path $srcRoot "private/tests/Get-ZtSafeErrorMessage.ps1")
 		. (Join-Path $srcRoot "private/tests/New-ZtSafeErrorRecord.ps1")
 		. (Join-Path $srcRoot "private/tests/Format-ZtTestErrorDetail.ps1")
@@ -103,12 +104,13 @@ Cookie: session=example-cookie
 			'Authorization: Bearer example-canary-token'
 			'Cookie: session=example-cookie'
 			'X-Api-Key: example-api-key'
+			'https://example.test/callback?access_token=example-access-token&client_secret=example-client-secret&sig=example-signature'
 		) -join "`n"
 
 		Add-ZtTestResultDetail -TestId '99999' -Title 'Canary test' -Description 'Canary description' -Status $false -Result $unsafeResult -CustomStatus Error
 
 		$storedResult = $script:__ZtSession.TestResultDetail.Value['99999'].TestResult
-		$storedResult | Should -Not -Match 'example-canary-token|example-cookie|example-api-key'
+		$storedResult | Should -Not -Match 'example-canary-token|example-cookie|example-api-key|example-access-token|example-client-secret|example-signature'
 		$storedResult | Should -Match '<redacted>'
 	}
 

--- a/src/powershell/private/core/Add-ZtTestResultDetail.ps1
+++ b/src/powershell/private/core/Add-ZtTestResultDetail.ps1
@@ -177,6 +177,8 @@ function Add-ZtTestResultDetail {
 		$Result = $Result -replace "%TestResult%", $graphResultMarkdown
 	}
 
+	$Result = Protect-ZtReportText -Text $Result
+
 	# Check if the docs team have provided a title for the test and use it if available
 
 	$docsTitle = $Title # Default to the title provided in the parameter

--- a/src/powershell/private/core/Protect-ZtReportText.ps1
+++ b/src/powershell/private/core/Protect-ZtReportText.ps1
@@ -1,0 +1,30 @@
+function Protect-ZtReportText {
+	<#
+	.SYNOPSIS
+		Removes common HTTP credentials from report content.
+
+	.DESCRIPTION
+		Redacts credential-bearing HTTP headers and bearer/basic authorization
+		values before text is persisted in assessment artifacts. This is a
+		defense-in-depth control; callers should not serialize arbitrary request
+		or response objects into report content.
+	#>
+	[CmdletBinding()]
+	[OutputType([string])]
+	param (
+		[AllowNull()]
+		[string]
+		$Text
+	)
+	process {
+		if ($null -eq $Text) {
+			return $null
+		}
+
+		$credentialHeaderPattern = '(?im)(\b(?:proxy-)?authorization|\bcookie|\bset-cookie|\bx-api-key|\bapi-key|\bocp-apim-subscription-key)\s*[:=]\s*[^\r\n,;}\]]+'
+		$sanitizedText = [regex]::Replace($Text, $credentialHeaderPattern, '$1: <redacted>')
+		$bearerPattern = '(?i)\bBearer\s+[A-Za-z0-9\-._~+/]+=*'
+
+		return [regex]::Replace($sanitizedText, $bearerPattern, 'Bearer <redacted>')
+	}
+}

--- a/src/powershell/private/core/Protect-ZtReportText.ps1
+++ b/src/powershell/private/core/Protect-ZtReportText.ps1
@@ -24,7 +24,9 @@ function Protect-ZtReportText {
 		$credentialHeaderPattern = '(?im)(\b(?:proxy-)?authorization|\bcookie|\bset-cookie|\bx-api-key|\bapi-key|\bocp-apim-subscription-key)\s*[:=]\s*[^\r\n,;}\]]+'
 		$sanitizedText = [regex]::Replace($Text, $credentialHeaderPattern, '$1: <redacted>')
 		$bearerPattern = '(?i)\bBearer\s+[A-Za-z0-9\-._~+/]+=*'
+		$sanitizedText = [regex]::Replace($sanitizedText, $bearerPattern, 'Bearer <redacted>')
+		$querySecretPattern = '(?i)(\b(?:access_token|client_secret|refresh_token|id_token|assertion|sig|token)\b\s*=\s*)[^&\s"''\r\n]+'
 
-		return [regex]::Replace($sanitizedText, $bearerPattern, 'Bearer <redacted>')
+		return [regex]::Replace($sanitizedText, $querySecretPattern, '$1<redacted>')
 	}
 }

--- a/src/powershell/private/tests/Format-ZtTestErrorDetail.ps1
+++ b/src/powershell/private/tests/Format-ZtTestErrorDetail.ps1
@@ -1,0 +1,44 @@
+function Format-ZtTestErrorDetail {
+	<#
+	.SYNOPSIS
+		Formats safe diagnostic details for a failed assessment test.
+
+	.DESCRIPTION
+		Creates the existing failed-test markdown structure from allow-listed
+		error properties. It intentionally does not format arbitrary ErrorRecord
+		properties such as TargetObject, request headers, or exception data.
+	#>
+	[CmdletBinding()]
+	[OutputType([string])]
+	param (
+		[Parameter(Mandatory)]
+		$Test,
+
+		[Parameter(Mandatory)]
+		[System.Management.Automation.ErrorRecord]
+		$ErrorRecord
+	)
+	process {
+		$safeError = New-ZtSafeErrorRecord -ErrorRecord $ErrorRecord
+		$details = [System.Collections.Generic.List[string]]::new()
+		$details.Add("Exception Type: $($ErrorRecord.Exception.GetType().FullName)")
+		$details.Add("Fully Qualified Error ID: $($safeError.FullyQualifiedErrorId)")
+
+		$statusCode = Get-ZtHttpStatusCode -ErrorRecord $ErrorRecord
+		if ($null -ne $statusCode) {
+			$details.Add("HTTP Status Code: $statusCode")
+		}
+
+		if ($ErrorRecord.InvocationInfo -and $ErrorRecord.InvocationInfo.ScriptName) {
+			$details.Add("Location: $($ErrorRecord.InvocationInfo.ScriptName):$($ErrorRecord.InvocationInfo.ScriptLineNumber)")
+		}
+
+		return @(
+			'❌  Test {0} failed due to an unexpected error.' -f $Test.TestID
+			' - **Error Message**: {0}.' -f $safeError.Exception.Message
+			'```'
+			($details -join [Environment]::NewLine)
+			'```'
+		) -join "`r`n"
+	}
+}

--- a/src/powershell/private/tests/Get-ZtSafeErrorMessage.ps1
+++ b/src/powershell/private/tests/Get-ZtSafeErrorMessage.ps1
@@ -1,0 +1,68 @@
+function Get-ZtSafeErrorMessage {
+	<#
+	.SYNOPSIS
+		Builds a diagnostic summary that is safe to persist.
+
+	.DESCRIPTION
+		Extracts a small allow-list of HTTP and Microsoft Graph diagnostic fields
+		from an ErrorRecord. It never returns an unstructured exception message,
+		request header dump, response body, or URL query string.
+	#>
+	[CmdletBinding()]
+	[OutputType([string])]
+	param (
+		[Parameter(Mandatory)]
+		[System.Management.Automation.ErrorRecord]
+		$ErrorRecord
+	)
+	process {
+		$diagnostics = [System.Collections.Generic.List[string]]::new()
+		$errorText = @(
+			$ErrorRecord.Exception.Message
+			$ErrorRecord.ErrorDetails.Message
+		) -join [Environment]::NewLine
+
+		$requestMatch = [regex]::Match($errorText, '(?i)\b(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\s+(https?://[^\s"'']+)')
+		if ($requestMatch.Success) {
+			$method = $requestMatch.Groups[1].Value.ToUpperInvariant()
+			$requestUri = $requestMatch.Groups[2].Value
+			try {
+				$uri = [System.Uri]$requestUri
+				$requestUri = $uri.GetLeftPart([System.UriPartial]::Path)
+			}
+			catch {
+				$requestUri = $requestUri -replace '\?[^\s"'']*$', ''
+			}
+			$diagnostics.Add("Graph request failed: $method $requestUri")
+		}
+
+		$statusCode = Get-ZtHttpStatusCode -ErrorRecord $ErrorRecord
+		if ($null -ne $statusCode) {
+			$reasonMatch = [regex]::Match($errorText, "(?im)^HTTP/\S+\s+$statusCode\s+([^\r\n]+)")
+			$reason = if ($reasonMatch.Success) { $reasonMatch.Groups[1].Value.Trim() } else { $null }
+			$statusDescription = if ($reason) { "$statusCode $reason" } else { "$statusCode" }
+			$diagnostics.Add("HTTP status: $statusDescription")
+		}
+
+		$graphCodeMatch = [regex]::Match($errorText, '"code"\s*:\s*"([A-Za-z0-9_.-]+)"')
+		if ($graphCodeMatch.Success) {
+			$diagnostics.Add("Graph error code: $($graphCodeMatch.Groups[1].Value)")
+		}
+
+		$requestIdMatch = [regex]::Match($errorText, '(?im)^\s*request-id\s*:\s*([0-9a-f-]{36})\s*$')
+		if ($requestIdMatch.Success) {
+			$diagnostics.Add("Request ID: $($requestIdMatch.Groups[1].Value)")
+		}
+
+		$clientRequestIdMatch = [regex]::Match($errorText, '(?im)^\s*client-request-id\s*:\s*([0-9a-f-]{36})\s*$')
+		if ($clientRequestIdMatch.Success) {
+			$diagnostics.Add("Client request ID: $($clientRequestIdMatch.Groups[1].Value)")
+		}
+
+		if ($diagnostics.Count -eq 0) {
+			return 'An unexpected error occurred. See the error details for the exception type and error ID.'
+		}
+
+		$diagnostics -join [Environment]::NewLine
+	}
+}

--- a/src/powershell/private/tests/Get-ZtSafeErrorMessage.ps1
+++ b/src/powershell/private/tests/Get-ZtSafeErrorMessage.ps1
@@ -63,6 +63,6 @@ function Get-ZtSafeErrorMessage {
 			return 'An unexpected error occurred. See the error details for the exception type and error ID.'
 		}
 
-		$diagnostics -join [Environment]::NewLine
+		$diagnostics -join '; '
 	}
 }

--- a/src/powershell/private/tests/Invoke-ZtTest.ps1
+++ b/src/powershell/private/tests/Invoke-ZtTest.ps1
@@ -168,18 +168,13 @@
 			}
 		}
 		catch {
-			Write-PSFMessage -Level Warning -Message "Error executing test '{0}': {1}" -StringValues $Test.TestID, $_.Exception.Message -Target $Test -ErrorRecord $_
+			$safeError = New-ZtSafeErrorRecord -ErrorRecord $_
+			Write-PSFMessage -Level Warning -Message "Error executing test '{0}': {1}" -StringValues $Test.TestID, $safeError.Exception.Message -Target $Test -ErrorRecord $safeError
 			$result.Success = $false
-			$result.Error = $_
-			$message = @(
-				'❌  Test {0} failed due to an unexpected error.' -f $Test.TestID
-				' - **Error Message**: {0}.' -f $_.Exception.Message
-				'```'
-				'{0}' -f ($_ | Get-Error | Out-String)
-				'```'
-			) -join "`r`n"
+			$result.Error = $safeError
+			$message = Format-ZtTestErrorDetail -Test $Test -ErrorRecord $_
 			Add-ZtTestResultDetail -TestId $Test.TestID -Title $Test.Title -Status $false -Result $message -CustomStatus 'Error'
-			Update-ZtProgressState -WorkerId $Test.TestID -WorkerName $result.DisplayName -WorkerStatus 'Error' -WorkerDetail "Error: $($_.Exception.Message)"
+			Update-ZtProgressState -WorkerId $Test.TestID -WorkerName $result.DisplayName -WorkerStatus 'Error' -WorkerDetail "Error: $($safeError.Exception.Message)"
 		}
 		finally {
 			$result.End = Get-Date

--- a/src/powershell/private/tests/New-ZtSafeErrorRecord.ps1
+++ b/src/powershell/private/tests/New-ZtSafeErrorRecord.ps1
@@ -1,0 +1,31 @@
+function New-ZtSafeErrorRecord {
+	<#
+	.SYNOPSIS
+		Creates a safe copy of an error record for assessment diagnostics.
+
+	.DESCRIPTION
+		Builds a new ErrorRecord without the original TargetObject, which can
+		contain HTTP request or response objects with credentials. Its message is
+		rebuilt from allow-listed diagnostic fields before use in reports and
+		diagnostic artifacts.
+	#>
+	[CmdletBinding()]
+	[OutputType([System.Management.Automation.ErrorRecord])]
+	param (
+		[Parameter(Mandatory)]
+		[System.Management.Automation.ErrorRecord]
+		$ErrorRecord
+	)
+	process {
+		$message = Get-ZtSafeErrorMessage -ErrorRecord $ErrorRecord
+		$exception = [System.Exception]::new($message)
+		$errorId = $ErrorRecord.FullyQualifiedErrorId
+
+		return [System.Management.Automation.ErrorRecord]::new(
+			$exception,
+			$errorId,
+			$ErrorRecord.CategoryInfo.Category,
+			$null
+		)
+	}
+}

--- a/src/powershell/private/tests/Write-ZtTestError.ps1
+++ b/src/powershell/private/tests/Write-ZtTestError.ps1
@@ -33,17 +33,12 @@
 		$ErrorRecord
 	)
 	process {
-		Write-PSFMessage -Level Warning -Message "Error executing test '{0}': {1}" -StringValues $Test.TestID, $ErrorRecord.Exception.Message -Target $Test -ErrorRecord $ErrorRecord
+		$safeError = New-ZtSafeErrorRecord -ErrorRecord $ErrorRecord
+		Write-PSFMessage -Level Warning -Message "Error executing test '{0}': {1}" -StringValues $Test.TestID, $safeError.Exception.Message -Target $Test -ErrorRecord $safeError
 		$Result.Success = $false
-		$Result.Error = $ErrorRecord
-		$message = @(
-			'❌  Test {0} failed due to an unexpected error.' -f $Test.TestID
-			' - **Error Message**: {0}.' -f $ErrorRecord.Exception.Message
-			'```'
-			'{0}' -f ($ErrorRecord | Get-Error | Out-String)
-			'```'
-		) -join "`r`n"
+		$Result.Error = $safeError
+		$message = Format-ZtTestErrorDetail -Test $Test -ErrorRecord $ErrorRecord
 		Add-ZtTestResultDetail -TestId $Test.TestID -Title $Test.Title -Status $false -Result $message -CustomStatus 'Error'
-		Update-ZtProgressState -WorkerId $Test.TestID -WorkerName $Result.DisplayName -WorkerStatus 'Error' -WorkerDetail "Error: $($ErrorRecord.Exception.Message)"
+		Update-ZtProgressState -WorkerId $Test.TestID -WorkerName $Result.DisplayName -WorkerStatus 'Error' -WorkerDetail "Error: $($safeError.Exception.Message)"
 	}
 }


### PR DESCRIPTION
Fix #1422 

This pull request introduces a comprehensive overhaul of error sanitization for PowerShell test diagnostics to prevent sensitive credential data from being persisted in logs, reports, or error records. The main improvements include a new defense-in-depth sanitization function, safe error record/message generation, and updated error formatting and logging logic to ensure only allow-listed diagnostic fields are exposed. Extensive tests are added to validate these protections.

**Error sanitization and redaction:**

* Added `Protect-ZtReportText` function to redact credential-bearing HTTP headers and sensitive values from report content before persistence, and integrated it into `Add-ZtTestResultDetail`.
* Updated test result persistence and logging to always sanitize error details, including at the TestResult persistence boundary and in optional test logs.

**Safe error record and message generation:**

* Introduced `New-ZtSafeErrorRecord` to create sanitized error records with only allow-listed diagnostic fields and without unsafe TargetObject data. This prevents request/response objects containing bearer tokens from being retained in test statistics or passed into logging.
* Added `Get-ZtSafeErrorMessage` to extract safe, structured diagnostic summaries (request method/path, HTTP status, Graph error code, and correlation IDs) from error records, omitting unstructured exception messages, headers, and response bodies.

**Error formatting and reporting:**

* Implemented `Format-ZtTestErrorDetail` to generate markdown-formatted error summaries using only sanitized fields for failed tests. It adds bounded metadata such as exception type, error ID, HTTP status, and source location.
* Refactored error handling in `Invoke-ZtTest.ps1` and `Write-ZtTestError.ps1` to use the new safe error record/message pipeline, ensuring all error reporting is sanitized and consistent.

**Testing:**

* Added `ErrorSanitization.Tests.ps1` with comprehensive tests to verify that credentials and sensitive values are never persisted in logs or reports, and that only safe diagnostic information is exposed.