### PR TITLE
Add AI-readiness Tier 1 baseline

### DIFF
--- a/.github/instructions/telemetry.instructions.md
+++ b/.github/instructions/telemetry.instructions.md
@@ -1,0 +1,67 @@
+---
+applyTo: "**"
+authority: canonical
+applies-to: pull-requests, ado-work-items
+last-reviewed: 2026-08-04
+owners: zerotrustassessment maintainers
+---
+
+# PR and ADO work-item telemetry tagging
+
+Every pull request and related ADO work item must declare how the work was produced and
+what kind of change it contains. These values are consumed by reporting pipelines.
+
+## Pull-request labels
+
+Apply one assistance label:
+
+- `agentic-cli`
+- `agentic-ide`
+- `agentic-mixed`
+- `manual`
+
+Apply one change-type label:
+
+- `bug`
+- `hotfix`
+- `feature`
+- `refactor`
+- `test`
+- `docs`
+- `security`
+- `infra`
+- `telemetry`
+- `chore`
+
+Agents must use an `agentic-*` value, never `manual`.
+
+## Pull-request description
+
+Append this block to every PR description:
+
+```text
+<!-- BEGIN pr-telemetry -->
+assistance: <agentic-cli|agentic-ide|agentic-mixed|manual>
+type: <bug|hotfix|feature|refactor|test|docs|security|infra|telemetry|chore>
+agent-tool: <copilot-cli|copilot-chat|claude-cli|cursor|other|n/a>
+agent-model: <model or n/a>
+work-item: AB#<id or n/a>
+<!-- END pr-telemetry -->
+```
+
+## ADO work items
+
+Use the same assistance and change-type values in the work item's Tags field. Append:
+
+```text
+<!-- BEGIN wit-telemetry -->
+assistance: <agentic-cli|agentic-ide|agentic-mixed|manual>
+type: <bug|hotfix|feature|refactor|test|docs|security|infra|telemetry|chore>
+agent-tool: <copilot-cli|copilot-chat|claude-cli|cursor|other|n/a>
+agent-model: <model or n/a>
+related-pr: <PR id or n/a>
+<!-- END wit-telemetry -->
+```
+
+Never remove or downgrade telemetry labels, tags, or footer values added by a human or
+prior agent.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# AGENTS.md - zerotrustassessment
+
+The **Zero Trust Assessment** PowerShell module runs tenant assessments and generates
+reports. This file is the entry point for humans and coding agents. Copilot-specific guidance
+already lives in [`.github/copilot-instructions.md`](.github/copilot-instructions.md), and
+there are repo skills under [`.github/skills/`](.github/skills/).
+
+## Repository map
+| Path | What lives here |
+| --- | --- |
+| `src/powershell/` | Module source and dependency initialization. |
+| `src/documentgenerator/` | Report and document-generation assets. |
+| `build/` | Build pipeline, configuration, and helpers. |
+| `code-tests/` | Pester commands, structure gates, and assessment tests. |
+| `.github/skills/` | Repository-specific agent skills. |
+| `.github/workflows/`, `.azure-pipelines/` | CI/CD definitions. |
+
+## Conventions
+See [`docs/conventions.md`](docs/conventions.md).
+
+## Verification / Definition of Done
+```powershell
+pwsh scripts/verify.ps1
+```
+
+For the full suite, build the module and run Pester:
+
+```powershell
+pwsh build/powershell/Build-PSModule.ps1
+Invoke-Pester -Path ./code-tests
+```
+
+A change is done when `verify.ps1` and the relevant tests under `code-tests/` pass.
+
+## PR and work-item telemetry
+Every PR must follow
+[`.github/instructions/telemetry.instructions.md`](.github/instructions/telemetry.instructions.md).

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,0 +1,26 @@
+# Conventions - zerotrustassessment
+
+These conventions reflect the current repository structure and should evolve with it.
+
+## Layout
+
+- `src/powershell/` contains module source.
+- `src/documentgenerator/` contains report-generation assets.
+- `build/` contains the build pipeline and configuration.
+- `code-tests/commands/` contains command tests.
+- `code-tests/general/` contains structural and integrity gates.
+- `code-tests/test-assessments/` contains assessment-specific tests.
+- `.github/skills/`, `.github/workflows/`, and `.azure-pipelines/` contain automation.
+
+## Authoring
+
+- Keep one PowerShell command per file and command names unique.
+- Add or update tests under `code-tests/` for behavior changes.
+- New assessments should have a matching `Test-Assessment.<id>.Tests.ps1`.
+- Build the module before running tests that import it.
+- Do not commit secrets, tokens, tenant identifiers, or sensitive report data.
+
+## Validation
+
+Run `pwsh scripts/verify.ps1` for the readiness verification loop. For full validation,
+build the module and run `Invoke-Pester -Path ./code-tests`.

