### PR TITLE
Moving Infrastructure, SecOps and AI out of Preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Connect-ZtAssessment
 Invoke-ZtAssessment
 ```
 
+By default, `Invoke-ZtAssessment` now runs all current pillars: Identity, Devices, Network, Data, Infrastructure, SecOps, and AI. The `-Preview` switch is reserved for future preview-only features.
+
 ## Infrastructure Pillar Scope
 
 Infrastructure pillar results are based on Microsoft Defender for Cloud recommendations and only include Azure subscriptions tagged with `ZeroTrustAssessment:Infrastructure`.

--- a/src/powershell/doc/readme.md
+++ b/src/powershell/doc/readme.md
@@ -10,7 +10,7 @@ Manually checking a tenant's configuration against the published guidance can be
 
 The Zero Trust Assessment module in this private preview helps customers perform an automated security assessment. This works by assessing the tenant configuration and provides guidance on how to improve the security of the tenant.
 
-The assessment is organized into **pillars**. The **Identity**, **Devices**, **Network**, and **Data** pillars are generally available. Additional preview pillars (**Infrastructure**, **SecOps**, and **AI**) can be enabled with the `-Preview` switch. See [Preview pillars](#preview-pillars-infrastructure-secops-and-ai) for details.
+The assessment is organized into **pillars**. The current default run includes **Identity**, **Devices**, **Network**, **Data**, **Infrastructure**, **SecOps**, and **AI**. The `-Preview` switch remains available for any future preview-only features. See [Preview-only pillars](#preview-only-pillars-future-use) for details.
 
 ## Prerequisites
 
@@ -201,8 +201,8 @@ The most commonly used parameters are described below. All parameters are option
 | Parameter | Description |
 |-----------|-------------|
 | `-Path <string>` | Folder where the report and exported data are written. Defaults to `./ZeroTrustReport` in the current directory. |
-| `-Pillar <string>` | Which pillar to assess. One of `All` (default), `Identity`, `Devices`, `Network`, `Data`, `Infrastructure`, `SecOps`, or `AI`. The last three are preview pillars and require `-Preview`. |
-| `-Preview` | Enables the preview pillars (`Infrastructure`, `SecOps`, `AI`). Without this switch only the generally available pillars run. See [Preview pillars](#preview-pillars-infrastructure-secops-and-ai). |
+| `-Pillar <string>` | Which pillar to assess. One of `All` (default), `Identity`, `Devices`, `Network`, `Data`, `Infrastructure`, `SecOps`, or `AI`. |
+| `-Preview` | Enables preview-only pillars when available in future releases. Current pillars do not require this switch. See [Preview-only pillars](#preview-only-pillars-future-use). |
 | `-Resume` | Reuses the data that was already exported to `-Path` on a previous run, skipping data collection and database rebuild, and re-runs only the tests/report. Useful to regenerate the report or re-run tests without re-exporting. The pillar must match the pillar used for the original export. |
 | `-Tests <id[,id...]>` | Runs only the specified test ID(s) (exact match, no wildcards). If omitted, all tests for the selected pillar run. Example: `-Tests 21770, 21771`. |
 | `-Days <1-30>` | Number of days of sign-in logs to query (1-30, default 30). |
@@ -216,21 +216,20 @@ The most commonly used parameters are described below. All parameters are option
 | `-TestTimeout <minutes/timespan>` | Maximum time a single test may run (default 60; `0` = disabled). Supports humanized input notation, such as `30m`, `2h`, or `'2h 15m'`. |
 | `-ExportThrottleLimit <n>` / `-TestThrottleLimit <n>` | Maximum number of parallel data collectors / tests (default 5 each). |
 
-### Preview pillars (Infrastructure, SecOps, and AI)
+### Preview-only pillars (future use)
 
-By default the assessment runs only the generally available pillars: **Identity**, **Devices**, **Network**, and **Data**.
+By default the assessment now runs all current pillars: **Identity**, **Devices**, **Network**, **Data**, **Infrastructure**, **SecOps**, and **AI**.
 
-The newest pillars - **Infrastructure**, **SecOps**, and **AI** - are in preview and are gated behind the `-Preview` switch. To include them, add `-Preview`:
+The `-Preview` switch is reserved for future preview-only features. When new preview-only pillars are introduced, include `-Preview` to run them:
 
 ```powershell
