### PR TITLE
Fix cache check logic in Invoke-ZtGraphRequestCache

### DIFF
--- a/src/powershell/private/core/Invoke-ZtGraphRequestCache.ps1
+++ b/src/powershell/private/core/Invoke-ZtGraphRequestCache.ps1
@@ -82,10 +82,11 @@
 		$cacheKey = "$cacheKey|$headerString"
 	}
 	$cachedResult = $script:__ZtSession.GraphCache.Value[$cacheKey]
+	$isCached = $cachedResult -or $script:__ZtSession.GraphCache.Value.ContainsKey($CacheKey)
 	$isMethodGet = $Method -eq 'GET'
 
 	# Don't read from cache for batch requests.
-	if (-not $cacheBlocked -and -not $DisableCache -and -not $isBatch -and $cachedResult -and $isMethodGet) {
+	if (-not $cacheBlocked -and -not $DisableCache -and -not $isBatch -and $isCached -and $isMethodGet) {
 		Write-PSFMessage "Using graph cache: $($cacheKey)" -Level Debug
 		return $cachedResult
 	}


### PR DESCRIPTION
Updated to respect empty results from cache in most cases (some extremely rare concurrency issues might lead to an extra request, but should not be relevant in virtually any relevant case imaginable)