--- a/scripts/verify.ps1
+++ b/scripts/verify.ps1
@@ -1,0 +1,74 @@
+#!/usr/bin/env pwsh
+
+$ErrorActionPreference = 'Stop'
+$root = Split-Path -Parent $PSScriptRoot
+$failures = 0
+
+Push-Location $root
+try {
+    Write-Host '== Syntax check: src PowerShell =='
+    $targets = @(
+        Get-ChildItem -Path (Join-Path $root 'src') -Recurse -File -Filter *.ps1 `
+            -ErrorAction SilentlyContinue
+    )
+
+    if (-not $targets) {
+        Write-Host '  WARN: no .ps1 files found under src/.'
+    }
+
+    foreach ($file in $targets) {
+        $tokens = $null
+        $errors = $null
+        [System.Management.Automation.Language.Parser]::ParseFile(
+            $file.FullName,
+            [ref]$tokens,
+            [ref]$errors
+        ) | Out-Null
+
+        if ($errors) {
+            Write-Host "  SYNTAX: $($file.FullName)"
+            $errors | ForEach-Object { Write-Host "    $($_.Message)" }
+            $failures++
+        }
+    }
+
+    if ($failures -eq 0) {
+        Write-Host "  OK: $($targets.Count) file(s) parse cleanly."
+    }
+
+    Write-Host '== Config check: build PowerShell data files =='
+    $configFiles = @(
+        Get-ChildItem -Path (Join-Path $root 'build') -Recurse -File -Filter *.psd1 `
+            -ErrorAction SilentlyContinue
+    )
+
+    foreach ($configFile in $configFiles) {
+        try {
+            Import-PowerShellDataFile -Path $configFile.FullName -ErrorAction Stop | Out-Null
+            Write-Host "  OK: $($configFile.Name)"
+        }
+        catch {
+            Write-Host "  INVALID: $($configFile.FullName) -> $($_.Exception.Message)"
+            $failures++
+        }
+    }
+
+    Write-Host '== Pester =='
+    if (Get-Module -ListAvailable -Name Pester) {
+        Write-Host "  INFO: run 'Invoke-Pester -Path ./code-tests' after building the module."
+    }
+    else {
+        Write-Host '  SKIP: Pester is not installed.'
+    }
+}
+finally {
+    Pop-Location
+}
+
+if ($failures -gt 0) {
+    Write-Host "verify.ps1 FAILED with $failures error(s)." -ForegroundColor Red
+    exit 1
+}
+
+Write-Host 'verify.ps1 PASSED.' -ForegroundColor Green
+exit 0


### PR DESCRIPTION
## Summary

Adds the missing CXE AI-readiness Tier-1 baseline artifacts:

- root `AGENTS.md` repository router
- `docs/conventions.md`
- `.github/instructions/telemetry.instructions.md`
- `scripts/verify.ps1` one-command verification loop

The existing `.github/copilot-instructions.md` and `.github/skills/` content are preserved. This is additive documentation and validation scaffolding only; no product behavior changes.

## Validation

- `pwsh scripts/verify.ps1`
  - 498 PowerShell files parsed successfully
  - build configuration loaded successfully

<!-- BEGIN pr-telemetry -->
assistance: agentic-cli
type: docs
agent-tool: copilot-cli
agent-model: gpt-5.6-sol
work-item: AB#n/a
<!-- END pr-telemetry -->