-# Run all pillars, including the preview pillars
-Invoke-ZtAssessment -Preview
+# Run all current pillars (default behavior)
+Invoke-ZtAssessment
 
-# Run a single preview pillar (still requires -Preview)
-Invoke-ZtAssessment -Pillar SecOps -Preview
+# Example future usage when preview-only pillars are introduced
+# Invoke-ZtAssessment -Preview
+# Invoke-ZtAssessment -Pillar <FuturePreviewPillar> -Preview
 ```
-
-If you select a preview pillar with `-Pillar` but omit `-Preview`, the assessment stops and reminds you to add the `-Preview` switch.
 
 ### Recommended: use a dedicated clean VM
 
@@ -244,7 +243,7 @@ After the assessment completes, you are redirected to the **Overview** tab of th
 
 ![Screenshot of Results](media/image5.png)
 
-The **Identity**, **Devices**, **Network**, **Data** (and **Infrastructure**, **SecOps** and **AI** as _preview_) tabs display the list of tests that were run against the tenant and provide recommendations on addressing the tenant configuration information.
+The **Identity**, **Devices**, **Network**, **Data**, **Infrastructure**, **SecOps**, and **AI** tabs display the list of tests that were run against the tenant and provide recommendations on addressing the tenant configuration information.
 
 ![Screenshot of test results](media/image6.png)
 
@@ -284,8 +283,7 @@ To remove the assessment, follow these steps.
 
 The **Identity** tab shows the results of the assessment on your tenant.
 
-The other tabs are in progress. Feel free to share feedback on the
-report. If you have any feedback or issues, reach out to your account contact that suggested you run the assessment or post in the private preview Teams channel.
+Feel free to share feedback on the report. If you have any feedback or issues, reach out to your account contact that suggested you run the assessment or post in the private preview Teams channel.
 
 ## FAQs
 

--- a/src/powershell/private/core/Get-ZtAssessmentResults.ps1
+++ b/src/powershell/private/core/Get-ZtAssessmentResults.ps1
@@ -51,15 +51,21 @@ function Get-ZtAssessmentResults {
 			NetworkTotal   = @($TestResults).Where{ $_.TestPillar -eq 'Network' -and $_.TestStatus -notin 'Skipped', 'Planned' }.Count
 			DataPassed     = @($TestResults).Where{ $_.TestPillar -eq 'Data' -and $_.TestStatus -eq 'Passed' }.Count
 			DataTotal      = @($TestResults).Where{ $_.TestPillar -eq 'Data' -and $_.TestStatus -notin 'Skipped', 'Planned' }.Count
+			InfrastructurePassed = @($TestResults).Where{ $_.TestPillar -eq 'Infrastructure' -and $_.TestStatus -eq 'Passed' }.Count
+			InfrastructureTotal  = @($TestResults).Where{ $_.TestPillar -eq 'Infrastructure' -and $_.TestStatus -notin 'Skipped', 'Planned' }.Count
+			SecOpsPassed         = @($TestResults).Where{ $_.TestPillar -eq 'SecOps' -and $_.TestStatus -eq 'Passed' }.Count
+			SecOpsTotal          = @($TestResults).Where{ $_.TestPillar -eq 'SecOps' -and $_.TestStatus -notin 'Skipped', 'Planned' }.Count
+			AIPassed             = @($TestResults).Where{ $_.TestPillar -eq 'AI' -and $_.TestStatus -eq 'Passed' }.Count
+			AITotal              = @($TestResults).Where{ $_.TestPillar -eq 'AI' -and $_.TestStatus -notin 'Skipped', 'Planned' }.Count
 		}
 
-		if($PreviewEnabled){
-			$summary | Add-Member -NotePropertyName 'InfrastructurePassed' -NotePropertyValue (@($TestResults).Where{ $_.TestPillar -eq 'Infrastructure' -and $_.TestStatus -eq 'Passed' }.Count)
-			$summary | Add-Member -NotePropertyName 'InfrastructureTotal' -NotePropertyValue (@($TestResults).Where{ $_.TestPillar -eq 'Infrastructure' -and $_.TestStatus -notin 'Skipped', 'Planned' }.Count)
-			$summary | Add-Member -NotePropertyName 'SecOpsPassed' -NotePropertyValue (@($TestResults).Where{ $_.TestPillar -eq 'SecOps' -and $_.TestStatus -eq 'Passed' }.Count)
-			$summary | Add-Member -NotePropertyName 'SecOpsTotal' -NotePropertyValue (@($TestResults).Where{ $_.TestPillar -eq 'SecOps' -and $_.TestStatus -notin 'Skipped', 'Planned' }.Count)
-			$summary | Add-Member -NotePropertyName 'AIPassed' -NotePropertyValue (@($TestResults).Where{ $_.TestPillar -eq 'AI' -and $_.TestStatus -eq 'Passed' }.Count)
-			$summary | Add-Member -NotePropertyName 'AITotal' -NotePropertyValue (@($TestResults).Where{ $_.TestPillar -eq 'AI' -and $_.TestStatus -notin 'Skipped', 'Planned' }.Count)
+		# Future preview-only pillars can be added here and included only when -Preview is enabled.
+		$previewPillars = @()
+		if ($PreviewEnabled -and $previewPillars.Count -gt 0) {
+			foreach ($previewPillar in $previewPillars) {
+				$summary | Add-Member -NotePropertyName ("{0}Passed" -f $previewPillar) -NotePropertyValue (@($TestResults).Where{ $_.TestPillar -eq $previewPillar -and $_.TestStatus -eq 'Passed' }.Count)
+				$summary | Add-Member -NotePropertyName ("{0}Total" -f $previewPillar) -NotePropertyValue (@($TestResults).Where{ $_.TestPillar -eq $previewPillar -and $_.TestStatus -notin 'Skipped', 'Planned' }.Count)
+			}
 		}
 
 		return $summary
@@ -88,7 +94,8 @@ function Get-ZtAssessmentResults {
 	# are always available, avoiding runspace scope issues.
 	#   - Specific pillar (e.g. -Pillar AI): set TestPillar to exactly the requested pillar.
 	#   - -Pillar All + preview enabled: keep full array (test appears on every tagged page).
-	#   - -Pillar All + preview disabled: strip 'AI' so the AI preview page stays empty.
+	#   - -Pillar All + preview disabled: strip only preview-only pillars.
+	$previewPillars = @()
 	$_reqPillar   = $script:__ZtSession.RequestedPillar
 	$_previewOn   = $script:__ZtSession.PreviewEnabled
 	$_isAllPillar = (-not $_reqPillar -or $_reqPillar -eq 'All')
@@ -96,8 +103,8 @@ function Get-ZtAssessmentResults {
 		if ($test.TestPillar -isnot [array]) { continue }
 		if (-not $_isAllPillar) {
 			$test.TestPillar = $_reqPillar
-		} elseif (-not $_previewOn) {
-			$test.TestPillar = $test.TestPillar | Where-Object { $_ -ne 'AI' }
+		} elseif (-not $_previewOn -and $previewPillars.Count -gt 0) {
+			$test.TestPillar = $test.TestPillar | Where-Object { $_ -notin $previewPillars }
 		}
 	}
 

--- a/src/powershell/private/tests/Invoke-ZtTests.ps1
+++ b/src/powershell/private/tests/Invoke-ZtTests.ps1
@@ -90,10 +90,11 @@
 	# Store the requested pillar so Get-ZtAssessmentResults can restrict TestPillar on cross-ref tests
 	$script:__ZtSession.RequestedPillar = $Pillar
 
-	# Filter based on preview feature flag
+	# Filter based on preview feature flag.
+	# Keep current released pillars in stable by default. Future preview-only pillars can be
+	# added to $previewPillars and will then require -Preview to run.
+	$stablePillars = @('Identity', 'Devices', 'Network', 'Data', 'Infrastructure', 'SecOps', 'AI')
 	if (-not $script:__ZtSession.PreviewEnabled) {
-		# Non-preview mode: Only include stable/released pillars
-		$stablePillars = @('Identity', 'Devices', 'Network', 'Data')
 		$testsToRun = $testsToRun.Where{ ($_.Pillar | Where-Object { $_ -in $stablePillars }) }
 	}
 

--- a/src/powershell/private/tests/Invoke-ZtTests.ps1
+++ b/src/powershell/private/tests/Invoke-ZtTests.ps1
@@ -91,8 +91,8 @@
 	$script:__ZtSession.RequestedPillar = $Pillar
 
 	# Filter based on preview feature flag.
-	# Keep current released pillars in stable by default. Future preview-only pillars can be
-	# added to $previewPillars and will then require -Preview to run.
+	# In non-preview mode, only stable pillars are included in the run list.
+	# Preview mode keeps the full set returned by Get-ZtTest.
 	$stablePillars = @('Identity', 'Devices', 'Network', 'Data', 'Infrastructure', 'SecOps', 'AI')
 	if (-not $script:__ZtSession.PreviewEnabled) {
 		$testsToRun = $testsToRun.Where{ ($_.Pillar | Where-Object { $_ -in $stablePillars }) }

--- a/src/powershell/public/Invoke-ZtAssessment.ps1
+++ b/src/powershell/public/Invoke-ZtAssessment.ps1
@@ -262,9 +262,8 @@ $titleLine
 	# Validate preview pillar requirements.
 	# Current released pillars run by default. Add future preview-only pillars to
 	# $previewPillars to gate them behind the -Preview switch.
-	$stablePillars = @('Identity', 'Devices', 'Network', 'Data', 'Infrastructure', 'SecOps', 'AI')
 	$previewPillars = @()
-	if ($Pillar -in $previewPillars -and $Pillar -notin $stablePillars -and -not $Preview) {
+	if ($Pillar -in $previewPillars -and -not $Preview) {
 		Write-Host
 		Write-Host "❌ " -NoNewline -ForegroundColor Red
 		Write-Host "The '$Pillar' pillar requires the " -NoNewline -ForegroundColor Red

--- a/src/powershell/public/Invoke-ZtAssessment.ps1
+++ b/src/powershell/public/Invoke-ZtAssessment.ps1
@@ -64,10 +64,10 @@ where the module's signing certificate is trusted by policy).
 WARNING: Some tests may fail or return incomplete results if CLM restrictions are truly in effect.
 
 .PARAMETER Pillar
-The Zero Trust pillar to assess. Valid values are 'All', 'Identity', 'Devices', 'Network', 'Data', 'Infrastructure', 'SecOps', or 'AI'. Defaults to 'All' which runs all tests. Infrastructure, SecOps, and AI pillars require the -Preview switch.
+The Zero Trust pillar to assess. Valid values are 'All', 'Identity', 'Devices', 'Network', 'Data', 'Infrastructure', 'SecOps', or 'AI'. Defaults to 'All' which runs all tests.
 
 .PARAMETER Preview
-When specified, enables running preview pillars (Infrastructure, SecOps, AI) that are not publicly available yet.
+When specified, enables running preview-only pillars and features.
 
 .EXAMPLE
 Invoke-ZtAssessment
@@ -259,12 +259,15 @@ $titleLine
 		return
 	}
 
-	# Validate preview pillar requirements
-	$previewPillars = @('Infrastructure', 'SecOps', 'AI')
-	if ($Pillar -in $previewPillars -and -not $Preview) {
+	# Validate preview pillar requirements.
+	# Current released pillars run by default. Add future preview-only pillars to
+	# $previewPillars to gate them behind the -Preview switch.
+	$stablePillars = @('Identity', 'Devices', 'Network', 'Data', 'Infrastructure', 'SecOps', 'AI')
+	$previewPillars = @()
+	if ($Pillar -in $previewPillars -and $Pillar -notin $stablePillars -and -not $Preview) {
 		Write-Host
 		Write-Host "❌ " -NoNewline -ForegroundColor Red
-		Write-Host "The '$Pillar' pillar is currently in preview and requires the " -NoNewline -ForegroundColor Red
+		Write-Host "The '$Pillar' pillar requires the " -NoNewline -ForegroundColor Red
 		Write-Host "-Preview" -NoNewline -ForegroundColor Yellow
 		Write-Host " switch." -ForegroundColor Red
 		Write-Host


### PR DESCRIPTION
Moving Infrastructure, SecOps and AI out of Preview, while preserving the logic for future use.